### PR TITLE
ci: move integration tests to release gate + nightly cron (#458)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - dev
+      - main
+  schedule:
+    - cron: "0 3 * * 1-5"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Move integration tests from the dev PR gate to the release gate only. This eliminates the ~60-minute Docker Compose E2E suite from every dev PR, while keeping it as a safety net for releases and nightly runs.

### Changes to `integration-test.yml` triggers

| Trigger | Before | After |
|---------|--------|-------|
| `pull_request` | `dev` | `main` |
| `schedule` | _(none)_ | Weeknights 3 AM UTC (Mon–Fri) |
| `workflow_dispatch` | ✅ | ✅ (unchanged) |

### Why this is safe

Dev PRs are now protected by the expanded unit test suite across 6 services (575+ tests) which runs in ~5 minutes instead of ~60 minutes. The integration + E2E suite still runs:
- On every PR targeting **main** (release gate)
- **Nightly** on weeknights (catches regressions early)
- **On demand** via workflow_dispatch

### ⚠️ Post-merge action required (Juanma)

After merging this PR:
1. **Remove** "Docker Compose integration + E2E" from **dev** branch required status checks
2. **Keep** (or add) "Docker Compose integration + E2E" as required on **main** branch protection

Without step 1, dev PRs will hang waiting for a check that no longer triggers.

Closes #458