### PR TITLE
i18n: Add Vitest tests for locale switching and translation completeness

### DIFF
--- a/src/aithena-ui/src/__tests__/i18n.test.tsx
+++ b/src/aithena-ui/src/__tests__/i18n.test.tsx
@@ -24,7 +24,11 @@ const LOCALE_STORAGE_KEY = 'aithena-locale';
 
 /** Simple component that displays a translated message so we can assert text. */
 function TranslatedLabel() {
-  return <span data-testid="label"><FormattedMessage id="app.subtitle" /></span>;
+  return (
+    <span data-testid="label">
+      <FormattedMessage id="app.subtitle" />
+    </span>
+  );
 }
 
 /** Exposes the current locale from the I18n context for assertions. */
@@ -70,12 +74,15 @@ describe('Translation completeness', () => {
 // ---------------------------------------------------------------------------
 
 describe('No empty translations', () => {
-  it.each(Object.entries(LOCALE_FILES))('%s locale has no empty string values', (_locale, messages) => {
-    const emptyKeys = Object.entries(messages)
-      .filter(([, value]) => value.trim() === '')
-      .map(([key]) => key);
-    expect(emptyKeys).toEqual([]);
-  });
+  it.each(Object.entries(LOCALE_FILES))(
+    '%s locale has no empty string values',
+    (_locale, messages) => {
+      const emptyKeys = Object.entries(messages)
+        .filter(([, value]) => value.trim() === '')
+        .map(([key]) => key);
+      expect(emptyKeys).toEqual([]);
+    }
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #380

Working as Lambert (🧪 Tester)

## Tests added (23 total)

**Translation completeness (6 tests)**
- Every non-English locale has the same keys as `en.json`
- No locale has extra keys beyond `en.json`

**No empty translations (4 tests)**
- Every locale file has no empty string values

**Locale switching via I18nContext (3 tests)**
- Defaults to English
- Switches from `en` to `es` and updates displayed text
- Switches to every supported locale (`ca`, `fr`)

**LanguageSwitcher component (3 tests)**
- Renders a select with all 4 language options
- Updates locale on selection change
- Label text updates to match current locale

**localStorage persistence (3 tests)**
- Persists locale to `localStorage` when changed
- Restores locale from `localStorage` on mount
- Ignores invalid values and falls back to English

**Browser locale detection (4 tests)**
- Exact match (e.g. `fr`)
- Prefix match (e.g. `es-MX` → `es`)
- Falls back to English for unsupported locales
- `localStorage` preference takes priority over browser locale

All 23 tests pass. No production code was modified.