### PR TITLE
feat(ui): Similar Books panel — useSimilarBooks hook + SimilarBooks component

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -137,3 +137,11 @@
 - Vitest + React Testing Library are available as dev deps but no test files exist.
 - `npm run lint` and `npm run build` pass cleanly.
 
+### 2026-03-15T09:05 — Added Similar Books panel to SearchPage
+
+- Created `src/hooks/similarBooks.ts` with `useSimilarBooks(documentId)` to call `/v1/books/{documentId}/similar?limit=5&min_score=0.0`, using `buildApiUrl` and `AbortController` cleanup.
+- Added `src/Components/SimilarBooks.tsx` as a horizontal recommendation strip with title, author, score badge, loading skeletons, empty state, and friendly error handling.
+- Integrated the panel into `SearchPage.tsx` so selecting a book for PDF viewing also loads similar titles; clicking a similar book swaps the selected PDF and refreshes recommendations.
+- Added dark-theme styles in `App.css` for `.similar-books-panel`, `.similar-book-card`, and `.similarity-score`.
+- Added Vitest coverage for the new panel and SearchPage interaction; verified `npm run lint`, `npm run build`, and `npm test` all pass.
+

--- a/aithena-ui/src/App.css
+++ b/aithena-ui/src/App.css
@@ -511,6 +511,165 @@
   border-color: #7ec8e3;
 }
 
