### PR TITLE
Frontend code quality improvements

### DIFF
--- a/src/aithena-ui/src/hooks/library.ts
+++ b/src/aithena-ui/src/hooks/library.ts
@@ -38,10 +38,10 @@ function parseLibraryParams(params: URLSearchParams): LibraryState {
   const sort = params.get('sort') || DEFAULTS.sort;
 
   const filters: SearchFilters = {};
-  const author = params.get('fq_author');
-  const category = params.get('fq_category');
-  const language = params.get('fq_language');
-  const year = params.get('fq_year');
+  const author = params.get('filter_author');
+  const category = params.get('filter_category');
+  const language = params.get('filter_language');
+  const year = params.get('filter_year');
 
   if (author) filters.author = author;
   if (category) filters.category = category;
@@ -66,10 +66,10 @@ function serializeLibraryState(state: LibraryState): URLSearchParams {
     params.set('sort', state.sort);
   }
 
-  if (state.filters.author) params.set('fq_author', state.filters.author);
-  if (state.filters.category) params.set('fq_category', state.filters.category);
-  if (state.filters.language) params.set('fq_language', state.filters.language);
-  if (state.filters.year) params.set('fq_year', state.filters.year);
+  if (state.filters.author) params.set('filter_author', state.filters.author);
+  if (state.filters.category) params.set('filter_category', state.filters.category);
+  if (state.filters.language) params.set('filter_language', state.filters.language);
+  if (state.filters.year) params.set('filter_year', state.filters.year);
 
   return params;
 }

--- a/src/aithena-ui/src/pages/LibraryPage.tsx
+++ b/src/aithena-ui/src/pages/LibraryPage.tsx
@@ -34,7 +34,7 @@ function LibraryPage() {
   } = useLibrary();
 
   const [selectedBook, setSelectedBook] = useState<BookResult | null>(null);
-  const resultsRegionRef = useRef<HTMLElement>(null);
+  const resultsRegionRef = useRef<HTMLElement | null>(null);
   const lastLoadingStateRef = useRef(false);
   const lastPdfTriggerRef = useRef<HTMLElement | null>(null);
   const resultsRegionId = useId();


### PR DESCRIPTION
Closes #469

Working as Dallas (⚛️ React/TypeScript UI)

- Fixed `useRef<HTMLElement>(null)` → `useRef<HTMLElement | null>(null)` for strictNullChecks compatibility
- Standardized URL params from `fq_*` to `filter_*` convention in library hook (matching search page)
- API params sent to backend remain `fq_*` as expected by Solr
- All 189 tests pass, lint/format/build clean