### PR TITLE
fix: E2E test failures — empty query validation + admin API key

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -239,7 +239,9 @@ jobs:
 
       - name: Run Python E2E tests
         working-directory: e2e
-        run: pytest -v --junitxml=pytest-results.xml
+        run: |
+          export ADMIN_API_KEY=$(grep '^ADMIN_API_KEY=' ../.env | cut -d= -f2)
+          pytest -v --junitxml=pytest-results.xml
 
       - name: Install Playwright dependencies
         working-directory: e2e/playwright

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -134,6 +134,15 @@ def auth_headers(api_url: str) -> dict[str, str]:
 
 
 @pytest.fixture(scope="session")
+def admin_api_headers() -> dict[str, str]:
+    """Return X-API-Key headers for admin endpoints."""
+    api_key = os.environ.get("ADMIN_API_KEY")
+    if not api_key:
+        pytest.skip("ADMIN_API_KEY environment variable must be set for admin endpoints")
+    return {"X-API-Key": api_key}
+
+
+@pytest.fixture(scope="session")
 def test_library_root() -> Generator[Path, None, None]:
     """
     Temporary library directory used as the document-data volume root.

--- a/e2e/test_admin_smoke.py
+++ b/e2e/test_admin_smoke.py
@@ -210,24 +210,24 @@ class TestAdminContainersEndpoint:
     """Container version/health snapshot coverage."""
 
     def test_admin_containers_returns_200(
-        self, api_url: str, api_available: None, auth_headers: dict[str, str]
+        self, api_url: str, api_available: None, admin_api_headers: dict[str, str]
     ) -> None:
         """GET /v1/admin/containers must return HTTP 200."""
-        resp = requests.get(f"{api_url}/v1/admin/containers", headers=auth_headers, timeout=10)
+        resp = requests.get(f"{api_url}/v1/admin/containers", headers=admin_api_headers, timeout=10)
         assert resp.status_code == 200
 
     def test_admin_containers_slash_alias_returns_200(
-        self, api_url: str, api_available: None, auth_headers: dict[str, str]
+        self, api_url: str, api_available: None, admin_api_headers: dict[str, str]
     ) -> None:
         """GET /v1/admin/containers/ must return HTTP 200 (trailing slash alias)."""
-        resp = requests.get(f"{api_url}/v1/admin/containers/", headers=auth_headers, timeout=10)
+        resp = requests.get(f"{api_url}/v1/admin/containers/", headers=admin_api_headers, timeout=10)
         assert resp.status_code == 200
 
     def test_admin_containers_contains_containers_list(
-        self, api_url: str, api_available: None, auth_headers: dict[str, str]
+        self, api_url: str, api_available: None, admin_api_headers: dict[str, str]
     ) -> None:
         """Admin containers response must include a 'containers' list."""
-        resp = requests.get(f"{api_url}/v1/admin/containers", headers=auth_headers, timeout=10)
+        resp = requests.get(f"{api_url}/v1/admin/containers", headers=admin_api_headers, timeout=10)
         body = resp.json()
         assert "containers" in body, f"'containers' key missing from /v1/admin/containers: {body}"
         assert isinstance(body["containers"], list), (
@@ -235,18 +235,18 @@ class TestAdminContainersEndpoint:
         )
 
     def test_admin_containers_list_is_non_empty(
-        self, api_url: str, api_available: None, auth_headers: dict[str, str]
+        self, api_url: str, api_available: None, admin_api_headers: dict[str, str]
     ) -> None:
         """The containers list must include at least one entry."""
-        resp = requests.get(f"{api_url}/v1/admin/containers", headers=auth_headers, timeout=10)
+        resp = requests.get(f"{api_url}/v1/admin/containers", headers=admin_api_headers, timeout=10)
         containers = resp.json().get("containers", [])
         assert len(containers) > 0, "Expected at least one container entry in /v1/admin/containers."
 
     def test_admin_containers_entries_have_required_fields(
-        self, api_url: str, api_available: None, auth_headers: dict[str, str]
+        self, api_url: str, api_available: None, admin_api_headers: dict[str, str]
     ) -> None:
         """Each container entry must include 'name', 'status', 'type', 'version', and 'commit'."""
-        resp = requests.get(f"{api_url}/v1/admin/containers", headers=auth_headers, timeout=10)
+        resp = requests.get(f"{api_url}/v1/admin/containers", headers=admin_api_headers, timeout=10)
         containers = resp.json().get("containers", [])
         required_fields = {"name", "status", "type", "version", "commit"}
         for entry in containers:
@@ -254,10 +254,10 @@ class TestAdminContainersEndpoint:
             assert not missing, f"Container entry missing fields {missing}: {entry}"
 
     def test_admin_containers_includes_solr_search_entry(
-        self, api_url: str, api_available: None, auth_headers: dict[str, str]
+        self, api_url: str, api_available: None, admin_api_headers: dict[str, str]
     ) -> None:
         """The containers list must include an entry for 'solr-search'."""
-        resp = requests.get(f"{api_url}/v1/admin/containers", headers=auth_headers, timeout=10)
+        resp = requests.get(f"{api_url}/v1/admin/containers", headers=admin_api_headers, timeout=10)
         containers = resp.json().get("containers", [])
         names = [c.get("name") for c in containers]
         assert "solr-search" in names, f"'solr-search' not found in container names: {names}"

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -247,6 +247,11 @@ def build_env_values(
     if reset or existing_redis_password in INSECURE_REDIS_PASSWORDS:
         redis_password = secret_factory(32)
 
+    existing_admin_api_key = existing_env.get("ADMIN_API_KEY", "")
+    admin_api_key = existing_admin_api_key
+    if reset or not existing_admin_api_key:
+        admin_api_key = secret_factory(32)
+
     env_values = {
         "BOOKS_PATH": str(library_path),
         "BOOK_LIBRARY_PATH": str(library_path),
@@ -258,6 +263,7 @@ def build_env_values(
         "AUTH_JWT_TTL": existing_env.get("AUTH_JWT_TTL", DEFAULT_AUTH_JWT_TTL),
         "AUTH_COOKIE_NAME": existing_env.get("AUTH_COOKIE_NAME", DEFAULT_AUTH_COOKIE_NAME),
         "AUTH_ADMIN_USERNAME": admin_user,
+        "ADMIN_API_KEY": admin_api_key,
         "RABBITMQ_USER": rabbitmq_user,
         "RABBITMQ_PASS": rabbitmq_pass,
         "REDIS_PASSWORD": redis_password,

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -819,21 +819,10 @@ def _search_semantic(
     Facets and highlights degrade to empty because the kNN query path does not
     produce Solr facet counts or highlight snippets.
     """
