### PR TITLE
fix: use repo root context for admin Docker build in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         service:
           - image: admin
-            context: ./src/admin
+            context: .
             dockerfile: ./src/admin/Dockerfile
           - image: aithena-ui
             context: ./src/aithena-ui


### PR DESCRIPTION
The v1.9.1 release workflow failed because the admin Docker build used `context: ./src/admin` but the Dockerfile uses repo-root-relative COPY paths (`COPY src/admin/pyproject.toml ...`).

**Error:** `/src/admin/src: not found`

**Fix:** Change admin context to `.` (repo root), matching docker-compose.yml and the solr-search pattern already in the release matrix.

After merging, we'll need to re-tag or re-run the release workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>