### PR TITLE
infra: make certbot optional via docker-compose.ssl.yml overlay

### DIFF
--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -427,3 +427,13 @@ jobs:
 - Category→squad routing: crash/security→kane, connection→parker, all infra→brett
 
 **Learning:** POSIX shell pattern matching via `case` statements is sufficient for log scanning without needing grep/awk. The `tr '[:upper:]' '[:lower:]'` approach for case-insensitive matching is portable across all sh implementations. Separating the issue-creation job from the test job avoids needing to handle both artifact upload and GitHub API calls in the same step.
+### Certbot Made Optional (docker-compose.ssl.yml)
+
+**Date:** $(date -u +%Y-%m-%dT%H:%MZ)
+**Context:** Most deployments run behind a reverse proxy or on local networks and don't need Let's Encrypt. The certbot service and its bind-mount volumes were always required, even for HTTP-only setups.
+
+**Solution:** Extracted all certbot/SSL configuration into a dedicated `docker-compose.ssl.yml` overlay file. The base `docker-compose.yml` and `docker-compose.prod.yml` now run HTTP-only on port 80. SSL users compose the files together: `docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d`.
+
+**Why overlay instead of profiles:** Docker Compose profiles can disable services but can't conditionally add volume mounts or port bindings to *other* services (nginx). The certbot bind-mount volumes (`/source/volumes/certbot-data/`) would still need to exist on the host because nginx referenced them. An overlay file cleanly isolates all SSL-related config in one place.
+
+**Learning:** When making a sidecar optional, check whether the *main* service (nginx) has dependencies on the sidecar's infrastructure (shared volumes, ports). Profiles alone can't handle cross-service dependency removal — use a compose overlay file instead.

--- a/.squad/decisions/inbox/brett-certbot-optional.md
+++ b/.squad/decisions/inbox/brett-certbot-optional.md
@@ -1,0 +1,38 @@
+# Decision: Certbot container is optional via docker-compose.ssl.yml
+
+**Author:** Brett (Infrastructure Architect)
+**Date:** 2025-07-18
+**Status:** Implemented
+
+## Context
+
+The certbot service and its Let's Encrypt volumes were always started by
+`docker compose up`, even for deployments that run behind a reverse proxy or
+on local networks without TLS. This forced operators to create
+`/source/volumes/certbot-data/{conf,www}` directories even when they had no
+use for them.
+
+## Decision
+
+All certbot/SSL configuration has been moved to `docker-compose.ssl.yml`:
+
+- **HTTP-only (default):** `docker compose up -d`
+- **With SSL:** `docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d`
+
+The overlay adds port 443, certbot volume mounts on nginx, the periodic nginx
+reload command, and the certbot sidecar container.
+
+## Rationale
+
+Docker Compose profiles (`profiles: ["ssl"]`) can disable services but cannot
+conditionally add volume mounts or ports to other services. Since nginx needed
+certbot's bind-mount volumes, profiles alone would still require the host
+directories to exist. A compose overlay file cleanly isolates all SSL config.
+
+## Impact
+
+- **New HTTP deployments:** No change needed — `docker compose up` works.
+- **Existing SSL deployments:** Add `-f docker-compose.ssl.yml` to all
+  `docker compose` commands.
+- Docs updated: production.md, quickstart.md, admin-manual.md,
+  failover-runbook.md.

--- a/.squad/decisions/inbox/copilot-directive-2026-03-19T1310.md
+++ b/.squad/decisions/inbox/copilot-directive-2026-03-19T1310.md
@@ -1,0 +1,4 @@
+### 2026-03-19T13:10: User directive — Certbot optional
+**By:** jmservera (via Copilot)
+**What:** Make the certbot container optional in docker-compose. Most deployments run behind a general reverse proxy or on local networks and don't need Let's Encrypt certificate management.
+**Why:** User request — simplifies default deployment, reduces unnecessary container overhead.

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -14,18 +14,16 @@
 #     real book corpus.
 #   - document-lister polls every 10 seconds (POLL_INTERVAL=10) instead of the default 60 s,
 #     so new files are discovered quickly during tests.
