### PR TITLE
Add /v1/admin/containers endpoint

### DIFF
--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -36,6 +36,12 @@
 
 <!-- Append learnings below -->
 
+### 2026-03-15 — Admin Containers Endpoint Contract (#202)
+
+- `solr-search` now exposes `GET /v1/admin/containers` (and trailing-slash alias) to aggregate container health/version data across app services, workers, and infrastructure.
+- HTTP services should be queried in parallel with a 2s timeout; `embeddings-server` uses `/version`, while non-HTTP services (`streamlit-admin`, `aithena-ui`) reuse shared build metadata (`VERSION`, `GIT_COMMIT`) plus TCP reachability.
+- Worker processes (`document-indexer`, `document-lister`) report `status: "unknown"` with shared repo version/commit because they do not expose stable runtime probes in codespaces without Docker runtime metadata.
+
 ### 2026-03-15 — Embeddings Container Contract
 
 - `embeddings-server` must run the repo's FastAPI app, not the Weaviate inference image, because downstream services expect `POST /v1/embeddings/` in OpenAI-compatible batch format.

--- a/.squad/decisions/inbox/parker-admin-containers.md
+++ b/.squad/decisions/inbox/parker-admin-containers.md
@@ -1,0 +1,12 @@
+# Parker — Admin Containers Aggregation Decision
+
+## Context
+Issue #202 adds `GET /v1/admin/containers` in `solr-search` to summarize the running stack without using Docker SDK access.
+
+## Decision
+- Reuse the existing `/v1/status` probing approach inside `solr-search`: TCP reachability for infrastructure, Solr cluster probing for Solr, and direct HTTP `/version` calls for HTTP services.
+- For non-HTTP repo services (`streamlit-admin`, `aithena-ui`, `document-indexer`, `document-lister`), report shared build metadata from `VERSION` and `GIT_COMMIT` injected into the repo's container builds.
+- Mark worker processes as `status: "unknown"` instead of `down` because they do not expose stable network probes in this environment and Docker runtime label inspection is intentionally unavailable.
+
+## Why
+This keeps the endpoint fast, deterministic, and compatible with codespaces where Docker is unavailable, while still surfacing useful release metadata for the whole stack.

--- a/solr-search/main.py
+++ b/solr-search/main.py
@@ -9,7 +9,7 @@ import threading
 import time
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
@@ -643,6 +643,143 @@ def service_status() -> dict[str, Any]:
             "redis": "up" if redis_up else "down",
             "rabbitmq": "up" if rabbitmq_up else "down",
         },
