### PR TITLE
Add versioned release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,48 +3,115 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  validate-tag:
+    name: Validate release tag
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      build_date: ${{ steps.build_date.outputs.build_date }}
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            document-indexer/uv.lock
-            solr-search/uv.lock
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install test dependencies
+      - name: Validate stable semver tag
+        id: version
+        shell: bash
         run: |
-          if [ -f document-indexer/uv.lock ]; then
-            cd document-indexer && uv sync --frozen && cd ..
-          fi
-          if [ -f solr-search/uv.lock ]; then
-            cd solr-search && uv sync --frozen && cd ..
-          fi
-
-      - name: Run tests
-        run: |
-          if [ -d document-indexer ] && find document-indexer -name 'test_*.py' -o -name '*_test.py' | grep -q .; then
-            cd document-indexer && uv run pytest -v && cd ..
-          fi
-          if [ -d solr-search ] && find solr-search -name 'test_*.py' -o -name '*_test.py' | grep -q .; then
-            cd solr-search && uv run pytest -v && cd ..
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Expected a stable semver tag in the form vX.Y.Z, got: $tag" >&2
+            exit 1
           fi
 
-      - name: Create GitHub Release
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Capture build timestamp
+        id: build_date
+        shell: bash
+        run: echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    name: Build and push ${{ matrix.service.image }}
+    runs-on: ubuntu-latest
+    needs: validate-tag
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - image: admin
+            context: ./admin
+            dockerfile: ./admin/Dockerfile
+          - image: aithena-ui
+            context: ./aithena-ui
+            dockerfile: ./aithena-ui/Dockerfile
+          - image: document-indexer
+            context: ./document-indexer
+            dockerfile: ./document-indexer/Dockerfile
+          - image: document-lister
+            context: ./document-lister
+            dockerfile: ./document-lister/Dockerfile
+          - image: embeddings-server
+            context: ./embeddings-server
+            dockerfile: ./embeddings-server/Dockerfile
+          - image: solr-search
+            context: .
+            dockerfile: ./solr-search/Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/jmservera/aithena-${{ matrix.service.image }}
+          tags: |
+            type=semver,pattern={{version}},value=v${{ needs.validate-tag.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ needs.validate-tag.outputs.version }}
+            type=semver,pattern={{major}},value=v${{ needs.validate-tag.outputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ needs.validate-tag.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ needs.validate-tag.outputs.build_date }}
+          cache-from: type=gha,scope=${{ matrix.service.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}
+
+  github-release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - validate-tag
+      - build-and-push
+    steps:
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,60 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-check:
+    name: Validate version metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate VERSION file
+        shell: bash
+        run: |
+          if [[ ! -f VERSION ]]; then
+            echo "VERSION file is missing." >&2
+            exit 1
+          fi
+
+          version="$(tr -d '[:space:]' < VERSION)"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must contain a stable semver (X.Y.Z). Found: $version" >&2
+            exit 1
+          fi
+
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+          echo "Validated VERSION=$version"
+
+      - name: Verify Dockerfiles declare VERSION build arg
+        shell: bash
+        run: |
+          dockerfiles=(
+            admin/Dockerfile
+            aithena-ui/Dockerfile
+            document-indexer/Dockerfile
+            document-lister/Dockerfile
+            embeddings-server/Dockerfile
+            solr-search/Dockerfile
+          )
+
+          for dockerfile in "${dockerfiles[@]}"; do
+            if ! grep -Eq '^ARG VERSION(=.+)?$' "$dockerfile"; then
+              echo "$dockerfile is missing an ARG VERSION declaration." >&2
+              exit 1
+            fi
+          done
+
+          echo "All release Dockerfiles declare ARG VERSION."

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -44,6 +44,14 @@
 
 <!-- Append learnings below -->
 
+### 2026-03-15 — Issue #204: GitHub Actions versioned release automation
+
+- Replaced the old tag-only release workflow with a semver-validated GHCR publish pipeline for all six source-built services: `admin`, `aithena-ui`, `document-indexer`, `document-lister`, `embeddings-server`, and `solr-search`.
+- The new `.github/workflows/release.yml` builds each image with `VERSION`, `GIT_COMMIT`, and `BUILD_DATE`, then publishes four release tags per image via `docker/metadata-action`: full (`X.Y.Z`), minor (`X.Y`), major (`X`), and `latest`.
+- Kept GitHub Release publication in the workflow so the tag ceremony still produces release notes after all image pushes succeed.
+- Added `.github/workflows/version-check.yml` to gate PRs into `dev` and `main` on a valid root `VERSION` file plus `ARG VERSION` declarations in the six release Dockerfiles.
+- No `ci.yml` change was required because the existing CI workflow only runs on `dev` branch pushes/PRs, so it does not conflict with tag-triggered release publishing.
+
 ### 2026-03-14 — Reskill session: current infrastructure snapshot
 
 **9 services operational:**

--- a/.squad/decisions/inbox/brett-cicd-release.md
+++ b/.squad/decisions/inbox/brett-cicd-release.md
@@ -1,0 +1,14 @@
+# Brett — CI/CD release automation decision
+
+## Context
+Issue #204 adds the first container release automation for the six source-built services after issue #199 standardized `VERSION`, `GIT_COMMIT`, and `BUILD_DATE` Docker build args.
+
+## Decision
+- Release publication is now driven by stable semver tags only (`vX.Y.Z`).
+- `.github/workflows/release.yml` publishes six GHCR images (`ghcr.io/jmservera/aithena-{service}`) using a matrix build and `docker/build-push-action`.
+- Every release tag produces four image tags per service: `X.Y.Z`, `X.Y`, `X`, and `latest`.
+- The release workflow preserves GitHub Releases by creating a GitHub release with generated notes after all image pushes succeed.
+- `.github/workflows/version-check.yml` now validates the root `VERSION` file and verifies that all release Dockerfiles declare `ARG VERSION` on PRs to `dev` and `main`.
+
+## Why
+This keeps the squad's semver release flow from DEC-070 aligned across git tags, container image tags, and the repo `VERSION` file. It also keeps the existing GitHub release notes ceremony intact while making container publication repeatable and auditable.


### PR DESCRIPTION
## Summary
- replace the tag release workflow with a semver-validated GHCR matrix publish for the six source-built services
- add a PR version check workflow for the root VERSION file and Dockerfile ARG VERSION declarations
- preserve GitHub release generation after successful image publishes; no ci.yml change was needed because branch CI does not run on release tags

## Validation
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/version-check.yml'))"
- local VERSION/Dockerfile validation script
- cd document-indexer && uv sync --frozen && uv run pytest -v --tb=short --cov=document_indexer --cov-report=term-missing
- cd solr-search && uv sync --frozen && uv run pytest tests/test_search_service.py -v --tb=short --cov=search_service --cov-report=term-missing
- cd solr-search && uv run pytest tests/test_integration.py -v --tb=short
- cd aithena-ui && npm ci && npm run lint && npm run format:check

Closes #204
Working as Brett (Infrastructure Architect)