### PR TITLE
Add System Status page to admin dashboard

### DIFF
--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -194,3 +194,9 @@ REDIS_PORT=6379
 - Worker-style services (`document-indexer`, `document-lister`) should log version and commit at startup rather than exposing an HTTP endpoint.
 - The Streamlit admin surface shows the injected app version in the sidebar as `Admin v{VERSION}` so container builds expose release identity without extra API calls.
 
+### 2026-03-15 — Admin Streamlit Page Conventions (#203)
+
+- The admin dashboard is a Streamlit multipage app: `src/main.py` is the landing dashboard and each file in `admin/src/pages/` becomes a sidebar page automatically.
+- Shared admin service endpoints should be centralized in `admin/src/pages/shared/config.py`; the System Status page reads `SOLR_SEARCH_URL` there and defaults to `http://solr-search:8080`.
+- The `/v1/admin/containers` endpoint currently reports the admin container as `streamlit-admin`, so the UI should present that service as `admin` for operator-facing labels while keeping the backend contract untouched.
+

--- a/admin/src/pages/shared/config.py
+++ b/admin/src/pages/shared/config.py
@@ -13,3 +13,5 @@ RABBITMQ_MGMT_PORT = int(os.environ.get("RABBITMQ_MGMT_PORT", 15672))
 RABBITMQ_MGMT_PATH_PREFIX = os.environ.get("RABBITMQ_MGMT_PATH_PREFIX", "").rstrip("/")
 RABBITMQ_USER = os.environ.get("RABBITMQ_USER", "guest")
 RABBITMQ_PASS = os.environ.get("RABBITMQ_PASS", "guest")
+
+SOLR_SEARCH_URL = os.environ.get("SOLR_SEARCH_URL", "http://solr-search:8080").rstrip("/")

--- a/admin/src/pages/system_status.py
+++ b/admin/src/pages/system_status.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import requests
+import streamlit as st
+from pages.shared.config import SOLR_SEARCH_URL
+
+APP_SERVICE_ORDER = [
+    "solr-search",
+    "embeddings-server",
+    "document-indexer",
+    "document-lister",
+    "streamlit-admin",
+    "admin",
+    "aithena-ui",
+]
+INFRA_SERVICE_ORDER = ["solr", "redis", "rabbitmq", "nginx", "zookeeper", "zoo1", "zoo2", "zoo3"]
+DISPLAY_NAME_OVERRIDES = {"streamlit-admin": "admin"}
+STATUS_STYLE = {
+    "up": ("✅", "green"),
+    "running": ("✅", "green"),
+    "healthy": ("✅", "green"),
+    "down": ("❌", "red"),
+}
+
+st.set_page_config(page_title="System Status", page_icon="🔧", layout="wide")
+st.title("🔧 System Status")
+
+
+def get_status_style(status: str) -> tuple[str, str]:
+    return STATUS_STYLE.get(status.lower(), ("⚠️", "orange"))
+
+
+@st.cache_data(ttl=30, show_spinner=False)
+def fetch_container_status() -> dict[str, Any]:
+    response = requests.get(f"{SOLR_SEARCH_URL}/v1/admin/containers", timeout=5)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_display_name(container: dict[str, Any]) -> str:
+    name = str(container.get("name") or "unknown")
+    return DISPLAY_NAME_OVERRIDES.get(name, name)
+
+
+def format_value(value: Any) -> str:
+    text = str(value).strip() if value is not None else ""
+    return text or "unknown"
+
+
+def shorten_commit(commit: Any) -> str:
+    text = format_value(commit)
+    return text if text == "unknown" else text[:8]
+
+
+def format_timestamp(timestamp: str) -> str:
+    if not timestamp:
+        return "unknown"
+
+    try:
+        normalized = timestamp.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return timestamp
+
+    return parsed.strftime("%Y-%m-%d %H:%M:%S %Z") or timestamp
+
+
+def order_containers(containers: list[dict[str, Any]], preferred_order: list[str]) -> list[dict[str, Any]]:
+    order_index = {name: index for index, name in enumerate(preferred_order)}
+    return sorted(
+        containers,
+        key=lambda container: (
+            order_index.get(str(container.get("name")), len(order_index)),
+            get_display_name(container),
+        ),
+    )
+
+
+def split_containers(containers: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    application: list[dict[str, Any]] = []
+    infrastructure: list[dict[str, Any]] = []
+
+    for container in containers:
+        name = str(container.get("name") or "")
+        container_type = str(container.get("type") or "")
+        if name in INFRA_SERVICE_ORDER or container_type == "infrastructure":
+            infrastructure.append(container)
+        else:
+            application.append(container)
+
+    return (
+        order_containers(application, APP_SERVICE_ORDER),
+        order_containers(infrastructure, INFRA_SERVICE_ORDER),
+    )
+
+
+def render_container_group(title: str, containers: list[dict[str, Any]], columns_per_row: int) -> None:
+    st.subheader(title)
+    if not containers:
+        st.info("No containers reported for this group.")
+        return
+
+    columns = st.columns(columns_per_row)
+    for index, container in enumerate(containers):
+        status = format_value(container.get("status"))
+        emoji, color = get_status_style(status)
+        version = format_value(container.get("version"))
+        commit = shorten_commit(container.get("commit"))
+        error = container.get("error")
+
+        with columns[index % columns_per_row]:
+            with st.container(border=True):
+                st.markdown(f"**{emoji} {get_display_name(container)}**")
+                st.markdown(f"Status: :{color}[{status}]")
+                st.markdown(f"Version: `{version}`")
+                st.markdown(f"Commit: `{commit}`")
+                if error:
+                    st.warning(str(error))
+
+
+summary_col, action_col = st.columns([4, 1])
+with action_col:
+    if st.button("🔄 Refresh", use_container_width=True):
+        fetch_container_status.clear()
+        st.rerun()
+
+try:
+    payload = fetch_container_status()
+except requests.exceptions.RequestException as exc:
+    st.warning(
+        f"Container status is currently unavailable from {SOLR_SEARCH_URL}/v1/admin/containers. {exc}"
+    )
+else:
+    containers = payload.get("containers", [])
+    total = int(payload.get("total", len(containers)))
+    healthy = int(payload.get("healthy", 0))
+    last_updated = format_timestamp(format_value(payload.get("last_updated")))
+    application_services, infrastructure_services = split_containers(containers)
+
+    with summary_col:
+        st.caption(f"Last updated: {last_updated}")
+
+    metric_total, metric_healthy, metric_attention = st.columns(3)
+    metric_total.metric("Total containers", total)
+    metric_healthy.metric("Healthy", healthy)
+    metric_attention.metric("Need attention", max(total - healthy, 0))
+
+    render_container_group("📦 Application Services", application_services, columns_per_row=3)
+    render_container_group("🏗️ Infrastructure Services", infrastructure_services, columns_per_row=4)


### PR DESCRIPTION
## Summary
- add a Streamlit System Status page that fetches `/v1/admin/containers` from `SOLR_SEARCH_URL`
- group reported containers into application and infrastructure sections with status, version, commit, refresh, and last-updated UI
- append Parker learnings for the admin multipage/config conventions

## Validation
- `python3 -m py_compile admin/src/main.py admin/src/pages/document_lister.py admin/src/pages/shared/config.py admin/src/pages/system_status.py`

Closes #203
Working as Parker (Backend Dev)