+    }
+
+
+CONTAINER_VERSION_TIMEOUT = 2.0
+
+
+def _build_container_entry(
+    name: str,
+    status: str,
+    container_type: str,
+    version: str = "unknown",
+    commit: str = "unknown",
+) -> dict[str, str]:
+    return {
+        "name": name,
+        "status": status,
+        "type": container_type,
+        "version": version,
+        "commit": commit,
+    }
+
+
+def _get_embeddings_version_url() -> str:
+    embeddings_url = settings.embeddings_url
+    if not embeddings_url.startswith(("http://", "https://")):
+        embeddings_url = f"http://{embeddings_url}"
+
+    parsed = urlparse(embeddings_url)
+    scheme = parsed.scheme or "http"
+    host = parsed.hostname or "embeddings-server"
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{scheme}://{host}{port}/version"
+
+
+def _get_http_container_status(
+    name: str,
+    version_url: str,
+    container_type: str = "service",
+    timeout: float = CONTAINER_VERSION_TIMEOUT,
+) -> dict[str, str]:
+    try:
+        response = requests.get(version_url, timeout=timeout)
+        response.raise_for_status()
+        payload = response.json()
+        return _build_container_entry(
+            name=name,
+            status="up",
+            container_type=container_type,
+            version=str(payload.get("version") or "unknown"),
+            commit=str(payload.get("commit") or "unknown"),
+        )
+    except Exception:
+        return _build_container_entry(name=name, status="down", container_type=container_type)
+
+
+def _get_tcp_container_status(
+    name: str,
+    host: str,
+    port: int,
+    container_type: str,
+    version: str = "unknown",
+    commit: str = "unknown",
+) -> dict[str, str]:
+    status = "up" if _tcp_check(host, port) else "down"
+    return _build_container_entry(name, status, container_type, version, commit)
+
+
+def _get_worker_container_status(name: str) -> dict[str, str]:
+    return _build_container_entry(
+        name=name,
+        status="unknown",
+        container_type="worker",
+        version=settings.version,
+        commit=settings.commit,
+    )
+
+
+def _get_solr_container_status() -> dict[str, str]:
+    parsed = urlparse(settings.solr_url)
+    solr_host = parsed.hostname or settings.solr_url
+    solr_port = parsed.port or 8983
+    solr_info = _get_solr_status(settings.solr_url, timeout=CONTAINER_VERSION_TIMEOUT)
+    status = "up" if _tcp_check(solr_host, solr_port) and solr_info["status"] != "error" else "down"
+    return _build_container_entry("solr", status, "infrastructure")
+
+
+@app.get("/v1/admin/containers/", include_in_schema=False, name="admin_containers_v1_slash")
+@app.get("/v1/admin/containers", name="admin_containers_v1")
+def admin_containers() -> dict[str, Any]:
+    """Return a combined version/health snapshot for app and infrastructure containers."""
+    checks = [
+        lambda: _build_container_entry(
+            "solr-search",
+            "up",
+            "service",
+            settings.version,
+            settings.commit,
+        ),
+        lambda: _get_http_container_status("embeddings-server", _get_embeddings_version_url()),
+        lambda: _get_tcp_container_status(
+            "streamlit-admin",
+            "streamlit-admin",
+            8501,
+            "service",
+            settings.version,
+            settings.commit,
+        ),
+        lambda: _get_tcp_container_status(
+            "aithena-ui",
+            "aithena-ui",
+            80,
+            "service",
+            settings.version,
+            settings.commit,
+        ),
+        lambda: _get_worker_container_status("document-indexer"),
+        lambda: _get_worker_container_status("document-lister"),
+        _get_solr_container_status,
+        lambda: _get_tcp_container_status("redis", settings.redis_host, settings.redis_port, "infrastructure"),
+        lambda: _get_tcp_container_status(
+            "rabbitmq",
+            settings.rabbitmq_host,
+            settings.rabbitmq_port,
+            "infrastructure",
+        ),
+        lambda: _get_tcp_container_status("nginx", "nginx", 80, "infrastructure"),
+    ]
+
+    with ThreadPoolExecutor(max_workers=len(checks)) as pool:
+        containers = [future.result() for future in [pool.submit(check) for check in checks]]
+
+    healthy = sum(1 for container in containers if container["status"] == "up")
+    return {
+        "containers": containers,
+        "last_updated": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "total": len(containers),
+        "healthy": healthy,
     }
 
 

