### PR TITLE
docs: address Copilot review comments on PR #619

### DIFF
--- a/.squad/skills/release-gate/SKILL.md
+++ b/.squad/skills/release-gate/SKILL.md
@@ -33,7 +33,7 @@ Newt (PM) is the release gate owner — no release without Newt's explicit appro
    ```
 
 ### Documentation Gate (REQUIRED — blocks release if incomplete)
-5. ✅ **Release notes created:** `docs/release-notes-vX.Y.Z.md` with:
+5. ✅ **Release notes created:** `docs/release-notes/vX.Y.Z.md` with:
    - Summary/codename/date
    - Milestone closure (all issues listed with GitHub #)
    - Per-category changes (Dependency Upgrades, Bug Fixes, Infrastructure, etc.)
@@ -43,7 +43,7 @@ Newt (PM) is the release gate owner — no release without Newt's explicit appro
    - Operator/infrastructure improvements (if applicable)
    - Security improvements (if any)
    - Upgrade instructions and validation highlights
-6. ✅ **Test report created:** `docs/test-report-vX.Y.Z.md` with:
+6. ✅ **Test report created:** `docs/test-reports/vX.Y.Z.md` with:
    - Per-service test counts (e.g., solr-search 231, aithena-ui 213, ...)
    - Total test count and pass/fail/skip breakdown
    - Coverage metrics (% of critical code)
@@ -112,7 +112,7 @@ All X issues in the vX.Y.Z milestone have been closed.
 
 ## See Also
 - Feature guide: docs/features/vX.Y.Z.md (if applicable)
-- Test report: docs/test-report-vX.Y.Z.md
+- Test report: docs/test-reports/vX.Y.Z.md
 - User manual: docs/user-manual.md
 - Admin manual: docs/admin-manual.md
 ```

--- a/README.md
+++ b/README.md
@@ -93,11 +93,16 @@ See [Release Process Overview](#release-process-overview) below for full details
 - [User Manual](docs/user-manual.md)
 - [Admin Manual](docs/admin-manual.md)
 - [Deployment Sizing Guide](docs/deployment/sizing-guide.md)
-- [i18n Contributor Guide](docs/i18n-guide.md)
+- [i18n Contributor Guide](docs/guides/i18n-guide.md)
 - [Security Baseline](docs/security/baseline-v0.6.0.md)
 
 ### Release Notes (newest first)
 
+- [v1.9.1 Release Notes](docs/release-notes/v1.9.1.md)
+- [v1.9.0 Release Notes](docs/release-notes/v1.9.0.md)
+- [v1.8.2 Release Notes](docs/release-notes/v1.8.2.md)
+- [v1.8.1 Release Notes](docs/release-notes/v1.8.1.md)
+- [v1.8.0 Release Notes](docs/release-notes/v1.8.0.md)
 - [v1.7.0 Release Notes](docs/release-notes/v1.7.0.md)
 - [v1.6.0 Release Notes](docs/release-notes/v1.6.0.md)
 - [v1.5.0 Release Notes](docs/release-notes/v1.5.0.md)
@@ -113,6 +118,8 @@ See [Release Process Overview](#release-process-overview) below for full details
 
 ### Test Reports (newest first)
 
+- [v1.8.1 Test Report](docs/test-reports/v1.8.1.md)
+- [v1.8.0 Test Report](docs/test-reports/v1.8.0.md)
 - [v1.7.0 Test Report](docs/test-reports/v1.7.0.md)
 - [v1.6.0 Test Report](docs/test-reports/v1.6.0.md)
 - [v1.5.0 Test Report](docs/test-reports/v1.5.0.md)

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -154,9 +154,8 @@ Docker Compose automatically orchestrates startup based on `depends_on` health c
 
 2. **Create volume directories**:
    ```bash
-   sudo mkdir -p /source/volumes/{rabbitmq-data,redis,solr-data,solr-data2,solr-data3}
+   sudo mkdir -p /source/volumes/{rabbitmq-data,redis,solr-data,solr-data2,solr-data3,zoo-backup}
    sudo mkdir -p /source/volumes/{zoo-data1,zoo-data2,zoo-data3}/{data,logs,datalog}
-   sudo mkdir -p /source/volumes/{rabbitmq-data,redis,zoo-backup}
    sudo chown -R 8983:8983 /source/volumes/solr-data*  # Solr UID
    sudo chown -R 1000:1000 /source/volumes/zoo-data*   # ZooKeeper UID
    ```

--- a/docs/test-reports/v1.8.0.md
+++ b/docs/test-reports/v1.8.0.md
@@ -5,7 +5,7 @@ _Release:_ UI/UX Improvements Milestone
 
 ## Executive Summary
 
-v1.8.0 passes all test suites across the Aithena platform. The combined test coverage includes 531 automated tests with 95% average code coverage. All service-level tests and integration tests pass cleanly, validating the design system, UI/UX improvements, and backend rate-limiting implementation.
+v1.8.0 passes all test suites across the Aithena platform. The combined test coverage includes 503 automated tests with 95% average code coverage. All service-level tests and integration tests pass cleanly, validating the design system, UI/UX improvements, and backend rate-limiting implementation.
 
 ## Test Results by Service
 


### PR DESCRIPTION
Fixes documentation issues identified by Copilot reviewer on the dev→main release PR #619:

1. **Test report totals** — Reconciled conflicting counts (531→503) in executive summary
2. **Test report location** — Moved `docs/test-report-v1.8.0.md` to `docs/test-reports/v1.8.0.md`
3. **README links** — Fixed i18n guide path, added v1.8.0–v1.9.1 release notes and test reports
4. **Deployment docs** — Consolidated duplicate `mkdir` commands (merged `zoo-backup` into first line)
5. **Release gate SKILL.md** — Updated doc paths to match restructured `docs/release-notes/` and `docs/test-reports/` layout

**Note:** Certbot image pinning in `docker-compose.ssl.yml` deferred to a dedicated issue — requires version research and testing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>