### PR TITLE
LINT-1: Add ruff Python linting and formatting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,26 @@ jobs:
         working-directory: solr-search
         run: python -m pytest tests/test_integration.py -v --tb=short
 
+  python-lint:
+    name: Python linting (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        continue-on-error: true
+        with:
+          args: "check"
+      - uses: astral-sh/ruff-action@v3
+        continue-on-error: true
+        with:
+          args: "format --check"
+
   all-tests-passed:
     name: All tests passed
     runs-on: ubuntu-latest
     needs:
       - document-indexer-tests
       - solr-search-tests
+      - python-lint
     steps:
       - run: echo "All tests passed successfully!"

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -62,3 +62,10 @@
 - Parker's `extract_metadata()` populates title_s, author_s, year_i, category_s directly from filesystem path parsing. His parser handles amades/ (author), balearics/ (category), bsal/ (journal) patterns.
 - Your test suite validates Parker's parser contracts: relative paths, conservative fallbacks, year-range handling. 4 failing tests flag real parser gaps to address in Phase 1.5.
 
+### 2026-03-14 — Ruff linting baseline added to CI
+
+- Added root `ruff.toml` targeting Python 3.11 with 120-character lines, Ruff lint families `E/F/W/I/UP/B/SIM/S`, and test-specific allowances (`S101` globally, all `S` rules under `tests/**`).
+- Updated `.github/workflows/ci.yml` with a `python-lint` job using `astral-sh/ruff-action@v3`; each Ruff step uses `continue-on-error: true` so the new checks are visible in CI without gating merges before LINT-5.
+- Current repo baseline from the root: `ruff check .` reports **107** lint violations and `ruff format --check .` reports **23** files needing reformatting.
+- Regression check after the CI change: `document-indexer` tests still pass (**51 passed**), and `solr-search` suites still pass (**18 passed** total).
+

--- a/.squad/decisions/inbox/copilot-ruff-ci-baseline.md
+++ b/.squad/decisions/inbox/copilot-ruff-ci-baseline.md
@@ -1,0 +1,4 @@
+### 2026-03-14T08:38: Ruff CI introduced as non-blocking baseline
+**By:** Lambert (via Copilot)
+**What:** Added root Ruff configuration plus a `python-lint` GitHub Actions job using `astral-sh/ruff-action@v3`, with each Ruff step marked `continue-on-error: true` until the backlog item for cleanup lands.
+**Why:** Issue #91 requires visibility for current lint/format debt in CI now, without blocking merges before the repository-wide fixes in LINT-5.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+target-version = "py311"
+line-length = 120
+
+[lint]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "S"]
+ignore = ["S101"]  # allow assert in tests
+
+[lint.per-file-ignores]
+"tests/**" = ["S"]  # security warnings OK in tests
+
+[format]
+quote-style = "double"


### PR DESCRIPTION
Closes #91

Adds ruff configuration and CI job.
- ruff.toml at repo root
- CI job using astral-sh/ruff-action
- Current violations: 107 lint, 23 format (fix in LINT-5)