### PR TITLE
docs(squad): Ripley review documentation for PR #416

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -623,3 +623,25 @@ The React AdminPage and Streamlit admin **are functionally redundant**. Both cal
 
 **Key principle reinforced:** `pull_request_target` is safe when you (1) explicitly gate on trusted actors, (2) checkout explicit SHAs, and (3) disable credential persistence. The workflow demonstrates best practices.
 
+
+### PR #416 Review — Stats Book Count Fix (2026-03-17)
+
+**Context:** Reviewed and merged jmservera's PR #416 implementing Phase 1 quick win for issue #404 (stats showing chunk count instead of book count).
+
+**Architectural Decision:**
+- ✅ Approved Solr grouping approach (`group=true&group.field=parent_id_s&group.limit=0`)
+- Uses existing `parent_id_s` field already populated by document-indexer
+- Extracts `ngroups` from grouped response instead of `numFound` from flat response
+- No schema changes or reindexing required
+
+**Quality Assessment:**
+- All 193 tests pass (7 stats tests + 4 unit tests updated)
+- Integration tests verify correct Solr parameters sent
+- Clean code with descriptive Phase 1 context in comments
+- Parker documented learning in their history
+
+**Learning:** Solr grouping with `ngroups` is the ideal pattern for counting distinct parent entities in parent/child document relationships. This Phase 1 quick win delivers accurate user-facing stats (3 books vs 127 chunks) without the complexity of full parent/child hierarchy (which would be Phase 2 if needed for search result deduplication).
+
+**Decision Rationale:** The minimal-change approach is architecturally sound. It solves the immediate problem (stats accuracy) while keeping the door open for future enhancements (full parent/child search deduplication) if needed.
+
+**Outcome:** PR #416 merged to `dev`, closes #404.

--- a/.squad/decisions/inbox/ripley-pr416-review.md
+++ b/.squad/decisions/inbox/ripley-pr416-review.md
@@ -1,0 +1,58 @@
+# Decision: Stats Book Count Architecture (PR #416)
+
+**Date:** 2026-03-17  
+**Decider:** Ripley (Lead)  
+**Context:** Issue #404 — Stats showing chunk count (127) instead of book count (3)
+
+## Decision
+
+Approved Phase 1 quick win using **Solr grouping** to count distinct books instead of implementing full parent/child document hierarchy.
+
+## Implementation
+
+**Approach:**
+- Use `group=true&group.field=parent_id_s&group.limit=0` in stats query
+- Extract `ngroups` from grouped response (distinct parent count)
+- Replace previous `numFound` extraction (total document count)
+
+**Why This Works:**
+- The `parent_id_s` field already exists in schema and is populated by document-indexer
+- No schema changes required
+- No reindexing required
+- Solr grouping is a standard, performant feature for this exact use case
+
+## Rationale
+
+**Trade-offs Considered:**
+1. **Phase 1 (chosen):** Grouping for stats only
+   - ✅ Minimal change (48 additions, 12 deletions)
+   - ✅ Solves user-facing problem immediately
+   - ✅ Zero migration/reindexing cost
+   - ⚠️ Doesn't deduplicate search results (not a requirement yet)
+
+2. **Full parent/child hierarchy:** Separate parent + child documents
+   - ❌ Requires schema redesign
+   - ❌ Requires reindexing all documents
+   - ❌ Adds complexity to search logic
+   - ✅ Would enable search result deduplication (if needed later)
+
+**Decision:** Phase 1 is architecturally sound. Full hierarchy can be Phase 2 if search deduplication becomes a requirement.
+
+## Pattern for Future Use
+
+**When to use Solr grouping for stats:**
+- Counting distinct parent entities in a parent/child relationship
+- The `ngroups` field gives exact unique parent count
+- More efficient than nested documents when you only need counts, not result deduplication
+
+## Team Impact
+
+- **Parker/Ash:** Pattern established for counting distinct entities in Solr
+- **Future stats work:** Use grouping when counting distinct books, authors, categories, etc.
+- **Search deduplication:** If needed later, implement full parent/child hierarchy as Phase 2
+
+## Verification
+
+- ✅ All 193 tests pass (7 stats tests updated to grouped response format)
+- ✅ Integration tests verify correct Solr parameters
+- ✅ PR #416 merged to `dev`, closes #404


### PR DESCRIPTION
## Summary

Documents Ripley's architectural review of PR #416 (stats book count fix).

## Changes

- **Ripley history:** Added PR #416 review learning with architectural decision rationale
- **Decision document:** Created `ripley-pr416-review.md` documenting:
  - Phase 1 Solr grouping approach (approved)
  - Trade-offs vs full parent/child hierarchy
  - Pattern for future stats work (use `ngroups` for distinct parent counts)
  - Team impact and verification status

## Context

PR #416 was reviewed, approved, and merged by Ripley. This PR captures the architectural decision and learning for the team's reference.

Related: #404 (closed by PR #416)