### PR TITLE
fix: correct v1.7.0 docs per copilot review

### DIFF
--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -1933,4 +1933,4 @@ To roll back to v1.6.0:
    docker compose pull
    docker compose up -d
    ```
-3. No data migration rollback needed — v1.7.0 makes no schema or volume changes. The app will detect the `aithena.locale` key and continue using it (no migration back to `aithena-locale` occurs).
+3. No data migration rollback needed — v1.7.0 makes no schema or volume changes. Note: v1.6.0 code reads only the old `aithena-locale` key, so after rollback it will not find the migrated `aithena.locale` key. Users who switched languages during v1.7.0 will revert to browser locale detection on their next visit. This is a cosmetic reset, not data loss.

--- a/docs/release-notes-v1.7.0.md
+++ b/docs/release-notes-v1.7.0.md
@@ -82,7 +82,7 @@ For operators moving to **v1.7.0**:
 - **Page i18n extraction:** All 5 page components and App.tsx now use `react-intl` for string rendering. English is the default language (no translation required).
 - **Dependabot routing:** Heartbeat workflow correctly identifies Dependabot PRs and routes them to squad members based on dependency domain.
 - **CI workflow upgrades:** Dependabot auto-merge workflow passes with Node 22, explicit failure handling working correctly.
-- **All tests passing:** 622 tests across 6 services with no regressions from v1.6.0.
+- **All tests passing:** 632 tests executed (628 passed, 4 skipped) across 5 services, plus 9 CI-verified embeddings-server tests (641 total). No regressions from v1.6.0.
 
 ## Documentation updated for this release
 

--- a/docs/test-report-v1.7.0.md
+++ b/docs/test-report-v1.7.0.md
@@ -11,7 +11,7 @@
 
 ## Summary
 
-All **622 tests** executed across 5 services (embeddings-server excluded from automated run due to torch/CUDA dependency — see notes). No regressions from v1.6.0. All services pass with full test coverage thresholds met.
+All **632 tests** executed across 5 services (628 passed, 4 skipped; embeddings-server's 9 tests excluded from automated run due to torch/CUDA dependency — see notes). 641 total including not-run. No regressions from v1.6.0. All services pass with full test coverage thresholds met.
 
 ---
 


### PR DESCRIPTION
Fixes copilot review comments on PR #494:

1. **Test report**: 622→632 executed (628 passed + 4 skipped), 641 total with embeddings-server
2. **Release notes**: matched corrected test counts
3. **Admin manual**: fixed rollback note — v1.6.0 code reads only `aithena-locale`, won't find migrated `aithena.locale` key