### PR TITLE
ci: skip workflows for non-build path changes (.squad, docs, etc.)

### DIFF
--- a/.github/workflows/security-bandit.yml
+++ b/.github/workflows/security-bandit.yml
@@ -5,16 +5,10 @@ on:
     branches:
       - dev
       - main
-    paths:
-      - '**/*.py'
-      - '.bandit'
   pull_request:
     branches:
       - dev
       - main
-    paths:
-      - '**/*.py'
-      - '.bandit'
 
 # Required for SARIF upload to Code Scanning
 permissions:

--- a/.github/workflows/security-checkov.yml
+++ b/.github/workflows/security-checkov.yml
@@ -5,20 +5,10 @@ on:
     branches:
       - dev
       - main
-    paths:
-      - '**/Dockerfile'
-      - 'docker-compose*.yml'
-      - '.github/workflows/**'
-      - '.checkov.yml'
   pull_request:
     branches:
       - dev
       - main
-    paths:
-      - '**/Dockerfile'
-      - 'docker-compose*.yml'
-      - '.github/workflows/**'
-      - '.checkov.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/security-zizmor.yml
+++ b/.github/workflows/security-zizmor.yml
@@ -5,16 +5,10 @@ on:
     branches:
       - dev
       - main
-    paths:
-      - '.github/workflows/**'
-      - '.zizmor.yml'
   pull_request:
     branches:
       - dev
       - main
-    paths:
-      - '.github/workflows/**'
-      - '.zizmor.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Optimizes CI/CD workflows to skip unnecessary runs when only non-build files change (e.g., `.squad/` config, `docs/`, markdown files).

## Problem

Every PR — even those touching only `.squad/` documentation or `docs/` — triggers the full CI pipeline (unit tests, integration tests, security scans, version checks), wasting CI minutes and adding wait time.

## Solution

### Required-check workflows (gate pattern)
These workflows must always report a status since they are PR merge gates:

- **ci.yml** — Adds a `changes` detection job using the GitHub API. Test jobs (`document-indexer-tests`, `solr-search-tests`, `python-lint`) are conditional. The `All tests passed` gate always runs and reports ✅ for both "tests passed" and "tests skipped" scenarios.
- **integration-test.yml** — Same pattern. The actual test job is renamed to `run-integration-tests`. A new `integration-gate` job with name `Docker Compose integration + E2E` always runs as the required status check. `workflow_dispatch` always runs full tests.

### Non-required workflows (simple paths filter)
These just skip entirely when irrelevant files change:

| Workflow | Triggers on |
|----------|------------|
| security-bandit.yml | `src/**/*.py`, `.bandit` |
| security-checkov.yml | `**/Dockerfile`, `docker-compose*.yml`, `.github/workflows/**`, `.checkov.yml` |
| security-zizmor.yml | `.github/workflows/**`, `.zizmor.yml` |
| version-check.yml | `VERSION`, `**/Dockerfile` |

### Non-build paths (skipped)
```
.squad/**
.github/ISSUE_TEMPLATE/**
.github/agents/**
docs/**
*.md (root-level)
LICENSE, .gitattributes, .gitignore
```

### No changes needed
- `lint-frontend.yml` — already path-filtered to `src/aithena-ui/**`
- `sync-squad-labels.yml` — already path-filtered to `.squad/team.md`
- `release.yml` — tag-triggered only
- `release-docs.yml` — manual/workflow_run only
- `dependabot-automerge.yml` — actor-filtered to `dependabot[bot]`
- Squad workflows — event-triggered (issues/labels), not code-triggered

## ⚠️ Note on integration-test.yml

The required check name `Docker Compose integration + E2E` is now on the **gate job** (`integration-gate`), not the actual test job. If your branch ruleset references the old job key, you may need to update it to match the new gate job name (the display name is unchanged).