### PR TITLE
feat(ui): add version footer (#201)

### DIFF
--- a/.squad/agents/dallas/history.md
+++ b/.squad/agents/dallas/history.md
@@ -11,6 +11,14 @@
 
 <!-- Append learnings below -->
 
+### 2026-03-15T16:31 — Added build-time version footer to main UI (#201)
+
+- Wired the frontend build version through `vite.config.ts` with `define.__APP_VERSION__ = JSON.stringify(process.env.VERSION || 'dev')`, matching Brett's Dockerfile `VERSION` env setup from #199.
+- Extended `src/vite-env.d.ts` with a global declaration so React components and Vitest can reference `__APP_VERSION__` without local imports.
+- Added `src/Components/Footer.tsx` + `Footer.css` as a fixed, non-intrusive bottom-right badge showing `Aithena v{__APP_VERSION__}` across all routes by rendering it once in `App.tsx`.
+- Added `src/__tests__/Footer.test.tsx` to assert the footer and version string render correctly.
+- Verified the UI with `npm run lint`, `npm run build`, and `npx vitest run` (all passing; existing Upload/useUpload tests still emit known React act() warnings).
+
 ### 2026-03-13T20:58 — Phase 2–4 GitHub Issues Assigned
 
 - Ripley decomposed Phase 2–4 into issues #36–#53, all assigned to `@copilot` with squad labels and release milestones.

--- a/aithena-ui/src/App.tsx
+++ b/aithena-ui/src/App.tsx
@@ -1,6 +1,7 @@
 import './App.css';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import TabNav from './Components/TabNav';
+import Footer from './Components/Footer';
 import SearchPage from './pages/SearchPage';
 import LibraryPage from './pages/LibraryPage';
 import UploadPage from './pages/UploadPage';
@@ -30,6 +31,7 @@ function App() {
             <Route path="/admin" element={<AdminPage />} />
           </Routes>
         </div>
+        <Footer />
       </div>
     </BrowserRouter>
   );

--- a/aithena-ui/src/Components/Footer.css
+++ b/aithena-ui/src/Components/Footer.css
@@ -1,0 +1,22 @@
+.app-footer {
+  position: fixed;
+  right: 16px;
+  bottom: 12px;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.app-footer__text {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(32, 33, 35, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(6px);
+}

--- a/aithena-ui/src/Components/Footer.tsx
+++ b/aithena-ui/src/Components/Footer.tsx
@@ -1,0 +1,11 @@
+import './Footer.css';
+
+function Footer() {
+  return (
+    <footer className="app-footer" role="contentinfo" aria-label="Application version">
+      <span className="app-footer__text">Aithena v{__APP_VERSION__}</span>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/aithena-ui/src/__tests__/Footer.test.tsx
+++ b/aithena-ui/src/__tests__/Footer.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Footer from '../Components/Footer';
+
+describe('Footer', () => {
+  it('renders the application version text', () => {
+    render(<Footer />);
+
+    expect(screen.getByRole('contentinfo', { name: /application version/i })).toBeInTheDocument();
+    expect(screen.getByText(`Aithena v${__APP_VERSION__}`)).toBeInTheDocument();
+  });
+});

--- a/aithena-ui/src/vite-env.d.ts
+++ b/aithena-ui/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/aithena-ui/vite.config.ts
+++ b/aithena-ui/vite.config.ts
@@ -7,6 +7,9 @@ const apiProxyTarget =
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.VERSION || 'dev'),
+  },
   plugins: [react({ fastRefresh: false })],
   base: '',
   server: {


### PR DESCRIPTION
Closes #201

Working as Dallas (Frontend Dev)

## Summary
- expose the build VERSION to Vite as __APP_VERSION__
- render a fixed footer badge showing the UI version on every page
- add a Footer test and record the frontend learning for Dallas

## Validation
- cd aithena-ui && npm run lint
- cd aithena-ui && npm run build
- cd aithena-ui && npx vitest run