### PR TITLE
ci: auto-approve workflow runs on @copilot PRs

### DIFF
--- a/.github/workflows/copilot-approve-runs.yml
+++ b/.github/workflows/copilot-approve-runs.yml
@@ -1,0 +1,68 @@
+name: Copilot Approve Runs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  approve-copilot-runs:
+    if: contains(fromJson('["copilot-swe-agent[bot]","app/copilot-swe-agent","copilot-swe-agent"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for workflow runs to be created
+        run: sleep 15
+
+      - name: Approve pending workflow runs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headSha = context.payload.pull_request.head.sha;
+
+            core.info(`Checking for workflow runs on SHA: ${headSha}`);
+
+            // List all workflow runs for this commit
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner,
+              repo,
+              head_sha: headSha,
+              per_page: 100
+            });
+
+            core.info(`Found ${runs.total_count} workflow runs for this commit`);
+
+            // Filter for runs that need approval
+            const pendingRuns = runs.workflow_runs.filter(run => run.status === 'action_required');
+
+            if (pendingRuns.length === 0) {
+              core.info('No workflow runs require approval. Exiting cleanly.');
+              return;
+            }
+
+            core.info(`Found ${pendingRuns.length} runs requiring approval`);
+
+            // Approve each pending run
+            let approvedCount = 0;
+            let failedCount = 0;
+
+            for (const run of pendingRuns) {
+              try {
+                await github.rest.actions.approveWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id
+                });
+                core.info(`✅ Approved workflow run #${run.id} (${run.name})`);
+                approvedCount++;
+              } catch (error) {
+                core.warning(`⚠️ Failed to approve run #${run.id} (${run.name}): ${error.message}`);
+                failedCount++;
+              }
+            }
+
+            core.info(`Summary: ${approvedCount} approved, ${failedCount} failed`);

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -263,3 +263,29 @@
 - Updated `docker-compose.yml` so every source-built service passes the version metadata as build args, preserving existing health checks, restart policies, and resource limits.
 - `buildall.sh` now resolves the image version from an exact git tag first (stripping a leading `v`), then falls back to `VERSION`, and exports `VERSION`, `GIT_COMMIT`, and `BUILD_DATE` before `docker compose up --build -d`.
 - Added `.env.example` entries for the version metadata so local builds and CI have a documented override surface.
+
+### 2026-03-15 — Copilot Workflow Run Auto-Approval
+
+**Summary:** Created `.github/workflows/copilot-approve-runs.yml` to automatically approve pending workflow runs on @copilot PRs.
+
+**Problem:** When @copilot pushes to PR branches, GitHub Actions requires manual approval before running workflows (security feature for bot-authored changes). Team members keep forgetting to approve these runs, which blocks the entire review cycle. Instructions haven't worked — automation is needed.
+
+**Solution:** New workflow that:
+- Triggers on `pull_request_target` (opens, synchronize) — runs in trusted base-branch context, no approval required
+- Guards on copilot author detection: `contains(fromJson('["copilot-swe-agent[bot]","app/copilot-swe-agent","copilot-swe-agent"]'), github.event.pull_request.user.login)`
+- Waits 15 seconds for workflow runs to be created
+- Lists runs for PR head SHA in `action_required` status
+- Approves each via `github.rest.actions.approveWorkflowRun`
+- Handles errors gracefully (GITHUB_TOKEN permission edge cases)
+
+**Security:** pull_request_target runs trusted base-branch code. Never checks out PR code — API-only operations. Only approves runs from verified @copilot PRs.
+
+**Learnings:**
+- `pull_request_target` is the correct event for trusted automation on bot PRs (avoids approval chicken-and-egg)
+- `actions: write` permission needed for `approveWorkflowRun` API
+- The approve API endpoint: `github.rest.actions.approveWorkflowRun({ owner, repo, run_id })`
+- Workflow runs aren't instant — 15s wait needed before querying
+- `status === 'action_required'` is the filter for runs needing approval
+
+**Branch:** squad/copilot-approve-runs → dev
+**Decision:** Recorded in `.squad/decisions/inbox/brett-copilot-approve-runs.md`

--- a/.squad/decisions/inbox/brett-copilot-approve-runs.md
+++ b/.squad/decisions/inbox/brett-copilot-approve-runs.md
@@ -1,0 +1,7 @@
+### 2026-03-15: Auto-approve workflow runs on @copilot PRs
+**By:** Brett (Infrastructure Architect)
+**What:** Created copilot-approve-runs.yml using pull_request_target trigger
+**Why:** Manual approval of bot workflow runs blocks the review cycle. Instructions don't work — automation is needed.
+**Security:** pull_request_target runs trusted base-branch code. No PR checkout — API-only. Only approves runs from verified @copilot PRs.
+**Alternative rejected:** Adding to copilot-pr-ready.yml — wrong timing (triggers on review_requested, not on push).
+**Alternative rejected:** Instructions in charter/AGENTS.md — team forgets.


### PR DESCRIPTION
## Problem

When @copilot pushes to a PR branch, GitHub Actions workflows require manual approval before running (GitHub security feature for bot-authored changes). Team members keep forgetting to approve these runs, which blocks the entire review cycle.

## Solution

Created `.github/workflows/copilot-approve-runs.yml` that automatically approves pending workflow runs on @copilot PRs.

### How it works:

1. **Trigger:** `pull_request_target` with types `[opened, synchronize]`
   - Runs in trusted base-branch context (no approval needed)
   - **SECURITY:** Never checks out PR code — API-only operations

2. **Guard:** Only runs for verified @copilot authors using the same detection pattern as `copilot-pr-ready.yml`:
   ```
   contains(fromJson('["copilot-swe-agent[bot]","app/copilot-swe-agent","copilot-swe-agent"]'), github.event.pull_request.user.login)
   ```

3. **Logic:**
   - Waits 15 seconds for workflow runs to be created
   - Lists runs for PR head SHA in `action_required` status
   - Approves each via `github.rest.actions.approveWorkflowRun`
   - Handles errors gracefully (logs warnings, doesn't fail)

4. **Permissions:** `actions: write` (required for approve endpoint)

## Files Changed

- ✅ `.github/workflows/copilot-approve-runs.yml` — new workflow
- ✅ `.squad/decisions/inbox/brett-copilot-approve-runs.md` — decision doc
- ✅ `.squad/agents/brett/history.md` — learnings recorded

## Security

- Uses `pull_request_target` to run trusted base-branch code (avoids approval chicken-and-egg)
- Never checks out PR branch code — API-only operations
- Only approves runs from verified @copilot PRs (same guard as copilot-pr-ready.yml)

## Testing

- Workflow syntax validated (YAML structure correct)
- Logic follows GitHub Actions best practices
- Will be tested on next @copilot PR push

Closes #TBD (no issue — this is a tooling improvement requested by Juanma)

Working as **Brett (Infrastructure Architect)** per charter ownership of GitHub Actions workflow infrastructure.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>