### PR TITLE
fix: dependabot CI uses service name for test runner selection (#598)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests
         working-directory: src/${{ matrix.service }}
         run: |
-          if [ -f pyproject.toml ]; then
+          if [ "${{ matrix.service }}" != "embeddings-server" ]; then
             uv run pytest -v --tb=short
           else
             python -m pytest -v --tb=short


### PR DESCRIPTION
Fixes #598

The dependabot-automerge workflow's 'Run tests' step checked for pyproject.toml to decide between uv and pip. Since embeddings-server now has a pyproject.toml, it incorrectly tried uv (which wasn't installed for that service).

Changed to explicit service-name check instead of file detection.