--- a/solr-search/tests/test_integration.py
+++ b/solr-search/tests/test_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -1041,6 +1042,162 @@ def test_status_services_down_when_tcp_fails(
     assert data["services"]["solr"] == "down"
     assert data["services"]["redis"] == "down"
     assert data["services"]["rabbitmq"] == "down"
+
+
+def _container_by_name(containers: list[dict[str, str]], name: str) -> dict[str, str]:
+    return next(container for container in containers if container["name"] == name)
+
+
+@patch("main._tcp_check", return_value=True)
+@patch("main.requests.get")
+def test_admin_containers_endpoint_happy_path(
+    mock_requests_get: MagicMock,
+    _mock_tcp: MagicMock,
+) -> None:
+    """GET /v1/admin/containers returns all services with shared build metadata and health."""
+
+    def side_effect(url: str, *args: object, **kwargs: object) -> MagicMock:
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        if url.endswith("/admin/collections"):
+            response.json.return_value = {
+                "cluster": {
+                    "live_nodes": ["node1", "node2", "node3"],
+                    "collections": {
+                        "books": {
+                            "shards": {
+                                "shard1": {"replicas": {"replica1": {"index": {"numDocs": 76}}}}
+                            }
+                        }
+                    },
+                }
+            }
+            return response
+        if url.endswith("/version") and "embeddings-server" in url:
+            response.json.return_value = {
+                "service": "embeddings-server",
+                "version": "0.7.0",
+                "commit": "abc1234",
+                "built": "2026-03-15T00:00:00Z",
+            }
+            return response
+        raise AssertionError(f"Unexpected URL {url}")
+
+    mock_requests_get.side_effect = side_effect
+
+    client = get_client()
+    response = client.get("/v1/admin/containers")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["total"] == 10
+    assert data["healthy"] == 8
+    assert data["last_updated"].endswith("Z")
+
+    solr_search = _container_by_name(data["containers"], "solr-search")
+    assert solr_search == {
+        "name": "solr-search",
+        "status": "up",
+        "type": "service",
+        "version": settings.version,
+        "commit": settings.commit,
+    }
+
+    embeddings = _container_by_name(data["containers"], "embeddings-server")
+    assert embeddings == {
+        "name": "embeddings-server",
+        "status": "up",
+        "type": "service",
+        "version": "0.7.0",
+        "commit": "abc1234",
+    }
+
+    assert _container_by_name(data["containers"], "streamlit-admin") == {
+        "name": "streamlit-admin",
+        "status": "up",
+        "type": "service",
+        "version": settings.version,
+        "commit": settings.commit,
+    }
+    assert _container_by_name(data["containers"], "aithena-ui") == {
+        "name": "aithena-ui",
+        "status": "up",
+        "type": "service",
+        "version": settings.version,
+        "commit": settings.commit,
+    }
+    assert _container_by_name(data["containers"], "document-indexer") == {
+        "name": "document-indexer",
+        "status": "unknown",
+        "type": "worker",
+        "version": settings.version,
+        "commit": settings.commit,
+    }
+    assert _container_by_name(data["containers"], "document-lister") == {
+        "name": "document-lister",
+        "status": "unknown",
+        "type": "worker",
+        "version": settings.version,
+        "commit": settings.commit,
+    }
+    assert _container_by_name(data["containers"], "solr") == {
+        "name": "solr",
+        "status": "up",
+        "type": "infrastructure",
+        "version": "unknown",
+        "commit": "unknown",
+    }
+    assert _container_by_name(data["containers"], "redis")["status"] == "up"
+    assert _container_by_name(data["containers"], "rabbitmq")["status"] == "up"
+    assert _container_by_name(data["containers"], "nginx")["status"] == "up"
+
+
+@patch("main.requests.get")
+def test_admin_containers_endpoint_degraded_path(mock_requests_get: MagicMock) -> None:
+    """GET /v1/admin/containers marks failed checks down while workers remain unknown."""
+
+    def requests_side_effect(url: str, *args: object, **kwargs: object) -> MagicMock:
+        if url.endswith("/admin/collections"):
+            raise Exception("solr unavailable")
+        if url.endswith("/version") and "embeddings-server" in url:
+            raise Exception("embeddings unavailable")
+        raise AssertionError(f"Unexpected URL {url}")
+
+    def tcp_side_effect(host: str, port: int, timeout: float = 2.0) -> bool:
+        host_statuses = {
+            "streamlit-admin": False,
+            settings.redis_host: True,
+            settings.rabbitmq_host: False,
+            "aithena-ui": True,
+            "nginx": True,
+            urlparse(settings.solr_url).hostname or settings.solr_url: False,
+        }
+        return host_statuses[host]
+
+    mock_requests_get.side_effect = requests_side_effect
+
+    with patch("main._tcp_check", side_effect=tcp_side_effect):
+        client = get_client()
+        response = client.get("/v1/admin/containers/")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["total"] == 10
+    assert data["healthy"] == 4
+    assert _container_by_name(data["containers"], "embeddings-server") == {
+        "name": "embeddings-server",
+        "status": "down",
+        "type": "service",
+        "version": "unknown",
+        "commit": "unknown",
+    }
+    assert _container_by_name(data["containers"], "streamlit-admin")["status"] == "down"
+    assert _container_by_name(data["containers"], "solr")["status"] == "down"
+    assert _container_by_name(data["containers"], "rabbitmq")["status"] == "down"
+    assert _container_by_name(data["containers"], "document-indexer")["status"] == "unknown"
+    assert _container_by_name(data["containers"], "document-lister")["status"] == "unknown"
 
 
 def test_get_solr_status_on_connection_error() -> None:


### PR DESCRIPTION
Closes #202

Working as Parker (Backend Dev)

## Summary
- add `/v1/admin/containers` in `solr-search` to aggregate service, worker, and infrastructure health/version metadata in parallel
- reuse existing Solr/Redis/RabbitMQ health patterns, query `embeddings-server` via `/version`, and use shared build metadata for non-HTTP repo services
- add happy-path and degraded-path tests covering the new endpoint contract

## Validation
- `cd solr-search && uv run pytest -v --tb=short`