-#   - nginx and certbot are disabled to reduce resource usage in dev/CI.
+#   - nginx is disabled to reduce resource usage in dev/CI.
+#   - certbot is not in the base compose (see docker-compose.ssl.yml).
 
 services:
   document-lister:
     environment:
       - POLL_INTERVAL=10
 
-  # Disable TLS services — not needed for local E2E testing
+  # Disable nginx — not needed for local E2E testing
   nginx:
-    profiles:
-      - production
-  certbot:
     profiles:
       - production
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -406,20 +406,9 @@ services:
         max-file: "3"
     ports:
       - "80:80"
-      - "443:443"
     volumes:
       - ./src/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./src/nginx/html:/usr/share/nginx/html:ro
-      - certbot-data-conf:/etc/letsencrypt
-      - certbot-data-www:/var/www/certbot
-    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
-  certbot:
-    image: certbot/certbot
-    restart: unless-stopped
-    volumes:
-      - certbot-data-conf:/etc/letsencrypt
-      - certbot-data-www:/var/www/certbot
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
   zoo1:
     image: zookeeper:3.9
     expose:
@@ -689,18 +678,7 @@ volumes:
       type: "none"
       o: "bind"
       device: "/source/volumes/rabbitmq-data"
-  certbot-data-conf:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/certbot-data/conf"
-  certbot-data-www:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/certbot-data/www"
+
   redis-data:
     driver: local
     driver_opts:

--- a/docker-compose.ssl.yml
+++ b/docker-compose.ssl.yml
@@ -1,0 +1,54 @@
+# docker-compose.ssl.yml
+#
+# SSL/TLS overlay — adds Let's Encrypt certbot and HTTPS support to nginx.
+#
+# Usage (development):
+#   docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d
+#
+# Usage (production / GHCR images):
+#   docker compose -f docker-compose.prod.yml -f docker-compose.ssl.yml up -d
+#
+# Prerequisites:
+#   sudo mkdir -p /source/volumes/certbot-data/{conf,www}
+#
+# The base compose files run HTTP-only on port 80. This overlay adds:
+#   - Port 443 on nginx
+#   - Certbot volume mounts on nginx (for ACME challenges and TLS certs)
+#   - Periodic nginx reload (picks up renewed certificates every 6 h)
+#   - Certbot sidecar container (renews certificates every 12 h)
+#
+# After first deploy, obtain the initial certificate:
+#   docker compose -f docker-compose.yml -f docker-compose.ssl.yml \
+#     run --rm certbot certonly --webroot -w /var/www/certbot \
+#     -d your.domain.com --agree-tos -m you@example.com
+
+services:
+  nginx:
+    ports:
+      - "443:443"
+    volumes:
+      - certbot-data-conf:/etc/letsencrypt
+      - certbot-data-www:/var/www/certbot
+    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
+
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - certbot-data-conf:/etc/letsencrypt
+      - certbot-data-www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+
+volumes:
+  certbot-data-conf:
+    driver: local
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "/source/volumes/certbot-data/conf"
+  certbot-data-www:
+    driver: local
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "/source/volumes/certbot-data/www"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -441,20 +441,9 @@ services:
         max-file: "3"
     ports:
       - "80:80"
-      - "443:443"
     volumes:
       - ./src/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./src/nginx/html:/usr/share/nginx/html:ro
-      - certbot-data-conf:/etc/letsencrypt
-      - certbot-data-www:/var/www/certbot
-    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
-  certbot:
-    image: certbot/certbot
-    restart: unless-stopped
-    volumes:
-      - certbot-data-conf:/etc/letsencrypt
-      - certbot-data-www:/var/www/certbot
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
   zoo1:
     image: zookeeper:3.9
     expose:
@@ -741,18 +730,7 @@ volumes:
       type: "none"
       o: "bind"
       device: "/source/volumes/rabbitmq-data"
-  certbot-data-conf:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/certbot-data/conf"
-  certbot-data-www:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/certbot-data/www"
+
   redis-data:
     driver: local
     driver_opts:

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -23,7 +23,7 @@ Aithena runs as a Docker Compose stack built around Solr, a document ingestion p
 | `embeddings-server` | Embedding service used by the search stack | internal only; direct `8085` via override |
 | `streamlit-admin` | Lightweight admin dashboard | proxied through `nginx`; direct `8501` via override |
 | `redis-commander` | Web UI for Redis inspection | proxied through `nginx`; direct `8081` via override |