-    # Empty-query handling: semantic/hybrid modes return an empty result set
-    # immediately, skipping embeddings and Solr calls entirely.  This differs
-    # from keyword mode, which normalizes "" to "*:*" and returns all indexed
-    # documents with facets.  The distinction exists because generating a
-    # meaningful embedding from an empty string is not possible.
+    # Empty-query guard: semantic mode requires a non-empty string to generate
+    # an embedding vector.  Return 400 rather than silently returning no results.
     if not q.strip():
-        return {
-            "query": q,
-            "mode": "semantic",
-            "sort": {"by": "score", "order": "desc"},
-            "degraded": False,
-            **build_pagination(0, 1, top_k),
-            "results": [],
-            "facets": {"author": [], "category": [], "year": [], "language": []},
-        }
+        raise HTTPException(status_code=400, detail="Query cannot be empty for semantic search")
 
     try:
         vector = _fetch_embedding(q)
@@ -894,17 +883,9 @@ def _search_hybrid(
     The RRF k constant is configurable via the ``RRF_K`` environment variable
     (default 60, per the original RRF paper).
     """
-    # See semantic mode comment — same rationale: no embedding possible for "".
+    # Empty-query guard: hybrid mode needs an embedding for the kNN leg.
     if not q.strip():
-        return {
-            "query": q,
-            "mode": "hybrid",
-            "sort": {"by": "score", "order": "desc"},
-            "degraded": False,
-            **build_pagination(0, 1, page_size),
-            "results": [],
-            "facets": {"author": [], "category": [], "year": [], "language": []},
-        }
+        raise HTTPException(status_code=400, detail="Query cannot be empty for hybrid search")
 
     candidate_limit = max(page_size * 2, 20)
 

--- a/src/solr-search/tests/test_integration.py
+++ b/src/solr-search/tests/test_integration.py
@@ -449,11 +449,7 @@ def test_search_semantic_mode_calls_embeddings_and_knn(mock_solr_get: MagicMock,
 def test_search_semantic_empty_query_returns_empty_results(mock_solr_get: MagicMock, mock_emb_post: MagicMock) -> None:
     client = get_client()
     response = client.get("/search", params={"q": "", "mode": "semantic"})
-    assert response.status_code == 200
-    data = response.json()
-    assert data["mode"] == "semantic"
-    assert data["results"] == []
-    assert data["total"] == 0
+    assert response.status_code == 400
     mock_emb_post.assert_not_called()
     mock_solr_get.assert_not_called()
 
@@ -578,11 +574,7 @@ def test_search_hybrid_mode_fuses_both_legs(mock_solr_get: MagicMock, mock_emb_p
 def test_search_hybrid_empty_query_returns_empty_results(mock_solr_get: MagicMock, mock_emb_post: MagicMock) -> None:
     client = get_client()
     response = client.get("/search", params={"q": "", "mode": "hybrid"})
-    assert response.status_code == 200
-    data = response.json()
-    assert data["mode"] == "hybrid"
-    assert data["results"] == []
-    assert data["total"] == 0
+    assert response.status_code == 400
     mock_emb_post.assert_not_called()
     mock_solr_get.assert_not_called()
 


### PR DESCRIPTION
## Problem
Integration/E2E tests fail on the dev → main PR (#619):
1. **Admin containers tests**: `ADMIN_API_KEY` not configured → 403 Forbidden
2. **Semantic/hybrid empty query tests**: Implementation returns 200 but tests expect 400

## Fix
### Empty query validation (semantic/hybrid)
Return HTTP 400 for empty queries in semantic/hybrid mode — can't generate embeddings from an empty string. Updated both `_search_semantic()` and `_search_hybrid()` in main.py.

### Admin API key
- `installer/setup.py`: Generate `ADMIN_API_KEY` alongside other secrets
- `e2e/conftest.py`: New `admin_api_headers` fixture providing `X-API-Key` header
- `e2e/test_admin_smoke.py`: Use `admin_api_headers` instead of Bearer token auth
- `.github/workflows/integration-test.yml`: Export `ADMIN_API_KEY` from `.env` for E2E runner

### Tests
- 501 solr-search unit tests passing at 94% coverage
- Updated unit tests to expect 400 for empty semantic/hybrid queries

Closes #616