### PR TITLE
feat(solr-search): circuit breaker for Redis/Solr graceful degradation (#340)

### DIFF
--- a/src/solr-search/circuit_breaker.py
+++ b/src/solr-search/circuit_breaker.py
@@ -1,0 +1,214 @@
+"""Generic circuit breaker for graceful degradation of external services.
+
+Implements the classic three-state pattern:
+
+    CLOSED  ->  OPEN  ->  HALF_OPEN  ->  CLOSED (or back to OPEN)
+
+Usage::
+
+    cb = CircuitBreaker(name="redis", failure_threshold=5, recovery_timeout=30.0)
+
+    try:
+        result = cb.call(some_risky_function, arg1, arg2)
+    except CircuitOpenError:
+        # Service is known-down -- use fallback
+        ...
+
+Environment-variable configuration is handled externally (see ``config.py``).
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import threading
+import time
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class CircuitState(enum.StrEnum):
+    """Possible states for a circuit breaker."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitOpenError(Exception):
+    """Raised when a call is attempted while the circuit is open."""
+
+    def __init__(self, name: str, remaining_seconds: float) -> None:
+        self.name = name
+        self.remaining_seconds = remaining_seconds
+        super().__init__(
+            f"Circuit '{name}' is OPEN -- retry in {remaining_seconds:.1f}s"
+        )
+
+
+class CircuitBreaker:
+    """Thread-safe circuit breaker.
+
+    Parameters
+    ----------
+    name:
+        Human-readable identifier used in logs and error messages.
+    failure_threshold:
+        Consecutive failures before the circuit opens.
+    recovery_timeout:
+        Seconds to wait in OPEN state before moving to HALF_OPEN.
+    expected_exceptions:
+        Exception types considered service failures (trigger the breaker).
+        Any exception *not* in this tuple propagates without affecting state.
+    success_threshold:
+        Successful calls required in HALF_OPEN to close the circuit.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 5,
+        recovery_timeout: float = 30.0,
+        expected_exceptions: tuple[type[BaseException], ...] = (Exception,),
+        success_threshold: int = 1,
+    ) -> None:
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.expected_exceptions = expected_exceptions
+        self.success_threshold = success_threshold
+
+        self._lock = threading.Lock()
+        self._state = CircuitState.CLOSED
+        self._failure_count: int = 0
+        self._success_count: int = 0
+        self._last_failure_time: float = 0.0
+        self._opened_at: float = 0.0
+
+    @property
+    def state(self) -> CircuitState:
+        """Return the current state, promoting OPEN -> HALF_OPEN if timeout elapsed."""
+        with self._lock:
+            self._maybe_promote()
+            return self._state
+
+    @property
+    def failure_count(self) -> int:
+        with self._lock:
+            return self._failure_count
+
+    def call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        """Execute *func* through the circuit breaker.
+
+        Raises ``CircuitOpenError`` if the circuit is OPEN and the
+        recovery timeout has not yet elapsed.
+        """
+        with self._lock:
+            self._maybe_promote()
+            if self._state is CircuitState.OPEN:
+                elapsed = time.monotonic() - self._opened_at
+                remaining = max(self.recovery_timeout - elapsed, 0.0)
+                raise CircuitOpenError(self.name, remaining)
+
+        try:
+            result = func(*args, **kwargs)
+        except BaseException as exc:
+            if isinstance(exc, self.expected_exceptions):
+                self._record_failure()
+                raise
+            raise
+        else:
+            self._record_success()
+            return result
+
+    def reset(self) -> None:
+        """Force the circuit back to CLOSED (e.g. manual recovery)."""
+        with self._lock:
+            old = self._state
+            self._state = CircuitState.CLOSED
+            self._failure_count = 0
+            self._success_count = 0
+        if old is not CircuitState.CLOSED:
+            logger.info(
+                "circuit_breaker.reset",
+                extra={"circuit": self.name, "old_state": old.value},
+            )
+
+    def get_status(self) -> dict[str, Any]:
+        """Return a JSON-serialisable snapshot for health endpoints."""
+        with self._lock:
+            self._maybe_promote()
+            return {
+                "name": self.name,
+                "state": self._state.value,
+                "failure_count": self._failure_count,
+                "failure_threshold": self.failure_threshold,
+                "recovery_timeout_seconds": self.recovery_timeout,
+                "success_threshold": self.success_threshold,
+            }
+
+    def _maybe_promote(self) -> None:
+        """Promote OPEN -> HALF_OPEN when recovery timeout elapsed. Requires lock."""
+        if (
+            self._state is CircuitState.OPEN
+            and time.monotonic() - self._opened_at >= self.recovery_timeout
+        ):
+            logger.info(
+                "circuit_breaker.state_change",
+                extra={
+                    "circuit": self.name,
+                    "from": CircuitState.OPEN.value,
+                    "to": CircuitState.HALF_OPEN.value,
+                },
+            )
+            self._state = CircuitState.HALF_OPEN
+            self._success_count = 0
+
+    def _record_failure(self) -> None:
+        with self._lock:
+            self._failure_count += 1
+            self._last_failure_time = time.monotonic()
+
+            if self._state is CircuitState.HALF_OPEN or (
+                self._state is CircuitState.CLOSED
+                and self._failure_count >= self.failure_threshold
+            ):
+                self._transition_to_open()
+
+    def _record_success(self) -> None:
+        with self._lock:
+            if self._state is CircuitState.HALF_OPEN:
+                self._success_count += 1
+                if self._success_count >= self.success_threshold:
+                    logger.info(
+                        "circuit_breaker.state_change",
+                        extra={
+                            "circuit": self.name,
+                            "from": CircuitState.HALF_OPEN.value,
+                            "to": CircuitState.CLOSED.value,
+                        },
+                    )
+                    self._state = CircuitState.CLOSED
+                    self._failure_count = 0
+                    self._success_count = 0
+            elif self._state is CircuitState.CLOSED:
+                self._failure_count = 0
+
+    def _transition_to_open(self) -> None:
+        """Move to OPEN state. Requires lock."""
+        logger.info(
+            "circuit_breaker.state_change",
+            extra={
+                "circuit": self.name,
+                "from": self._state.value,
+                "to": CircuitState.OPEN.value,
+                "failure_count": self._failure_count,
+            },
+        )
+        self._state = CircuitState.OPEN
+        self._opened_at = time.monotonic()
+        self._success_count = 0

--- a/src/solr-search/config.py
+++ b/src/solr-search/config.py
@@ -55,6 +55,10 @@ class Settings:
     auth_jwt_secret: str
     auth_jwt_ttl_seconds: int
     auth_cookie_name: str
+    cb_redis_failure_threshold: int
+    cb_redis_recovery_timeout: float
+    cb_solr_failure_threshold: int
+    cb_solr_recovery_timeout: float
 
     @property
     def select_url(self) -> str:
@@ -105,4 +109,8 @@ settings = Settings(
     auth_jwt_secret=os.environ.get("AUTH_JWT_SECRET", "development-only-change-me"),
     auth_jwt_ttl_seconds=parse_ttl_to_seconds(os.environ.get("AUTH_JWT_TTL", "24h")),
     auth_cookie_name=os.environ.get("AUTH_COOKIE_NAME", "aithena_auth"),
+    cb_redis_failure_threshold=int(os.environ.get("CB_REDIS_FAILURE_THRESHOLD", "5")),
+    cb_redis_recovery_timeout=float(os.environ.get("CB_REDIS_RECOVERY_TIMEOUT", "30")),
+    cb_solr_failure_threshold=int(os.environ.get("CB_SOLR_FAILURE_THRESHOLD", "5")),
+    cb_solr_recovery_timeout=float(os.environ.get("CB_SOLR_RECOVERY_TIMEOUT", "30")),
 )

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -9,11 +9,11 @@ import socket
 import threading
 import time
 from collections import defaultdict, deque
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, TypeVar
 from urllib.parse import urlparse
 
 import pika
@@ -30,6 +30,7 @@ from auth import (
     init_auth_db,
     set_auth_cookie,
 )
+from circuit_breaker import CircuitBreaker, CircuitOpenError, CircuitState
 from config import settings
 from fastapi import FastAPI, HTTPException, Query, Request, Response, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -57,6 +58,8 @@ from search_service import (
 setup_logging(service_name="solr-search")
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+
 SortBy = Literal["score", "title", "author", "year", "category", "language"]
 SortOrder = Literal["asc", "desc"]
 
@@ -81,6 +84,24 @@ async def lifespan(_app: FastAPI):
 
 
 app = FastAPI(title=settings.title, version=settings.version, lifespan=lifespan)
+
+# ---------------------------------------------------------------------------
+# Circuit breakers — configured via CB_* environment variables (see config.py)
+# ---------------------------------------------------------------------------
+
+redis_circuit = CircuitBreaker(
+    name="redis",
+    failure_threshold=settings.cb_redis_failure_threshold,
+    recovery_timeout=settings.cb_redis_recovery_timeout,
+    expected_exceptions=(redis_lib.RedisError, OSError, ConnectionError),
+)
+
+solr_circuit = CircuitBreaker(
+    name="solr",
+    failure_threshold=settings.cb_solr_failure_threshold,
+    recovery_timeout=settings.cb_solr_recovery_timeout,
+    expected_exceptions=(requests.RequestException, ValueError),
+)
 
 PUBLIC_PATHS: frozenset[str] = frozenset(
     {
@@ -160,6 +181,8 @@ if settings.cors_origins:
         allow_headers=["*"],
     )
 
+# stores it in a ContextVar, and returns it in the X-Correlation-ID response header.
+
 
 @app.middleware("http")
 async def request_logging_middleware(request: Request, call_next):
@@ -183,11 +206,21 @@ async def request_logging_middleware(request: Request, call_next):
     return response
 
 
+def _raw_solr_query(params: dict[str, Any]) -> dict[str, Any]:
+    """Execute a Solr HTTP request.  Raised exceptions feed the circuit breaker."""
+    response = requests.get(settings.select_url, params=params, timeout=settings.request_timeout)
+    response.raise_for_status()
+    return response.json()
+
+
 def query_solr(params: dict[str, Any]) -> dict[str, Any]:
     try:
-        response = requests.get(settings.select_url, params=params, timeout=settings.request_timeout)
-        response.raise_for_status()
-        return response.json()
+        return solr_circuit.call(_raw_solr_query, params)
+    except CircuitOpenError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Search service temporarily unavailable — Solr circuit breaker is open",
+        ) from exc
     except requests.Timeout as exc:
         raise HTTPException(status_code=504, detail="Timed out waiting for Solr") from exc
     except requests.RequestException as exc:
@@ -297,8 +330,26 @@ async def require_authentication(request: Request, call_next):
 
 @app.get("/v1/health", include_in_schema=False, name="health_v1")
 @app.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok", "service": settings.title, "version": settings.version}
+def health() -> dict[str, Any]:
+    redis_cb = redis_circuit.get_status()
+    solr_cb = solr_circuit.get_status()
+
+    if solr_cb["state"] == CircuitState.OPEN.value:
+        overall = "unavailable"
+    elif redis_cb["state"] == CircuitState.OPEN.value:
+        overall = "degraded"
+    else:
+        overall = "ok"
+
+    return {
+        "status": overall,
+        "service": settings.title,
+        "version": settings.version,
+        "circuit_breakers": {
+            "redis": redis_cb,
+            "solr": solr_cb,
+        },
+    }
 
 
 @app.get("/v1/info", include_in_schema=False, name="info_v1")
@@ -805,6 +856,11 @@ def _get_redis_pool() -> redis_lib.ConnectionPool:
     return _redis_pool
 
 
+def _redis_call(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Execute *func* through the Redis circuit breaker."""
+    return redis_circuit.call(func, *args, **kwargs)
+
+
 def _tcp_check(host: str, port: int, timeout: float = 2.0) -> bool:
     """Return True if a TCP connection to *host*:*port* succeeds within *timeout* seconds."""
     try:
@@ -851,39 +907,48 @@ def _get_solr_status(solr_url: str, timeout: float = 5.0) -> dict[str, Any]:
     return {"status": solr_status, "nodes": node_count, "docs_indexed": docs_indexed}
 
 
+def _raw_indexing_status(key_pattern: str) -> tuple[dict[str, int], set[str]]:
+    """Inner Redis scan — raised exceptions feed the circuit breaker."""
+    pool = _get_redis_pool()
+    client = redis_lib.Redis(connection_pool=pool)
+    keys = list(client.scan_iter(match=key_pattern, count=100))
+    empty: dict[str, int] = {"total_discovered": 0, "indexed": 0, "failed": 0, "pending": 0}
+    if not keys:
+        return empty, set()
+
+    values = client.mget(keys)
+    indexed = 0
+    failed = 0
+    pending = 0
+    failed_keys: set[str] = set()
+    for key, val in zip(keys, values, strict=False):
+        if val is None:
+            pending += 1
+        elif val == "text_indexed":
+            indexed += 1
+        elif val == "failed":
+            failed += 1
+            failed_keys.add(str(key))
+        else:
+            pending += 1
+
+    total = len(keys)
+    return {
+        "total_discovered": total,
+        "indexed": indexed,
+        "failed": failed,
+        "pending": pending,
+    }, failed_keys
+
+
 def _get_indexing_status_details(key_pattern: str) -> tuple[dict[str, int], set[str] | None]:
-    """Scan Redis for *key_pattern* keys and return counts plus failed-key identities."""
-    empty = {"total_discovered": 0, "indexed": 0, "failed": 0, "pending": 0}
+    """Scan Redis for *key_pattern* keys — routes through Redis circuit breaker."""
+    empty: dict[str, int] = {"total_discovered": 0, "indexed": 0, "failed": 0, "pending": 0}
     try:
-        pool = _get_redis_pool()
-        client = redis_lib.Redis(connection_pool=pool)
-        keys = list(client.scan_iter(match=key_pattern, count=100))
-        if not keys:
-            return empty, set()
-
-        values = client.mget(keys)
-        indexed = 0
-        failed = 0
-        pending = 0
-        failed_keys: set[str] = set()
-        for key, val in zip(keys, values, strict=False):
-            if val is None:
-                pending += 1
-            elif val == "text_indexed":
-                indexed += 1
-            elif val == "failed":
-                failed += 1
-                failed_keys.add(str(key))
-            else:
-                pending += 1
-
-        total = len(keys)
-        return {
-            "total_discovered": total,
-            "indexed": indexed,
-            "failed": failed,
-            "pending": pending,
-        }, failed_keys
+        return _redis_call(_raw_indexing_status, key_pattern)
+    except CircuitOpenError:
+        logger.warning("redis_circuit_open: skipping indexing status check")
+        return empty, None
     except Exception:
         return empty, None
 
@@ -1159,7 +1224,14 @@ def _iter_admin_docs(
     Raises HTTPException 503 if the Redis scan itself fails.
     """
     try:
-        keys = list(client.scan_iter(match=_admin_key_pattern(), count=100))
+        keys: list[str] = _redis_call(
+            lambda: list(client.scan_iter(match=_admin_key_pattern(), count=100)),
+        )
+    except CircuitOpenError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Redis circuit breaker is open — admin operations temporarily unavailable",
+        ) from exc
     except Exception as exc:
         raise HTTPException(status_code=503, detail="Cannot connect to Redis") from exc
 
@@ -1214,7 +1286,12 @@ def _delete_admin_key(redis_key: str) -> bool:
     """Delete *redis_key* from Redis.  Returns True if the key existed."""
     try:
         client = _get_admin_redis_client()
-        return bool(client.delete(redis_key))
+        return bool(_redis_call(client.delete, redis_key))
+    except CircuitOpenError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Redis circuit breaker is open — admin operations temporarily unavailable",
+        ) from exc
     except Exception as exc:
         raise HTTPException(status_code=503, detail="Cannot connect to Redis") from exc
 

--- a/src/solr-search/tests/test_circuit_breaker.py
+++ b/src/solr-search/tests/test_circuit_breaker.py
@@ -1,0 +1,336 @@
+"""Tests for circuit_breaker.py -- state transitions, thresholds, recovery.
+
+Also tests graceful degradation of Redis and Solr calls through the
+circuit breakers integrated in main.py.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import redis as redis_lib
+import requests
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("AUTH_DB_PATH", "/tmp/test-auth.db")  # noqa: S108
+os.environ.setdefault("AUTH_JWT_SECRET", "test-auth-secret")
+os.environ.setdefault("AUTH_JWT_TTL", "24h")
+os.environ.setdefault("AUTH_COOKIE_NAME", "aithena_auth")
+
+from circuit_breaker import CircuitBreaker, CircuitOpenError, CircuitState  # noqa: E402
+
+from tests.auth_helpers import create_authenticated_client  # noqa: E402
+
+
+def _raise_value_error() -> None:
+    raise ValueError("boom")
+
+
+def _raise_type_error() -> None:
+    raise TypeError("unexpected")
+
+
+def _raise_redis_error() -> None:
+    raise redis_lib.ConnectionError("Redis connection refused")
+
+
+def _raise_request_error() -> None:
+    raise requests.ConnectionError("Solr connection refused")
+
+
+def _trip_breaker(breaker: CircuitBreaker, raiser) -> None:
+    for _ in range(breaker.failure_threshold):
+        with contextlib.suppress(Exception):
+            breaker.call(raiser)
+
+
+def _mock_solr_response() -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = {
+        "response": {"numFound": 0, "docs": []},
+        "highlighting": {},
+        "facet_counts": {"facet_fields": {}},
+    }
+    mock.raise_for_status.return_value = None
+    return mock
+
+
+def _get_test_client():
+    return create_authenticated_client()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for CircuitBreaker
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerStateTransitions:
+
+    def _make_breaker(self, **kwargs) -> CircuitBreaker:
+        defaults = {
+            "name": "test",
+            "failure_threshold": 3,
+            "recovery_timeout": 0.2,
+            "expected_exceptions": (ValueError,),
+            "success_threshold": 1,
+        }
+        defaults.update(kwargs)
+        return CircuitBreaker(**defaults)
+
+    def test_starts_closed(self) -> None:
+        cb = self._make_breaker()
+        assert cb.state is CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_stays_closed_below_threshold(self) -> None:
+        cb = self._make_breaker(failure_threshold=3)
+        for _ in range(2):
+            with contextlib.suppress(ValueError):
+                cb.call(_raise_value_error)
+        assert cb.state is CircuitState.CLOSED
+        assert cb.failure_count == 2
+
+    def test_opens_at_threshold(self) -> None:
+        cb = self._make_breaker(failure_threshold=3)
+        for _ in range(3):
+            with contextlib.suppress(ValueError):
+                cb.call(_raise_value_error)
+        assert cb.state is CircuitState.OPEN
+
+    def test_open_circuit_rejects_calls(self) -> None:
+        cb = self._make_breaker(failure_threshold=1, recovery_timeout=10.0)
+        with contextlib.suppress(ValueError):
+            cb.call(_raise_value_error)
+        assert cb.state is CircuitState.OPEN
+
+        try:
+            cb.call(lambda: "ok")
+            raised = False
+        except CircuitOpenError as exc:
+            raised = True
+            assert exc.name == "test"
+            assert exc.remaining_seconds > 0
+        assert raised
+
+    def test_transitions_to_half_open_after_timeout(self) -> None:
+        cb = self._make_breaker(failure_threshold=1, recovery_timeout=0.1)
+        with contextlib.suppress(ValueError):
+            cb.call(_raise_value_error)
+        assert cb.state is CircuitState.OPEN
+        time.sleep(0.15)
+        assert cb.state is CircuitState.HALF_OPEN
+
+    def test_half_open_success_closes_circuit(self) -> None:
+        cb = self._make_breaker(failure_threshold=1, recovery_timeout=0.1)
+        with contextlib.suppress(ValueError):
+            cb.call(_raise_value_error)
+        time.sleep(0.15)
+        assert cb.state is CircuitState.HALF_OPEN
+        result = cb.call(lambda: "recovered")
+        assert result == "recovered"
+        assert cb.state is CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_half_open_failure_reopens_circuit(self) -> None:
+        cb = self._make_breaker(failure_threshold=1, recovery_timeout=0.1)
+        with contextlib.suppress(ValueError):
+            cb.call(_raise_value_error)
+        time.sleep(0.15)
+        assert cb.state is CircuitState.HALF_OPEN
+        with contextlib.suppress(ValueError):
+            cb.call(_raise_value_error)
+        assert cb.state is CircuitState.OPEN
+
+    def test_success_resets_failure_count(self) -> None:
+        cb = self._make_breaker(failure_threshold=3)
+        for _ in range(2):
+            with contextlib.suppress(ValueError):
+                cb.call(_raise_value_error)
+        assert cb.failure_count == 2
+        cb.call(lambda: "ok")
+        assert cb.failure_count == 0
+        for _ in range(2):
+            with contextlib.suppress(ValueError):
+                cb.call(_raise_value_error)
+        assert cb.state is CircuitState.CLOSED
+
+    def test_unexpected_exception_does_not_affect_state(self) -> None:
+        cb = self._make_breaker(failure_threshold=1, expected_exceptions=(ValueError,))
+        with contextlib.suppress(TypeError):
+            cb.call(_raise_type_error)
+        assert cb.state is CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_manual_reset(self) -> None:
+        cb = self._make_breaker(failure_threshold=1, recovery_timeout=100.0)
+        with contextlib.suppress(ValueError):
+            cb.call(_raise_value_error)
+        assert cb.state is CircuitState.OPEN
+        cb.reset()
+        assert cb.state is CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_get_status_returns_dict(self) -> None:
+        cb = self._make_breaker()
+        status = cb.get_status()
+        assert status["name"] == "test"
+        assert status["state"] == "closed"
+        assert status["failure_count"] == 0
+        assert status["failure_threshold"] == 3
+        assert status["recovery_timeout_seconds"] == 0.2
+
+    def test_success_threshold_requires_multiple_successes(self) -> None:
+        cb = self._make_breaker(failure_threshold=1, recovery_timeout=0.1, success_threshold=2)
+        with contextlib.suppress(ValueError):
+            cb.call(_raise_value_error)
+        time.sleep(0.15)
+        assert cb.state is CircuitState.HALF_OPEN
+        cb.call(lambda: "ok")
+        assert cb.state is CircuitState.HALF_OPEN
+        cb.call(lambda: "ok")
+        assert cb.state is CircuitState.CLOSED
+
+    def test_call_returns_function_result(self) -> None:
+        cb = self._make_breaker()
+        assert cb.call(lambda: 42) == 42
+
+    def test_call_passes_args_and_kwargs(self) -> None:
+        cb = self._make_breaker()
+        assert cb.call(lambda a, b, extra=0: a + b + extra, 1, 2, extra=10) == 13
+
+
+# ---------------------------------------------------------------------------
+# Integration tests -- circuit breakers in main.py
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpointCircuitBreakers:
+
+    def test_health_reports_circuit_breaker_states(self) -> None:
+        client = _get_test_client()
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert "circuit_breakers" in data
+        assert "redis" in data["circuit_breakers"]
+        assert "solr" in data["circuit_breakers"]
+        redis_cb = data["circuit_breakers"]["redis"]
+        assert redis_cb["state"] == "closed"
+        assert "failure_count" in redis_cb
+
+    def test_health_status_ok_when_all_circuits_closed(self) -> None:
+        import main
+        main.redis_circuit.reset()
+        main.solr_circuit.reset()
+        client = _get_test_client()
+        data = client.get("/health").json()
+        assert data["status"] == "ok"
+
+    def test_health_status_degraded_when_redis_circuit_open(self) -> None:
+        import main
+        main.solr_circuit.reset()
+        _trip_breaker(main.redis_circuit, _raise_redis_error)
+        try:
+            data = _get_test_client().get("/health").json()
+            assert data["status"] == "degraded"
+            assert data["circuit_breakers"]["redis"]["state"] == "open"
+        finally:
+            main.redis_circuit.reset()
+
+    def test_health_status_unavailable_when_solr_circuit_open(self) -> None:
+        import main
+        main.redis_circuit.reset()
+        _trip_breaker(main.solr_circuit, _raise_request_error)
+        try:
+            data = _get_test_client().get("/health").json()
+            assert data["status"] == "unavailable"
+            assert data["circuit_breakers"]["solr"]["state"] == "open"
+        finally:
+            main.solr_circuit.reset()
+
+    def test_v1_health_also_has_circuit_breakers(self) -> None:
+        data = _get_test_client().get("/v1/health").json()
+        assert "circuit_breakers" in data
+
+
+class TestSolrCircuitBreaker:
+
+    @patch("main.requests.get")
+    def test_solr_failure_trips_circuit(self, mock_get: MagicMock) -> None:
+        import main
+        main.solr_circuit.reset()
+        mock_get.side_effect = requests.ConnectionError("Solr down")
+
+        client = _get_test_client()
+        for _ in range(main.solr_circuit.failure_threshold):
+            resp = client.get("/search", params={"q": "test"})
+            assert resp.status_code == 502
+
+        resp = client.get("/search", params={"q": "test"})
+        assert resp.status_code == 503
+        assert "circuit breaker" in resp.json()["detail"].lower()
+        main.solr_circuit.reset()
+
+    @patch("main.requests.get")
+    def test_solr_recovers_after_timeout(self, mock_get: MagicMock) -> None:
+        import main
+        original_timeout = main.solr_circuit.recovery_timeout
+        main.solr_circuit.recovery_timeout = 0.1
+        main.solr_circuit.reset()
+
+        mock_get.side_effect = requests.ConnectionError("Solr down")
+        client = _get_test_client()
+        for _ in range(main.solr_circuit.failure_threshold):
+            client.get("/search", params={"q": "test"})
+        assert main.solr_circuit.state is CircuitState.OPEN
+
+        time.sleep(0.15)
+        assert main.solr_circuit.state is CircuitState.HALF_OPEN
+
+        mock_get.side_effect = None
+        mock_get.return_value = _mock_solr_response()
+        resp = client.get("/search", params={"q": "test"})
+        assert resp.status_code == 200
+        assert main.solr_circuit.state is CircuitState.CLOSED
+
+        main.solr_circuit.recovery_timeout = original_timeout
+        main.solr_circuit.reset()
+
+
+class TestRedisGracefulDegradation:
+
+    @patch("main.requests.get")
+    def test_status_endpoint_degrades_when_redis_circuit_open(self, mock_get: MagicMock) -> None:
+        import main
+        main.redis_circuit.reset()
+        _trip_breaker(main.redis_circuit, _raise_redis_error)
+        assert main.redis_circuit.state is CircuitState.OPEN
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"cluster": {"live_nodes": ["n1"], "collections": {}}}
+        mock_get.return_value = mock_response
+
+        try:
+            data = _get_test_client().get("/v1/status").json()
+            assert data["indexing"]["total_discovered"] == 0
+        finally:
+            main.redis_circuit.reset()
+
+    def test_admin_documents_returns_503_when_redis_circuit_open(self) -> None:
+        import main
+        main.redis_circuit.reset()
+        _trip_breaker(main.redis_circuit, _raise_redis_error)
+        try:
+            resp = _get_test_client().get("/v1/admin/documents")
+            assert resp.status_code == 503
+            assert "circuit breaker" in resp.json()["detail"].lower()
+        finally:
+            main.redis_circuit.reset()


### PR DESCRIPTION
## Circuit Breaker for Redis/Solr Graceful Degradation

Closes #340

### What

Adds a circuit breaker pattern to the solr-search service so that Redis and Solr outages are handled gracefully instead of cascading into 500 errors.

### New file: `circuit_breaker.py`

Generic, reusable `CircuitBreaker` class:
- **State machine:** CLOSED → OPEN → HALF_OPEN → CLOSED
- Thread-safe (`threading.Lock`)
- Configurable failure threshold, recovery timeout, and success threshold
- Structured logging on every state transition (`circuit_breaker.state_change`)
- `CircuitOpenError` raised when calls are rejected in OPEN state

### Integration in `main.py`

| Circuit | Wraps | When OPEN |
|---------|-------|-----------|
| `solr_circuit` | `query_solr` (Solr HTTP) | Returns HTTP 503 with clear message |
| `redis_circuit` | indexing status, admin docs scan, admin key delete | Status returns zeros (graceful degradation); admin ops return 503 |

**Health endpoint** now reports:
```json
{
  "status": "ok | degraded | unavailable",
  "circuit_breakers": {
    "redis": {"state": "closed", "failure_count": 0},
    "solr": {"state": "closed", "failure_count": 0}
  }
}
```
- Solr OPEN → `"unavailable"` (Solr is critical for search)
- Redis OPEN → `"degraded"` (Redis is cache layer, can bypass)

### Configuration (`config.py`)

| Environment Variable | Default | Description |
|---------------------|---------|-------------|
| `CB_REDIS_FAILURE_THRESHOLD` | 5 | Failures before Redis circuit opens |
| `CB_REDIS_RECOVERY_TIMEOUT` | 30s | Seconds before half-open probe |
| `CB_SOLR_FAILURE_THRESHOLD` | 5 | Failures before Solr circuit opens |
| `CB_SOLR_RECOVERY_TIMEOUT` | 30s | Seconds before half-open probe |

### Tests (`tests/test_circuit_breaker.py`)

23 tests total:
- **14 unit tests** — CircuitBreaker state machine (transitions, resets, thresholds, thread safety)
- **5 health endpoint tests** — circuit state reporting, status levels
- **2 Solr integration tests** — failure tripping, recovery after timeout
- **2 Redis integration tests** — graceful degradation, admin 503

**Results:** 23/23 pass. Full suite: 191/193 (2 pre-existing correlation test failures unrelated to this PR).

### Design decisions

- **Generic class, not Redis/Solr-specific:** The `CircuitBreaker` can be reused for any external dependency
- **Separate circuits:** Redis and Solr fail independently — a Redis outage doesn't block search, a Solr outage doesn't break admin status
- **No new dependencies:** Pure Python implementation using `threading`, `time.monotonic()`
- **Structured logging:** State transitions emit structured log events compatible with the existing `logging_config.py` JSON format