-| `certbot` | Certificate renewal helper | internal only |
+| `certbot` | Certificate renewal helper (optional — see `docker-compose.ssl.yml`) | internal only |
 
 ### Service dependencies
 

--- a/docs/deployment/failover-runbook.md
+++ b/docs/deployment/failover-runbook.md
@@ -7,7 +7,7 @@ This runbook covers operator recovery for the Docker Compose deployment defined 
 ## Preconditions
 
 - Run `python3 -m installer` before the first `docker compose up` so `.env`, `AUTH_DB_DIR`, `AUTH_DB_PATH`, and the SQLite auth DB exist.
-- Use the base `docker-compose.yml` for full failover drills. `docker-compose.e2e.yml` intentionally disables `nginx` and `certbot`, so it is not suitable for the nginx outage scenario.
+- Use the base `docker-compose.yml` for full failover drills. `docker-compose.e2e.yml` intentionally disables `nginx`, so it is not suitable for the nginx outage scenario. If your deployment uses SSL, add `-f docker-compose.ssl.yml` to include the certbot sidecar.
 - Use `docker compose ps` and container health checks to confirm process-level readiness.
 - Use the status probe below for application-level confirmation:
 
@@ -50,7 +50,7 @@ A healthy baseline should show:
 | `redis-commander` | `redis` healthy | Redis admin UI. |
 | `aithena-ui` | `solr-search` healthy | End-user UI. |
 | `nginx` | `aithena-ui`, `solr-search`, `streamlit-admin`, `redis-commander`, `rabbitmq`, `solr` healthy | Public ingress and auth gate for `/v1/*`, `/documents/*`, and `/admin/*`. |
-| `certbot` | — | Certificate renewal sidecar. |
+| `certbot` | — | Certificate renewal sidecar (optional — only with `docker-compose.ssl.yml`). |
 
 ### Important architecture caveat
 

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -154,10 +154,9 @@ Docker Compose automatically orchestrates startup based on `depends_on` health c
 
 2. **Create volume directories**:
    ```bash
-   sudo mkdir -p /source/volumes/{solr-data,solr-data2,solr-data3}
+   sudo mkdir -p /source/volumes/{rabbitmq-data,redis,solr-data,solr-data2,solr-data3}
    sudo mkdir -p /source/volumes/{zoo-data1,zoo-data2,zoo-data3}/{data,logs,datalog}
    sudo mkdir -p /source/volumes/{rabbitmq-data,redis,zoo-backup}
-   sudo mkdir -p /source/volumes/certbot-data/{conf,www}
    sudo chown -R 8983:8983 /source/volumes/solr-data*  # Solr UID
    sudo chown -R 1000:1000 /source/volumes/zoo-data*   # ZooKeeper UID
    ```
@@ -544,6 +543,45 @@ If full system failure:
    docker compose restart document-lister  # Triggers full library scan
    ```
 
+## Enable HTTPS
+
+The base Compose files run HTTP-only on port 80. To add Let's Encrypt TLS via
+certbot, use the `docker-compose.ssl.yml` overlay:
+
+1. **Create certbot volume directories:**
+
+   ```bash
+   sudo mkdir -p /source/volumes/certbot-data/{conf,www}
+   ```
+
+2. **Start the stack with SSL:**
+
+   ```bash
+   # Development (local build)
+   docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d
+
+   # Production (GHCR images)
+   docker compose -f docker-compose.prod.yml -f docker-compose.ssl.yml up -d
+   ```
+
+3. **Obtain the initial certificate:**
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.ssl.yml \
+     run --rm certbot certonly --webroot -w /var/www/certbot \
+     -d your.domain.com --agree-tos -m you@example.com
+   ```
+
+4. **Add an HTTPS server block** to `src/nginx/default.conf` that references
+   `/etc/letsencrypt/live/your.domain.com/`. Restart nginx after editing.
+
+The certbot sidecar renews certificates automatically every 12 hours, and
+nginx reloads every 6 hours to pick up renewed certificates.
+
+> **Migrating from older setups:** If your deployment previously had certbot
+> in the base compose file, add `-f docker-compose.ssl.yml` to your
+> `docker compose` commands to restore the same behavior.
+
 ## Production Hardening Checklist
 
 Before going to production, verify:
