### PR TITLE
ops: add failover runbooks and drill script

### DIFF
--- a/docs/deployment/failover-runbook.md
+++ b/docs/deployment/failover-runbook.md
@@ -1,0 +1,350 @@
+# Failover & Recovery Runbook
+
+This runbook covers operator recovery for the Docker Compose deployment defined in `docker-compose.yml`. It is based on the current Compose wiring, health checks, volumes, and `solr-search` behavior in `solr-search/main.py`.
+
+> Docker is not available in this sandbox, so the steps below are based on code analysis rather than a live drill. Use `e2e/failover-drill.sh` in a Docker-capable environment to validate the procedure.
+
+## Preconditions
+
+- Run `python3 -m installer` before the first `docker compose up` so `.env`, `AUTH_DB_DIR`, `AUTH_DB_PATH`, and the SQLite auth DB exist.
+- Use the base `docker-compose.yml` for full failover drills. `docker-compose.e2e.yml` intentionally disables `nginx` and `certbot`, so it is not suitable for the nginx outage scenario.
+- Use `docker compose ps` and container health checks to confirm process-level readiness.
+- Use the status probe below for application-level confirmation:
+
+```bash
+docker compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+```
+
+Why this probe is preferred:
+
+- `solr-search` exposes `/v1/status/` without FastAPI auth.
+- nginx protects `/v1/*` externally, so unauthenticated `curl http://localhost/v1/status/` will be rejected.
+- The internal probe still works even when nginx is down.
+
+A healthy baseline should show:
+
+- `services.solr = up`
+- `services.redis = up`
+- `services.rabbitmq = up`
+- `services.embeddings = up`
+- `embeddings_available = true`
+- `solr.status = ok`
+- `solr.nodes >= 3`
+
+## Service dependency map
+
+| Service | Hard dependencies (`depends_on`) | Operational notes |
+| --- | --- | --- |
+| `redis` | — | Stores indexing state (`doc:*`) and supports admin/indexing services. |
+| `rabbitmq` | — | Durable queue broker for indexing and uploads. |
+| `zoo1`, `zoo2`, `zoo3` | — | SolrCloud coordination layer; quorum is required for stable Solr operation. |
+| `solr` | `zoo1`, `zoo2`, `zoo3` healthy | Primary Solr endpoint used by `solr-search` and `document-indexer`. |
+| `solr2` | `zoo1`, `zoo2`, `zoo3`, `solr` healthy | Additional Solr replica node. |
+| `solr3` | `zoo1`, `zoo2`, `zoo3`, `solr2` healthy | Additional Solr replica node. |
+| `solr-init` | `solr`, `solr2`, `solr3` healthy | One-shot bootstrap that uploads config and creates the `books` collection with `replicationFactor=3`. |
+| `embeddings-server` | — | Required for semantic/hybrid search and document embedding. |
+| `document-lister` | `rabbitmq`, `redis` healthy | Polls `document-data` and publishes indexing work to RabbitMQ. |
+| `document-indexer` | `rabbitmq`, `redis`, `embeddings-server` healthy | Consumes queue items, creates embeddings, and writes to Solr. |
+| `solr-search` | `solr`, `embeddings-server`, `rabbitmq`, `redis` healthy | Search/API tier. Startup is gated by Redis and RabbitMQ, but runtime search availability mainly depends on Solr and embeddings. |
+| `streamlit-admin` | `rabbitmq`, `redis` healthy | Admin dashboard for queue/indexing visibility. |
+| `redis-commander` | `redis` healthy | Redis admin UI. |
+| `aithena-ui` | `solr-search` healthy | End-user UI. |
+| `nginx` | `aithena-ui`, `solr-search`, `streamlit-admin`, `redis-commander`, `rabbitmq`, `solr` healthy | Public ingress and auth gate for `/v1/*`, `/documents/*`, and `/admin/*`. |
+| `certbot` | — | Certificate renewal sidecar. |
+
+### Important architecture caveat
+
+The Solr cluster has three nodes, but the application tier is configured to talk to `http://solr:8983/solr` directly:
+
+- `solr-search` uses `SOLR_URL=http://solr:8983/solr`
+- `document-indexer` uses `SOLR_HOST=solr`
+
+That means losing the **primary `solr` service** is still a user-visible outage even if `solr2` and `solr3` are alive.
+
+## `/v1/status/` behavior
+
+`/v1/status/` aggregates four checks:
+
+- Solr cluster state and live-node count from `CLUSTERSTATUS`
+- Redis `doc:*` key counts for indexing state
+- TCP reachability for Solr, Redis, and RabbitMQ
+- embeddings-server `/version` reachability
+
+Expected status semantics:
+
+| Field | Meaning |
+| --- | --- |
+| `solr.status = ok` | Solr `CLUSTERSTATUS` succeeded and at least 3 live nodes were seen. |
+| `solr.status = degraded` | Solr answered, but fewer than 3 live nodes were seen. |
+| `solr.status = error` | Solr cluster query failed or no live nodes were reachable. |
+| `services.<name> = up/down` | Simple reachability check for Solr, Redis, RabbitMQ, or embeddings-server. |
+| `embeddings_available` | `true` when embeddings-server answers its `/version` probe. |
+| `indexing.*` | Redis-backed indexing counters; if Redis is unavailable the endpoint returns zeros. |
+
+## Failure scenarios
+
+### 1. Primary Solr service down (`solr`)
+
+**Typical symptoms**
+
+- `/v1/status/` reports:
+  - `services.solr = down`
+  - `solr.status = error`
+  - `solr.nodes = 0`
+- Keyword, semantic, and hybrid search requests fail.
+- Document indexing cannot write to Solr.
+- nginx may stay up, but `/v1/search` and `/documents/*` requests will fail upstream.
+
+**Detection**
+
+```bash
+docker compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+```
+
+**Recovery**
+
+1. Start or restart the primary node:
+   ```bash
+   docker compose restart solr
+   ```
+2. Wait for `solr` to become healthy:
+   ```bash
+   docker compose ps solr
+   ```
+3. If the collection or configset was lost, rerun the bootstrap job:
+   ```bash
+   docker compose up -d solr-init
+   docker compose logs --tail=100 solr-init
+   ```
+4. Restart direct dependents if they do not recover cleanly:
+   ```bash
+   docker compose restart document-indexer solr-search nginx
+   ```
+5. Re-run `/v1/status/` and confirm `services.solr = up`.
+
+**Expected behavior during failure**
+
+There is **no** fallback when Solr is unavailable. Semantic/hybrid fallback only helps when embeddings fail; it does not replace Solr.
+
+### 2. Redis down
+
+**Typical symptoms**
+
+- `/v1/status/` reports `services.redis = down`.
+- `indexing.total_discovered`, `indexed`, `failed`, and `pending` fall back to zeros because Redis reads fail.
+- Search requests usually continue to work.
+- `document-lister`, `document-indexer`, `streamlit-admin`, and `redis-commander` may stop working or restart repeatedly until Redis returns.
+
+**Detection**
+
+```bash
+docker compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+```
+
+**Recovery**
+
+1. Restart Redis:
+   ```bash
+   docker compose restart redis
+   ```
+2. Wait for `redis-cli ping` health to recover:
+   ```bash
+   docker compose ps redis
+   ```
+3. Restart Redis-dependent services if they do not reconnect automatically:
+   ```bash
+   docker compose restart document-lister document-indexer streamlit-admin redis-commander
+   ```
+4. Re-run `/v1/status/` and confirm `services.redis = up`.
+
+**Expected behavior during failure**
+
+- Existing search traffic should still work.
+- Indexing progress tracking is unavailable until Redis returns.
+
+### 3. RabbitMQ down
+
+**Typical symptoms**
+
+- `/v1/status/` reports `services.rabbitmq = down`.
+- Search requests usually continue to work.
+- New uploads and document discovery stop flowing into the indexing queue.
+- `document-lister`, `document-indexer`, and `streamlit-admin` may fail or restart until RabbitMQ is healthy again.
+
+**Detection**
+
+```bash
+docker compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+```
+
+**Recovery**
+
+1. Restart RabbitMQ:
+   ```bash
+   docker compose restart rabbitmq
+   ```
+2. Wait for the broker health check to pass:
+   ```bash
+   docker compose ps rabbitmq
+   ```
+3. Restart queue-dependent services if needed:
+   ```bash
+   docker compose restart document-lister document-indexer streamlit-admin
+   ```
+4. Re-run `/v1/status/` and confirm `services.rabbitmq = up`.
+
+**Expected behavior during failure**
+
+- Search remains available.
+- Ingestion/indexing work pauses until the queue broker returns.
+
+### 4. embeddings-server down
+
+**Typical symptoms**
+
+- `/v1/status/` reports:
+  - `services.embeddings = down`
+  - `embeddings_available = false`
+- Keyword search still works.
+- Semantic and hybrid search requests degrade to keyword mode and include:
+  - `degraded: true`
+  - `message: "Embeddings unavailable — showing keyword results"`
+  - `requested_mode: "semantic"` or `"hybrid"`
+- `document-indexer` cannot generate new embeddings while the outage lasts.
+
+**Detection**
+
+```bash
+docker compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+```
+
+**Recovery**
+
+1. Restart the embeddings service:
+   ```bash
+   docker compose restart embeddings-server
+   ```
+2. Wait for its `/health` probe to pass:
+   ```bash
+   docker compose ps embeddings-server
+   ```
+3. Restart `document-indexer` if it does not reconnect automatically:
+   ```bash
+   docker compose restart document-indexer
+   ```
+4. Re-run `/v1/status/` and confirm embeddings are back up.
+5. Run a semantic search probe and confirm the response is no longer degraded.
+
+**Expected behavior during failure**
+
+This is the designed graceful-degradation path: semantic/hybrid requests fall back to keyword search instead of returning 502/504.
+
+### 5. nginx down
+
+**Typical symptoms**
+
+- `curl http://localhost/health` fails.
+- External access to `/`, `/documents/*`, `/admin/*`, and `/v1/*` fails.
+- Internal service-to-service traffic continues; `solr-search` can still answer `/v1/status/` internally.
+
+**Detection**
+
+- External ingress check:
+  ```bash
+  curl -f http://localhost/health
+  ```
+- Internal API check (works even when nginx is stopped):
+  ```bash
+  docker compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+  ```
+
+**Recovery**
+
+1. Confirm upstream services are healthy enough to serve traffic:
+   ```bash
+   docker compose ps aithena-ui solr-search streamlit-admin redis-commander rabbitmq solr
+   ```
+2. Restart nginx:
+   ```bash
+   docker compose restart nginx
+   ```
+3. Validate external ingress:
+   ```bash
+   curl -f http://localhost/health
+   ```
+4. If nginx still returns 502/503, recover the unhealthy upstream and restart nginx again.
+
+**Expected behavior during failure**
+
+nginx is only the ingress tier. Its failure does not stop the internal search/indexing stack, but it removes external access.
+
+## Graceful degradation: semantic → keyword fallback
+
+The fallback applies only when the embeddings request fails with a transient backend error (`502` or `504`):
+
+- `mode=semantic` → returns a keyword search payload with `degraded: true`
+- `mode=hybrid` → returns a keyword search payload with `degraded: true`
+- `mode=keyword` → unaffected
+
+Operationally, this means:
+
+- An embeddings outage should not take the search UI offline.
+- A Solr outage still breaks all search modes because keyword search also depends on Solr.
+- Recovery validation should include one semantic or hybrid request after embeddings-server returns to confirm `degraded` goes back to `false`.
+
+## Recommended restart ordering
+
+Compose health checks define the safe recovery order. Restart from the bottom of the dependency graph upward.
+
+1. **Core stateful infrastructure**
+   - `redis`
+   - `rabbitmq`
+   - `zoo1`, `zoo2`, `zoo3`
+2. **Search cluster**
+   - `solr`, `solr2`, `solr3`
+   - `solr-init` (if collection/config bootstrap must be replayed)
+3. **ML service**
+   - `embeddings-server`
+4. **Workers and API**
+   - `document-lister`
+   - `document-indexer`
+   - `solr-search`
+5. **Operator and user interfaces**
+   - `streamlit-admin`
+   - `redis-commander`
+   - `aithena-ui`
+6. **Ingress**
+   - `nginx`
+
+### Practical rule
+
+After restoring an upstream dependency, restart the services that depend on it if they do not reconnect automatically. Compose `depends_on` only guarantees startup ordering; it does not re-run that logic after a later runtime failure.
+
+## Data durability
+
+| Data / state | Backing storage | What survives restart | What can be lost |
+| --- | --- | --- | --- |
+| Solr index (`books`) | Bind-mounted `solr-data`, `solr-data2`, `solr-data3` | Indexed documents and vectors survive normal restarts. | If the Solr volumes are deleted or corrupted, search data is lost and must be rebuilt from source documents. |
+| ZooKeeper metadata | Bind-mounted `zoo-data*` volumes | Collection metadata and cluster coordination data survive restarts. | Losing ZooKeeper data can require re-running `solr-init` and re-forming the cluster. |
+| Redis indexing state | Bind-mounted `/source/volumes/redis`, Redis RDB snapshots (`--save 20 1`) | Most `doc:*` state survives orderly restarts. | Recent in-memory updates since the last snapshot can be lost on crash/forced stop. |
+| RabbitMQ queue state | Bind-mounted `/source/volumes/rabbitmq-data` | Durable queues and persistent messages survive broker restarts. | In-flight work can be retried; if the volume is removed, queued work is lost. |
+| Auth DB | Host bind mount from `AUTH_DB_DIR` to `/data/auth`, SQLite `users.db` | Users, password hashes, and auth data survive container restarts. | If `AUTH_DB_DIR` is deleted, logins are lost until the DB is restored or recreated. |
+| Source documents | `document-data` bind mount | PDFs remain intact because they live on the host library path. | Not affected by container restarts unless the host path changes or is deleted. |
+
+## Suggested operator validation after recovery
+
+Run these after any fix:
+
+```bash
+# Core application health
+docker compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+
+# Public ingress (nginx scenarios)
+curl -f http://localhost/health
+
+# Optional authenticated search smoke test
+curl -f -H "Authorization: Bearer $TOKEN" \
+  "http://localhost/v1/search?q=history&mode=keyword&page_size=1"
+```
+
+If the outage involved embeddings-server, repeat the smoke test with `mode=semantic` and confirm the response is no longer degraded.

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -2,6 +2,8 @@
 
 This guide covers production deployment of the Aithena book library search system using Docker Compose.
 