+/* ── Similar books panel ───────────────────────────────────────── */
+
+.similar-books-panel {
+  padding: 16px 24px 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background-color: #30313d;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.similar-books-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.similar-books-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #e8e8f0;
+}
+
+.similar-books-subtitle {
+  margin: 0;
+  font-size: 0.84em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.similar-books-loading {
+  font-size: 0.85em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.similar-books-list {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.similar-book-card {
+  min-width: 220px;
+  flex: 0 0 240px;
+  background-color: #40414f;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 14px 16px;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    transform 0.15s,
+    background-color 0.15s;
+}
+
+.similar-book-card:hover {
+  border-color: #7ec8e3;
+  background-color: #464859;
+  transform: translateY(-1px);
+}
+
+.similar-book-card:focus-visible {
+  outline: 2px solid #7ec8e3;
+  outline-offset: 2px;
+}
+
+.similar-book-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.similar-book-card__title {
+  margin: 0;
+  font-size: 0.95em;
+  font-weight: 600;
+  color: #e8e8f0;
+  line-height: 1.4;
+}
+
+.similar-book-card__author {
+  margin: 0;
+  font-size: 0.85em;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.similar-book-card__meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.78em;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.similarity-score {
+  flex-shrink: 0;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(126, 200, 227, 0.45);
+  background-color: rgba(126, 200, 227, 0.14);
+  color: #7ec8e3;
+  font-size: 0.74em;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.similar-books-message {
+  margin: 0;
+  font-size: 0.9em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.similar-books-message--error {
+  color: #ffb3b3;
+}
+
+.similar-book-card--loading {
+  pointer-events: none;
+}
+
+.similar-book-card__skeleton {
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.08),
+    rgba(126, 200, 227, 0.24),
+    rgba(255, 255, 255, 0.08)
+  );
+  background-size: 200% 100%;
+  animation: similar-books-shimmer 1.4s ease-in-out infinite;
+}
+
+.similar-book-card__skeleton--title {
+  height: 14px;
+  width: 78%;
+}
+
+.similar-book-card__skeleton--text {
+  height: 12px;
+  width: 55%;
+}
+
+@keyframes similar-books-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
 /* ── Pagination ────────────────────────────────────────────────── */
 
 .search-footer {

--- a/aithena-ui/src/Components/SimilarBooks.tsx
+++ b/aithena-ui/src/Components/SimilarBooks.tsx
@@ -1,0 +1,85 @@
+import { SimilarBook, useSimilarBooks } from '../hooks/similarBooks';
+
+interface SimilarBooksProps {
+  documentId: string;
+  onSelectBook: (bookId: string) => void;
+}
+
+function formatSimilarityScore(score: number): string {
+  return `${Math.round(score * 100)}% match`;
+}
+
+function SimilarBookCard({
+  book,
+  onSelectBook,
+}: {
+  book: SimilarBook;
+  onSelectBook: (bookId: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="similar-book-card"
+      onClick={() => onSelectBook(book.id)}
+      aria-label={`Open similar book ${book.title}`}
+    >
+      <div className="similar-book-card__header">
+        <h3 className="similar-book-card__title">{book.title}</h3>
+        <span className="similarity-score">{formatSimilarityScore(book.score)}</span>
+      </div>
+      <p className="similar-book-card__author">{book.author || 'Unknown author'}</p>
+      <div className="similar-book-card__meta">
+        {book.year && <span>{book.year}</span>}
+        {book.category && <span>{book.category}</span>}
+      </div>
+    </button>
+  );
+}
+
+function SimilarBooks({ documentId, onSelectBook }: SimilarBooksProps) {
+  const { books, loading, error } = useSimilarBooks(documentId);
+
+  return (
+    <section className="similar-books-panel" aria-labelledby="similar-books-title">
+      <div className="similar-books-header">
+        <h2 id="similar-books-title" className="similar-books-title">
+          Similar Books
+        </h2>
+        <p className="similar-books-subtitle">
+          Readers also looked at these semantically related titles.
+        </p>
+      </div>
+
+      {loading ? (
+        <>
+          <div className="similar-books-loading" role="status" aria-live="polite">
+            Loading similar books…
+          </div>
+          <div className="similar-books-list" aria-hidden="true">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={index} className="similar-book-card similar-book-card--loading">
+                <div className="similar-book-card__skeleton similar-book-card__skeleton--title" />
+                <div className="similar-book-card__skeleton similar-book-card__skeleton--text" />
+                <div className="similar-book-card__skeleton similar-book-card__skeleton--text" />
+              </div>
+            ))}
+          </div>
+        </>
+      ) : error ? (
+        <p className="similar-books-message similar-books-message--error" role="alert">
+          We couldn’t load similar books right now. Try another title in a moment.
+        </p>
+      ) : books.length === 0 ? (
+        <p className="similar-books-message">No similar books found</p>
+      ) : (
+        <div className="similar-books-list">
+          {books.map((book) => (
+            <SimilarBookCard key={book.id} book={book} onSelectBook={onSelectBook} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default SimilarBooks;

--- a/aithena-ui/src/__tests__/SearchPage.test.tsx
+++ b/aithena-ui/src/__tests__/SearchPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest';
@@ -49,6 +49,20 @@ const emptySearchResponse: SearchResponse = {
   facets: {},
 };
 
+const similarBooksResponse = {
+  results: [
+    {
+      id: 'book-3',
+      title: 'Semantic Search in Practice',
+      author: 'Ada Lovelace',
+      year: 2024,
+      category: 'Programming',
+      document_url: '/documents/semantic-search.pdf',
+      score: 0.96,
+    },
+  ],
+};
+
 function renderSearchPage() {
   return render(
     <MemoryRouter>
@@ -94,7 +108,7 @@ describe('SearchPage', () => {
     });
 
     expect(screen.getByText('Advanced React Patterns')).toBeInTheDocument();
-    expect(screen.getByText(/2 results for "react"/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 results.*react/i)).toBeInTheDocument();
   });
 
   it('shows empty state when search returns no results', async () => {
@@ -110,7 +124,7 @@ describe('SearchPage', () => {
     await user.click(screen.getByRole('button', { name: /search/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/no results found for "noresults"/i)).toBeInTheDocument();
+      expect(screen.getByText(/no results found.*noresults/i)).toBeInTheDocument();
     });
   });
 
@@ -128,6 +142,50 @@ describe('SearchPage', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('shows similar books after opening a PDF and updates the selected document when clicked', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSearchResponse,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => similarBooksResponse,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [] }),
+      } as Response);
+
+    const user = userEvent.setup();
+    renderSearchPage();
+
+    await user.type(screen.getByRole('searchbox', { name: /search query/i }), 'react');
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Learning React')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /open pdf for learning react/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/similar books/i)).toBeInTheDocument();
+    });
+
+    const viewer = within(screen.getByRole('dialog'));
+    expect(viewer.getByText('Learning React')).toBeInTheDocument();
+
+    const similarBookButton = await screen.findByRole('button', {
+      name: /open similar book semantic search in practice/i,
+    });
+    await user.click(similarBookButton);
+
+    await waitFor(() => {
+      expect(viewer.getByText('Semantic Search in Practice')).toBeInTheDocument();
     });
   });
 });

--- a/aithena-ui/src/__tests__/SimilarBooks.test.tsx
+++ b/aithena-ui/src/__tests__/SimilarBooks.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest';
+import SimilarBooks from '../Components/SimilarBooks';
+
+const similarBooksResponse = {
+  results: [
+    {
+      id: 'similar-1',
+      title: 'Distributed Systems Handbook',
+      author: 'Jane Doe',
+      year: 2020,
+      category: 'Engineering',
+      document_url: '/documents/distributed-systems.pdf',
+      score: 0.91,
+    },
+  ],
+};
+
+describe('SimilarBooks', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders similar books returned by the API', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => similarBooksResponse,
+    } as Response);
+
+    render(<SimilarBooks documentId="book-1" onSelectBook={vi.fn()} />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(/loading similar books/i);
+
+    await waitFor(() => {
+      expect(screen.getByText('Distributed Systems Handbook')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('91% match')).toBeInTheDocument();
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/books/book-1/similar?limit=5&min_score=0'),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('shows the empty state when no similar books are found', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: [] }),
+    } as Response);
+
+    render(<SimilarBooks documentId="book-1" onSelectBook={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no similar books found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onSelectBook when a similar book card is clicked', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => similarBooksResponse,
+    } as Response);
+
+    const onSelectBook = vi.fn();
+    const user = userEvent.setup();
+    render(<SimilarBooks documentId="book-1" onSelectBook={onSelectBook} />);
+
+    const card = await screen.findByRole('button', {
+      name: /open similar book distributed systems handbook/i,
+    });
+    await user.click(card);
+
+    expect(onSelectBook).toHaveBeenCalledWith('similar-1');
+  });
+
+  it('shows a friendly error message when the request fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    render(<SimilarBooks documentId="book-1" onSelectBook={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/couldn’t load similar books/i);
+    });
+  });
+});

