### PR TITLE
feat: auto-mark Copilot draft PRs ready when review is requested

### DIFF
--- a/.github/workflows/copilot-pr-ready.yml
+++ b/.github/workflows/copilot-pr-ready.yml
@@ -1,0 +1,32 @@
+name: Copilot PR Ready
+
+on:
+  pull_request:
+    types: [review_requested]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  mark-copilot-pr-ready:
+    if: >-
+      github.event.pull_request.draft == true &&
+      contains(fromJson('["copilot-swe-agent[bot]","app/copilot-swe-agent","copilot-swe-agent"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark Copilot PR ready for review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // REST API cannot set draft=false; must use GraphQL mutation
+            await github.graphql(`
+              mutation($pullRequestId: ID!) {
+                markPullRequestAsReady(input: {pullRequestId: $pullRequestId}) {
+                  pullRequest { isDraft }
+                }
+              }
+            `, { pullRequestId: pr.node_id });
+
+            core.info(`Marked PR #${pr.number} ready for review after Copilot requested review.`);

--- a/.squad/decisions/inbox/brett-copilot-pr-ready.md
+++ b/.squad/decisions/inbox/brett-copilot-pr-ready.md
@@ -1,0 +1,54 @@
+# Brett — Copilot PR auto-ready decision
+
+## Context
+
+`@copilot` opens draft PRs, finishes work, requests review, and sometimes leaves the PR in draft state. That blocks the squad because reviewable work is hidden until someone manually inspects PR status.
+
+## Workflow review
+
+- `squad-heartbeat.yml` does **not** listen for `pull_request` `review_requested`; it only listens for `pull_request: [closed]`, issue events, and manual dispatch.
+- `squad-heartbeat.yml` currently has `pull-requests: read`, so it cannot mark PRs ready without a permission increase.
+- There was no existing workflow that marks draft Copilot PRs ready when review is requested.
+
+## Options evaluated
+
+### Option A — Dedicated workflow on `pull_request.review_requested`
+**Pros**
+- Best event fidelity: reacts exactly when Copilot requests review.
+- Least privilege: only needs `pull-requests: write`.
+- Small and easy to audit.
+- No checkout required, so it avoids running PR code.
+
+**Cons**
+- One additional workflow file.
+
+### Option B — Extend `squad-heartbeat.yml`
+**Pros**
+- Reuses existing workflow.
+- Fewer workflow files.
+
+**Cons**
+- Broadens Ralph's monitoring workflow with write access to pull requests.
+- Mixes unrelated responsibilities (board monitoring + PR state mutation).
+- Current heartbeat cadence is not a strong fallback because the schedule is disabled.
+
+### Option C — Dedicated workflow + heartbeat fallback
+**Pros**
+- Highest theoretical resilience.
+
+**Cons**
+- More moving parts for a small automation.
+- Heartbeat fallback is weak until the schedule is re-enabled.
+- Extra maintenance for limited practical gain.
+
+## Decision
+
+Chosen: **Option A**.
+
+Add a dedicated workflow, `.github/workflows/copilot-pr-ready.yml`, triggered by `pull_request` `review_requested`. When the PR author is `copilot-swe-agent[bot]`, `app/copilot-swe-agent`, or `copilot-swe-agent` and the PR is still draft, the workflow marks it ready for review using `github.rest.pulls.readyForReview()`.
+
+## Notes
+
+- Yes, we **could** add `review_requested` to `squad-heartbeat.yml`, but the dedicated workflow is cleaner and more secure.
+- I did **not** remove `[WIP]` from PR titles. Draft state is the real workflow gate, while title rewriting is more opinionated and can surprise humans.
+- If Ralph's scheduled heartbeat is re-enabled later, a lightweight fallback scan can be added then if we observe missed events in practice.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/copilot-pr-ready.yml` — a GitHub Action that automatically marks @copilot's draft PRs as ready for review when a review is requested.

### Problem
@copilot finishes work on draft PRs and requests review to jmservera, but leaves them as drafts. The squad team doesn't notice, causing PRs to sit idle until manually discovered.

### Solution
A focused workflow triggered on `pull_request: [review_requested]` that:
1. Checks if the PR author is `copilot-swe-agent[bot]`
2. Checks if the PR is still a draft
3. If both true → marks the PR ready for review via GraphQL `markPullRequestAsReady` mutation

### Design Decision
Chose a dedicated workflow (Option A) over modifying squad-heartbeat.yml because:
- **Better event fidelity** — reacts immediately when review is requested
- **Least privilege** — only needs `pull-requests: write`
- **Separation of concerns** — heartbeat monitors board state, this handles PR lifecycle

Full rationale in `.squad/decisions/inbox/brett-copilot-pr-ready.md`

### Technical Notes
- Uses GraphQL mutation (REST API cannot set `draft: false`)
- No checkout needed — runs entirely via GitHub API
- Job-level `if` guard means non-copilot PRs don't even start a runner

Closes the copilot-review handoff gap identified by the PM.