+For service-by-service outage handling and recovery drills, see the [failover runbook](failover-runbook.md).
+
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
@@ -13,6 +15,7 @@ This guide covers production deployment of the Aithena book library search syste
 - [Monitoring & Logging](#monitoring--logging)
 - [Troubleshooting](#troubleshooting)
 - [Backup & Restore](#backup--restore)
+- [Failover Runbook](failover-runbook.md)
 
 ## Prerequisites
 

--- a/e2e/failover-drill.sh
+++ b/e2e/failover-drill.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Full failover coverage expects docker-compose.yml only. The e2e override disables
+# nginx and certbot, so keep COMPOSE_FILES at its default unless you intentionally
+# want a reduced-scope drill.
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+read -r -a COMPOSE_FILES <<<"${COMPOSE_FILES:-docker-compose.yml}"
+COMPOSE_ARGS=()
+for compose_file in "${COMPOSE_FILES[@]}"; do
+  COMPOSE_ARGS+=( -f "$compose_file" )
+done
+
+compose() {
+  docker compose "${COMPOSE_ARGS[@]}" "$@"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+log() {
+  printf '\n[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"
+}
+
+json_matches() {
+  local payload="$1"
+  local expr="$2"
+  JSON_PAYLOAD="$payload" JSON_EXPR="$expr" python3 - <<'PY'
+import json
+import os
+import sys
+
+data = json.loads(os.environ["JSON_PAYLOAD"])
+expr = os.environ["JSON_EXPR"]
+if not eval(expr, {"__builtins__": {}}, {"data": data}):
+    sys.exit(1)
+PY
+}
+
+assert_json() {
+  local payload="$1"
+  local expr="$2"
+  local message="$3"
+  if ! json_matches "$payload" "$expr"; then
+    echo "Assertion failed: $message" >&2
+    printf '%s\n' "$payload" >&2
+    exit 1
+  fi
+}
+
+container_id() {
+  compose ps -q "$1"
+}
+
+container_state() {
+  local cid
+  cid="$(container_id "$1")"
+  [[ -n "$cid" ]] || return 1
+  docker inspect -f '{{.State.Status}}' "$cid"
+}
+
+container_exit_code() {
+  local cid
+  cid="$(container_id "$1")"
+  [[ -n "$cid" ]] || return 1
+  docker inspect -f '{{.State.ExitCode}}' "$cid"
+}
+
+container_health() {
+  local cid
+  cid="$(container_id "$1")"
+  [[ -n "$cid" ]] || return 1
+  docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid"
+}
+
+wait_for_state() {
+  local service="$1"
+  local target="$2"
+  local timeout="${3:-300}"
+  local started_at=$SECONDS
+
+  while (( SECONDS - started_at < timeout )); do
+    local state=""
+    case "$target" in
+      healthy)
+        state="$(container_health "$service" 2>/dev/null || true)"
+        [[ "$state" == "healthy" ]] && return 0
+        ;;
+      running)
+        state="$(container_state "$service" 2>/dev/null || true)"
+        [[ "$state" == "running" ]] && return 0
+        ;;
+      exited)
+        state="$(container_state "$service" 2>/dev/null || true)"
+        [[ "$state" == "exited" ]] && return 0
+        ;;
+      exited0)
+        state="$(container_state "$service" 2>/dev/null || true)"
+        if [[ "$state" == "exited" ]] && [[ "$(container_exit_code "$service" 2>/dev/null || true)" == "0" ]]; then
+          return 0
+        fi
+        ;;
+      *)
+        echo "Unsupported wait target: $target" >&2
+        exit 1
+        ;;
+    esac
+    sleep 2
+  done
+
+  compose ps >&2 || true
+  echo "Timed out waiting for $service to reach state '$target'" >&2
+  return 1
+}
+
+status_json() {
+  compose exec -T solr-search wget -qO- http://localhost:8080/v1/status/
+}
+
+wait_for_status() {
+  local expr="$1"
+  local timeout="${2:-180}"
+  local started_at=$SECONDS
+  local payload=""
+
+  while (( SECONDS - started_at < timeout )); do
+    if payload="$(status_json 2>/dev/null)" && json_matches "$payload" "$expr"; then
+      printf '%s\n' "$payload"
+      return 0
+    fi
+    sleep 2
+  done
+
+  [[ -n "$payload" ]] && printf '%s\n' "$payload" >&2
+  echo "Timed out waiting for status condition: $expr" >&2
+  return 1
+}
+
+api_login() {
+  [[ -n "${DRILL_USERNAME:-}" ]] || {
+    echo "Set DRILL_USERNAME to run authenticated search probes." >&2
+    exit 1
+  }
+  [[ -n "${DRILL_PASSWORD:-}" ]] || {
+    echo "Set DRILL_PASSWORD to run authenticated search probes." >&2
+    exit 1
+  }
+
+  local login_body response
+  login_body="$(python3 -c 'import json, os; print(json.dumps({"username": os.environ["DRILL_USERNAME"], "password": os.environ["DRILL_PASSWORD"]}))')"
+  response="$(curl -fsS \
+    -H 'Content-Type: application/json' \
+    -d "$login_body" \
+    http://localhost/v1/auth/login)"
+
+  TOKEN="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])' <<<"$response")"
+  export TOKEN
+}
+
+api_get_json() {
+  local url="$1"
+  curl -fsS -H "Authorization: Bearer ${TOKEN}" "$url"
+}
+
+api_get_status() {
+  local url="$1"
+  local body_file="$TMP_DIR/response-body.json"
+  HTTP_STATUS="$(curl -sS -o "$body_file" -w '%{http_code}' -H "Authorization: Bearer ${TOKEN}" "$url")"
+  HTTP_BODY="$(cat "$body_file")"
+  export HTTP_STATUS HTTP_BODY
+}
+
+assert_keyword_search_ok() {
+  local payload
+  payload="$(api_get_json 'http://localhost/v1/search?q=history&mode=keyword&page_size=1')"
+  assert_json "$payload" "data['mode'] == 'keyword' and data['degraded'] is False" "keyword search should succeed"
+}
+
+assert_semantic_degraded() {
+  local payload
+  payload="$(api_get_json 'http://localhost/v1/search?q=history&mode=semantic&page_size=1')"
+  assert_json "$payload" "data['mode'] == 'keyword'" "semantic fallback should return keyword mode"
+  assert_json "$payload" "data['degraded'] is True" "semantic fallback should mark degraded=true"
+  assert_json "$payload" "data['requested_mode'] == 'semantic'" "semantic fallback should preserve requested_mode"
+}
+
+assert_semantic_recovered() {
+  local payload
+  payload="$(api_get_json 'http://localhost/v1/search?q=history&mode=semantic&page_size=1')"
+  assert_json "$payload" "data['mode'] == 'semantic' and data['degraded'] is False" "semantic search should recover after embeddings restart"
+}
+
+assert_search_fails() {
+  api_get_status 'http://localhost/v1/search?q=history&mode=keyword&page_size=1'
+  if [[ "$HTTP_STATUS" == "200" ]]; then
+    echo "Expected search failure, but got HTTP 200" >&2
+    printf '%s\n' "$HTTP_BODY" >&2
+    exit 1
+  fi
+}
+
+check_nginx_health() {
+  curl -fsS http://localhost/health >/dev/null
+}
+
+require_cmd docker
+require_cmd python3
+require_cmd curl
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+log "Validating Docker Compose configuration"
+compose config >/dev/null
+
+log "Starting the full stack"
+compose up -d --build
+
+for service in redis rabbitmq zoo1 zoo2 zoo3 solr solr2 solr3 embeddings-server document-lister document-indexer solr-search streamlit-admin redis-commander aithena-ui nginx; do
+  wait_for_state "$service" healthy 360
+done
+wait_for_state solr-init exited0 180
+
+log "Checking healthy baseline via /v1/status/"
+BASELINE_STATUS="$(wait_for_status "data['services']['solr'] == 'up' and data['services']['redis'] == 'up' and data['services']['rabbitmq'] == 'up' and data['services']['embeddings'] == 'up' and data['embeddings_available'] is True and data['solr']['status'] == 'ok' and data['solr']['nodes'] >= 3" 180)"
+assert_json "$BASELINE_STATUS" "data['indexing']['total_discovered'] >= 0" "status endpoint should expose indexing counts"
+check_nginx_health
+api_login
+assert_keyword_search_ok
+assert_semantic_recovered
+
+log "Scenario: primary solr service down"
+compose stop solr
+wait_for_status "data['services']['solr'] == 'down' and data['solr']['status'] == 'error'" 120 >/dev/null
+assert_search_fails
+compose start solr
+wait_for_state solr healthy 240
+compose restart solr-search nginx document-indexer
+wait_for_state solr-search healthy 180
+wait_for_state nginx healthy 180
+wait_for_state document-indexer healthy 180
+wait_for_status "data['services']['solr'] == 'up' and data['solr']['status'] == 'ok' and data['solr']['nodes'] >= 3" 240 >/dev/null
+assert_keyword_search_ok
+
+log "Scenario: redis down"
+compose stop redis
+REDIS_DOWN_STATUS="$(wait_for_status "data['services']['redis'] == 'down'" 90)"
+assert_json "$REDIS_DOWN_STATUS" "data['indexing'] == {'total_discovered': 0, 'indexed': 0, 'failed': 0, 'pending': 0}" "Redis outage should zero indexing counters"
+assert_keyword_search_ok
+compose start redis
+wait_for_state redis healthy 120
+compose restart document-lister document-indexer streamlit-admin redis-commander
+wait_for_state document-lister healthy 180
+wait_for_state document-indexer healthy 180
+wait_for_state streamlit-admin healthy 180
+wait_for_state redis-commander healthy 180
+wait_for_status "data['services']['redis'] == 'up'" 120 >/dev/null
+assert_keyword_search_ok
+
+log "Scenario: rabbitmq down"
+compose stop rabbitmq
+wait_for_status "data['services']['rabbitmq'] == 'down'" 120 >/dev/null
+assert_keyword_search_ok
+compose start rabbitmq
+wait_for_state rabbitmq healthy 180
+compose restart document-lister document-indexer streamlit-admin
+wait_for_state document-lister healthy 180
+wait_for_state document-indexer healthy 180
+wait_for_state streamlit-admin healthy 180
+wait_for_status "data['services']['rabbitmq'] == 'up'" 120 >/dev/null
+assert_keyword_search_ok
+
+log "Scenario: embeddings-server down"
+compose stop embeddings-server
+EMBEDDINGS_DOWN_STATUS="$(wait_for_status "data['services']['embeddings'] == 'down' and data['embeddings_available'] is False" 120)"
+assert_json "$EMBEDDINGS_DOWN_STATUS" "data['services']['solr'] == 'up'" "Embeddings outage should not take Solr down"
+assert_keyword_search_ok
+assert_semantic_degraded
+compose start embeddings-server
+wait_for_state embeddings-server healthy 240
+compose restart document-indexer
+wait_for_state document-indexer healthy 180
+wait_for_status "data['services']['embeddings'] == 'up' and data['embeddings_available'] is True" 180 >/dev/null
+assert_semantic_recovered
+
+log "Scenario: nginx down"
+compose stop nginx
+wait_for_state nginx exited 60
+if curl -fsS http://localhost/health >/dev/null 2>&1; then
+  echo "Expected nginx health check to fail while nginx is stopped" >&2
+  exit 1
+fi
+NGINX_INTERNAL_STATUS="$(status_json)"
+assert_json "$NGINX_INTERNAL_STATUS" "data['services']['solr'] == 'up' and data['services']['redis'] == 'up' and data['services']['rabbitmq'] == 'up' and data['services']['embeddings'] == 'up'" "Core services should stay available internally when nginx is stopped"
+compose start nginx
+wait_for_state nginx healthy 180
+check_nginx_health
+assert_keyword_search_ok
+
+log "Final recovery validation"
+FINAL_STATUS="$(wait_for_status "data['services']['solr'] == 'up' and data['services']['redis'] == 'up' and data['services']['rabbitmq'] == 'up' and data['services']['embeddings'] == 'up' and data['embeddings_available'] is True and data['solr']['status'] == 'ok' and data['solr']['nodes'] >= 3" 240)"
+assert_json "$FINAL_STATUS" "data['solr']['docs_indexed'] >= 0" "Solr status should include an indexed document count after recovery"
+check_nginx_health
+assert_keyword_search_ok
+assert_semantic_recovered
+
+log "Failover drill completed successfully"
+compose ps


### PR DESCRIPTION
Closes #218. Note: drill script requires Docker Compose and should be validated in CI or a Docker-capable environment.