### PR TITLE
fix: copy .npmrc in aithena-ui Dockerfile for npm ci (#616)

### DIFF
--- a/src/aithena-ui/Dockerfile
+++ b/src/aithena-ui/Dockerfile
@@ -9,7 +9,7 @@ ARG VERSION
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY package*.json .npmrc ./
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
## Problem
The aithena-ui Dockerfile copies only `package*.json` before running `npm ci`, but the project's `.npmrc` (which sets `legacy-peer-deps=true`) is not included. This causes Docker builds to fail with:
```
npm error ERESOLVE could not resolve
npm error While resolving: eslint-plugin-jsx-a11y@6.10.2
npm error Found: eslint@10.0.3
```

## Fix
Copy `.npmrc` alongside `package*.json` in the Dockerfile build stage.

Closes #616