@@ -552,7 +590,7 @@ Before going to production, verify:
 - [ ] `python3 -m installer` completed successfully — `.env` written, auth DB created, and generated secrets reviewed
 - [ ] Volume directories created with correct ownership
 - [ ] Firewall configured (only 80/443 public, block all other ports)
-- [ ] SSL certificates configured in nginx (Let's Encrypt via certbot)
+- [ ] SSL certificates configured in nginx if public-facing (see [Enable HTTPS](#enable-https) below)
 - [ ] RabbitMQ credentials rotated away from `guest/guest` via `.env` (`RABBITMQ_USER` / `RABBITMQ_PASS`) or matching `default_user` / `default_pass` settings in `src/rabbitmq/rabbitmq.conf`
 - [ ] Redis password set in `.env` (`REDIS_PASSWORD`) so Compose enables `redis-server --requirepass`
 - [ ] Rotated credentials applied with `docker compose up -d --force-recreate redis rabbitmq redis-commander streamlit-admin document-lister document-indexer solr-search nginx`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,7 +49,6 @@ Create the Docker volume mount points:
 
 ```bash
 sudo mkdir -p /source/volumes/{rabbitmq-data,redis,solr-data,solr-data2,solr-data3}
-sudo mkdir -p /source/volumes/certbot-data/{conf,www}
 sudo mkdir -p /source/volumes/{zoo-data1,zoo-data2,zoo-data3}/{logs,data,datalog}
 sudo mkdir -p /source/volumes/zoo-backup
 ```
@@ -106,11 +105,22 @@ Sign in with the admin credentials you configured during installation.
 
 ### Enable HTTPS with Let's Encrypt
 
-Edit the nginx configuration to enable TLS:
+To add TLS, use the SSL overlay:
 
 ```bash
-# Update src/nginx/default.conf with your domain and enable certbot
-docker compose -f docker-compose.prod.yml restart nginx
+# Create certbot volume directories
+sudo mkdir -p /source/volumes/certbot-data/{conf,www}
+
+# Start with SSL enabled
+docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d
+
+# Obtain the initial certificate
+docker compose -f docker-compose.yml -f docker-compose.ssl.yml \
+  run --rm certbot certonly --webroot -w /var/www/certbot \
+  -d your.domain.com --agree-tos -m you@example.com
+
+# Update src/nginx/default.conf with your domain's HTTPS server block
+docker compose -f docker-compose.yml -f docker-compose.ssl.yml restart nginx
 ```
 
 ### Add Documents to the Library


### PR DESCRIPTION
## Summary

Makes the certbot container optional by extracting all SSL/TLS configuration into a dedicated `docker-compose.ssl.yml` overlay file. Most deployments run behind a reverse proxy or on local networks and don't need Let's Encrypt — this change removes the certbot requirement from the default stack.

## What changed

| Before | After |
|--------|-------|
| `docker compose up` starts certbot, requires host dirs for certbot volumes | `docker compose up` is HTTP-only on port 80, no certbot overhead |
| Port 443 always exposed on nginx | Port 443 only with SSL overlay |
| certbot bind-mount dirs always required | Only needed when using SSL |

### Default (HTTP-only)
```bash
docker compose up -d
```

### With SSL/TLS
```bash
docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d
```

## Files changed

- **docker-compose.yml / docker-compose.prod.yml**: Removed certbot service, certbot volumes from nginx, port 443, certbot volume definitions, SSL reload command
- **docker-compose.ssl.yml** (new): Complete SSL overlay — certbot service, nginx port 443 + certbot volumes + reload loop, volume definitions
- **docker-compose.e2e.yml**: Removed stale certbot profile override (certbot no longer in base)
- **docs/**: Updated production.md (new Enable HTTPS section), quickstart.md, admin-manual.md, failover-runbook.md

## Migration for existing SSL deployments

Add `-f docker-compose.ssl.yml` to your `docker compose` commands:

```bash
# Before
docker compose up -d

# After
docker compose -f docker-compose.yml -f docker-compose.ssl.yml up -d
```

Working as Brett (Infrastructure Architect).