### PR TITLE
Document ecdsa CVE-2024-23342 baseline exception (Dependabot #118)

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -12,6 +12,7 @@ This directory contains security-related documentation for the aithena project.
 ### Audit Guides
 
 - **[OWASP ZAP Manual Audit Guide](owasp-zap-audit-guide.md)** — Step-by-step instructions for conducting dynamic application security testing (DAST) with OWASP ZAP, plus Docker Compose infrastructure-as-code (IaC) security review checklist.
+- **[Baseline Exceptions](baseline-exceptions.md)** — Security findings accepted as baseline with documented risk assessment and mitigation strategies.
 
 ---
 

--- a/docs/security/baseline-exceptions.md
+++ b/docs/security/baseline-exceptions.md
@@ -1,0 +1,48 @@
+# Security Baseline Exceptions
+
+This document tracks security findings that have been accepted as baseline exceptions with documented risk assessment and mitigation.
+
+## CVE-2024-23342 — ecdsa Timing Side-Channel (Dependabot #118)
+
+**Status:** ACCEPTED RISK  
+**Severity:** HIGH (CVSS 7.4)  
+**Affected Service:** solr-search  
+**Dependency Chain:** python-jose[cryptography] → ecdsa 0.19.1  
+
+### Vulnerability Details
+The `ecdsa` Python package (pure Python ECDSA implementation) is vulnerable to CVE-2024-23342, a timing side-channel attack (Minerva attack) that could allow private key recovery through careful measurement of signature generation timing.
+
+### Why No Patch Available
+- **No fixed version exists** — The ecdsa maintainers have explicitly stated that constant-time/side-channel-resistant cryptography is not feasible in pure Python
+- **Project recommendation** — The ecdsa project's security policy advises against using this package for production security-critical operations
+- **Vulnerable range:** >= 0 (all versions, including 0.19.1)
+
+### Mitigation
+1. **Runtime backend selection:** solr-search uses `python-jose[cryptography]`, which prefers the `pyca/cryptography` backend (OpenSSL-backed, side-channel hardened) over the pure Python `ecdsa` package
+2. **ecdsa is fallback only:** The ecdsa package is installed as a fallback dependency but is **not used at runtime** when the cryptography backend is available
+3. **Verification:** The `cryptography` package is explicitly declared in `pyproject.toml` via `python-jose[cryptography]>=3.3.0`
+
+### Risk Assessment
+- **Exploitability:** LOW — Attacker would need to observe many JWT signing operations with precise timing measurements
+- **Impact:** HIGH — If exploited, could lead to JWT secret key compromise
+- **Likelihood:** LOW — Runtime uses cryptography backend, not ecdsa
+- **Residual Risk:** ACCEPTABLE for current use case
+
+### Planned Remediation
+- **Target:** v1.1.0 milestone (P1)
+- **Action:** Replace `python-jose` with `PyJWT` library, which does not require ecdsa as a dependency
+- **Issue:** #TBD (to be created)
+- **Justification:** This is a larger refactor requiring auth code changes and testing; deferring to avoid blocking v1.0.1 security fixes
+
+### References
+- **CVE:** CVE-2024-23342
+- **Dependabot Alert:** #118
+- **GHSA:** GHSA-wj6h-64fc-37mp
+- **NVD:** https://nvd.nist.gov/vuln/detail/CVE-2024-23342
+- **ecdsa Security Policy:** https://github.com/tlsfuzzer/python-ecdsa/blob/master/SECURITY.md
+
+---
+
+**Reviewed by:** Kane (Security Engineer)  
+**Date:** 2026-03-16  
+**Next Review:** v1.1.0 planning (estimated 2026-04)


### PR DESCRIPTION
Closes #290

## Changes

### Baseline Exception Documentation
Created `docs/security/baseline-exceptions.md` documenting CVE-2024-23342 (Dependabot alert #118) as an **accepted risk** with mitigation evidence:

- **Vulnerability:** Minerva timing attack in ecdsa Python package (CVSS 7.4 HIGH)
- **No patch available:** All ecdsa versions >= 0 are vulnerable; maintainers state pure Python cannot be side-channel resistant
- **Dependency chain:** `python-jose[cryptography]` → `ecdsa 0.19.1` (transitive, fallback only)
- **Mitigation:** solr-search uses `pyca/cryptography` backend at runtime (OpenSSL-backed, side-channel hardened), NOT the ecdsa package
- **Risk assessment:** LOW exploitability (requires precise timing measurements of many signing operations), LOW likelihood (cryptography backend used), ACCEPTABLE residual risk
- **Planned remediation:** Replace python-jose with PyJWT in v1.1.0 (P1) to eliminate ecdsa dependency

## Testing

No code changes — documentation only.

## Security Review

- **Reviewed by:** Kane (Security Engineer)
- **Research:** Confirmed no patched ecdsa version exists, python-jose always installs ecdsa as fallback even with cryptography backend
- **Alternative considered:** Replacing python-jose with PyJWT requires auth code refactor (larger scope than P0 dependency fix)
- **Recommendation:** Accept baseline exception, plan v1.1.0 refactor

## References

- **CVE:** CVE-2024-23342
- **Dependabot Alert:** #118
- **GHSA:** GHSA-wj6h-64fc-37mp
- **NVD:** https://nvd.nist.gov/vuln/detail/CVE-2024-23342