### PR TITLE
Fix secrets-outside-env in squad-issue-assign.yml (#94)

### DIFF
--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -118,11 +118,9 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        env:
-          COPILOT_ASSIGN_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
-          github-token: ${{ env.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;


### PR DESCRIPTION
Closes #294

## Changes
- Moved COPILOT_ASSIGN_TOKEN from step-level env: block to inline github-token parameter
- Prevents secret exposure in environment while maintaining functionality

## Testing
- YAML validation passes