### PR TITLE
fix: standardize localStorage key to aithena.locale with migration

### DIFF
--- a/src/aithena-ui/src/__tests__/i18n.test.tsx
+++ b/src/aithena-ui/src/__tests__/i18n.test.tsx
@@ -20,7 +20,8 @@ const LOCALE_FILES: Record<string, Record<string, string>> = {
   fr: frMessages,
 };
 
-const LOCALE_STORAGE_KEY = 'aithena-locale';
+const LOCALE_STORAGE_KEY = 'aithena.locale';
+const LEGACY_LOCALE_STORAGE_KEY = 'aithena-locale';
 
 /** Simple component that displays a translated message so we can assert text. */
 function TranslatedLabel() {
@@ -275,6 +276,20 @@ describe('localStorage persistence', () => {
     );
 
     expect(screen.getByTestId('current-locale')).toHaveTextContent('en');
+  });
+
+  it('migrates from legacy key (aithena-locale) to new key (aithena.locale)', () => {
+    localStorage.setItem(LEGACY_LOCALE_STORAGE_KEY, 'es');
+
+    render(
+      <I18nProvider>
+        <LocaleDisplay />
+      </I18nProvider>
+    );
+
+    expect(screen.getByTestId('current-locale')).toHaveTextContent('es');
+    expect(localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('es');
+    expect(localStorage.getItem(LEGACY_LOCALE_STORAGE_KEY)).toBeNull();
   });
 });
 

--- a/src/aithena-ui/src/contexts/I18nContext.tsx
+++ b/src/aithena-ui/src/contexts/I18nContext.tsx
@@ -16,7 +16,8 @@ const MESSAGES: Record<Locale, Record<string, string>> = {
 
 const SUPPORTED_LOCALES: Locale[] = ['en', 'es', 'ca', 'fr'];
 const DEFAULT_LOCALE: Locale = 'en';
-const LOCALE_STORAGE_KEY = 'aithena-locale';
+const LOCALE_STORAGE_KEY = 'aithena.locale';
+const LEGACY_LOCALE_STORAGE_KEY = 'aithena-locale';
 
 interface I18nContextValue {
   locale: Locale;
@@ -45,6 +46,14 @@ function detectLocale(): Locale {
   const storedLocale = localStorage.getItem(LOCALE_STORAGE_KEY);
   if (storedLocale && SUPPORTED_LOCALES.includes(storedLocale as Locale)) {
     return storedLocale as Locale;
+  }
+
+  // Migrate from legacy key (aithena-locale → aithena.locale)
+  const legacyLocale = localStorage.getItem(LEGACY_LOCALE_STORAGE_KEY);
+  if (legacyLocale && SUPPORTED_LOCALES.includes(legacyLocale as Locale)) {
+    localStorage.setItem(LOCALE_STORAGE_KEY, legacyLocale);
+    localStorage.removeItem(LEGACY_LOCALE_STORAGE_KEY);
+    return legacyLocale as Locale;
   }
 
   // Check browser locale


### PR DESCRIPTION
Closes #472

## Changes

Renames the localStorage key from `aithena-locale` to `aithena.locale` to follow the dot-namespaced convention used throughout the project.

### Migration logic
- On first access, `detectLocale()` checks for the new key (`aithena.locale`)
- If not found, checks for the legacy key (`aithena-locale`)
- If legacy key exists with a valid locale, migrates it to the new key and removes the legacy entry
- Existing users keep their language preference seamlessly

### Files changed
- `src/aithena-ui/src/contexts/I18nContext.tsx` — renamed key constant, added migration
- `src/aithena-ui/src/__tests__/i18n.test.tsx` — updated key, added migration test

### Test results
- 213 tests passing (1 new migration test)
- Lint clean, format clean