### PR TITLE
fix: admin Dockerfile COPY paths for repo-root build context

### DIFF
--- a/src/admin/Dockerfile
+++ b/src/admin/Dockerfile
@@ -9,10 +9,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
+COPY src/admin/pyproject.toml src/admin/uv.lock ./
 RUN uv sync --frozen --no-dev --native-tls
 
-COPY src ./src
+COPY src/admin/src ./src
 
 # ---------- runtime stage ----------
 FROM python:3.12-slim AS runtime


### PR DESCRIPTION
The admin service build was failing with:
```
failed to calculate checksum of ref: "/uv.lock": not found
```

**Root cause:** The Dockerfile used bare paths (`COPY pyproject.toml uv.lock ./`) but the build context is the repo root (`context: .` in docker-compose.yml). Files are at `src/admin/pyproject.toml`, not at the root.

**Fix:** Updated COPY paths to use `src/admin/` prefix, matching the pattern used by solr-search and other services.

```diff
-COPY pyproject.toml uv.lock ./
+COPY src/admin/pyproject.toml src/admin/uv.lock ./
-COPY src ./src
+COPY src/admin/src ./src
```