### PR TITLE
fix: add group.ngroups=true to stats query (#468)

### DIFF
--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -895,6 +895,7 @@ def stats() -> dict[str, Any]:
         "wt": "json",
         "group": "true",
         "group.field": "parent_id_s",
+        "group.ngroups": "true",
         "group.limit": 0,
         "stats": "true",
         "stats.field": "page_count_i",

--- a/src/solr-search/search_service.py
+++ b/src/solr-search/search_service.py
@@ -371,7 +371,7 @@ def parse_stats_response(payload: dict[str, Any]) -> dict[str, Any]:
     """
     grouped = payload.get("grouped", {})
     parent_id_groups = grouped.get("parent_id_s", {})
-    total_books: int = parent_id_groups.get("ngroups", 0)
+    total_books: int = parent_id_groups.get("ngroups", 0) or parent_id_groups.get("matches", 0)
 
     facet_fields: dict[str, list[Any]] = payload.get("facet_counts", {}).get("facet_fields", {})
 


### PR DESCRIPTION
Fixes #468

## Problem

The `/v1/stats` endpoint always reported `total_books=0` because:
- The Solr grouped query was missing `group.ngroups=true`, so the `ngroups` field was never returned in the response.
- `parse_stats_response()` read `ngroups` which was absent, defaulting to 0.

## Fix

1. **`main.py`** — Added `"group.ngroups": "true"` to the stats query params so Solr returns the group count.
2. **`search_service.py`** — Added a fallback: if `ngroups` is missing or 0, use `matches` instead.

## Testing

All 193 existing tests pass. No new tests needed — existing test mocks already include `ngroups` in their payloads.

---
Working as Parker (Backend Dev)