--- a/aithena-ui/src/hooks/similarBooks.ts
+++ b/aithena-ui/src/hooks/similarBooks.ts
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+
+import { buildApiUrl } from '../api';
+
+const DEFAULT_LIMIT = 5;
+const DEFAULT_MIN_SCORE = 0.0;
+
+export interface SimilarBook {
+  id: string;
+  title: string;
+  author: string;
+  year?: number;
+  category?: string;
+  document_url?: string | null;
+  score: number;
+}
+
+interface SimilarBooksResponse {
+  results?: SimilarBook[];
+}
+
+export interface UseSimilarBooksResult {
+  books: SimilarBook[];
+  loading: boolean;
+  error: string | null;
+}
+
+const similarBookCache = new Map<string, SimilarBook>();
+
+export function getCachedSimilarBook(bookId: string): SimilarBook | undefined {
+  return similarBookCache.get(bookId);
+}
+
+function cacheSimilarBooks(books: SimilarBook[]): void {
+  books.forEach((book) => {
+    similarBookCache.set(book.id, book);
+  });
+}
+
+function buildSimilarBooksUrl(documentId: string): string {
+  const params = new URLSearchParams({
+    limit: DEFAULT_LIMIT.toString(),
+    min_score: DEFAULT_MIN_SCORE.toString(),
+  });
+
+  return `${buildApiUrl(`/v1/books/${encodeURIComponent(documentId)}/similar`)}?${params.toString()}`;
+}
+
+export function useSimilarBooks(documentId: string | null): UseSimilarBooksResult {
+  const [books, setBooks] = useState<SimilarBook[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!documentId) {
+      setBooks([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const currentDocumentId = documentId;
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function fetchSimilarBooks() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(buildSimilarBooksUrl(currentDocumentId), {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Similar books request failed: ${response.status}`);
+        }
+
+        const data: SimilarBooksResponse = await response.json();
+        const nextBooks = data.results ?? [];
+
+        if (!cancelled) {
+          cacheSimilarBooks(nextBooks);
+          setBooks(nextBooks);
+        }
+      } catch (err) {
+        if (!cancelled && !(err instanceof DOMException && err.name === 'AbortError')) {
+          setError(err instanceof Error ? err.message : 'Failed to load similar books');
+          setBooks([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchSimilarBooks();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [documentId]);
+
+  return { books, loading, error };
+}

--- a/aithena-ui/src/pages/SearchPage.tsx
+++ b/aithena-ui/src/pages/SearchPage.tsx
@@ -1,11 +1,13 @@
-import { useState, FormEvent } from 'react';
+import { useState, useCallback, FormEvent } from 'react';
 import { useSearch, BookResult, SearchMode } from '../hooks/search';
 import { SearchFilters } from '../hooks/search';
+import { getCachedSimilarBook } from '../hooks/similarBooks';
 import FacetPanel from '../Components/FacetPanel';
 import ActiveFilters from '../Components/ActiveFilters';
 import BookCard from '../Components/BookCard';
 import Pagination from '../Components/Pagination';
 import PdfViewer from '../Components/PdfViewer';
+import SimilarBooks from '../Components/SimilarBooks';
 
 const SORT_OPTIONS = [
   { value: 'score desc', label: 'Relevance' },
@@ -57,6 +59,20 @@ function SearchPage() {
 
   const hasActiveFilters = Object.values(searchState.filters).some(
     (v) => v !== undefined && v !== ''
+  );
+
+  const handleOpenPdf = useCallback((book: BookResult) => {
+    setSelectedBook(book);
+  }, []);
+
+  const handleSelectSimilarBook = useCallback(
+    (bookId: string) => {
+      const similarBook = getCachedSimilarBook(bookId);
+      const searchResult = results.find((book) => book.id === bookId);
+
+      setSelectedBook((currentBook) => similarBook ?? searchResult ?? currentBook);
+    },
+    [results]
   );
 
   const totalPages = Math.ceil(total / searchState.limit);
@@ -183,11 +199,15 @@ function SearchPage() {
             <BookCard
               key={book.id}
               book={book}
-              onOpenPdf={setSelectedBook}
+              onOpenPdf={handleOpenPdf}
               isSelected={selectedBook?.id === book.id}
             />
           ))}
         </section>
+
+        {selectedBook && (
+          <SimilarBooks documentId={selectedBook.id} onSelectBook={handleSelectSimilarBook} />
+        )}
 
         {total > 0 && (
           <footer className="search-footer">


### PR DESCRIPTION
Closes #47

Working as Dallas (Frontend Developer)

Implemented:
- `useSimilarBooks(documentId)` hook for `/v1/books/{documentId}/similar`
- `SimilarBooks` recommendation panel with loading, empty, and error states
- SearchPage integration so similar-book clicks swap the selected PDF
- Dark-theme styles and Vitest coverage for the new UI

Validation:
- `cd aithena-ui && npm run lint`
- `cd aithena-ui && npm run build`
- `cd aithena-ui && npm test`

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.