### PR TITLE
SEC-3: Add zizmor GitHub Actions security scanning

### DIFF
--- a/.github/workflows/security-zizmor.yml
+++ b/.github/workflows/security-zizmor.yml
@@ -1,0 +1,38 @@
+name: Security - GitHub Actions Supply Chain (zizmor)
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  zizmor:
+    name: GitHub Actions Security Scan
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor security scan
+        uses: zizmorcore/zizmor-action@v0.1.1
+        with:
+          # SARIF output automatically uploaded to GitHub Code Scanning
+          # Focuses on P0 findings: template-injection and dangerous-triggers
+          advanced-security: true


### PR DESCRIPTION
## Summary

Implements SEC-3 (#90) - zizmor GitHub Actions supply chain security scanning.

Closes #90

## Implementation

**Workflow:** `.github/workflows/security-zizmor.yml`

- **Tool:** zizmorcore/zizmor-action@v0.1.1 (official action)
- **Triggers:** Push/PR to dev/main when `.github/workflows/` files change
- **Focus:** P0 findings (template-injection, dangerous-triggers)
- **Non-blocking:** `continue-on-error: true` prevents CI breakage
- **SARIF Upload:** Results appear in GitHub Code Scanning
- **Permissions:** security-events write for SARIF, actions/contents read

## Known Baseline

Per v0.6.0 spec:
- **CKV_GHA_7** (pin actions to SHA) - Deferred to v0.7.0 audit

## Testing

- Workflow will trigger on merge to dev
- Expected to scan existing workflows for template injection and dangerous trigger patterns
- Results will appear in Security > Code scanning

## Working as Kane (Security Engineer)

Per squad charter - security scanning implementation and baseline exception documentation.