### PR TITLE
chore: update Python version from 3.11 to 3.12 in dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install uv (for uv-managed services)
         if: matrix.service != 'embeddings-server'


### PR DESCRIPTION
change to python 3.12 to make tests pass