### PR TITLE
fix: use POST for Solr queries to avoid URI too large errors

### DIFF
--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -368,7 +368,7 @@ async def request_logging_middleware(request: Request, call_next):
 
 def _raw_solr_query(params: dict[str, Any]) -> dict[str, Any]:
     """Execute a Solr HTTP request.  Raised exceptions feed the circuit breaker."""
-    response = requests.get(settings.select_url, params=params, timeout=settings.request_timeout)
+    response = requests.post(settings.select_url, data=params, timeout=settings.request_timeout)
     response.raise_for_status()
     return response.json()
 

--- a/src/solr-search/tests/test_books.py
+++ b/src/solr-search/tests/test_books.py
@@ -83,7 +83,7 @@ def _mock_solr_ok(mock_get: MagicMock, payload: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_returns_results(mock_get: MagicMock) -> None:
     docs = [_make_book_doc(i) for i in range(3)]
     _mock_solr_ok(mock_get, _solr_response(docs))
@@ -101,7 +101,7 @@ def test_books_returns_results(mock_get: MagicMock) -> None:
     assert data["results"][0]["author"] == "Author 0"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_trailing_slash_alias(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
@@ -112,7 +112,7 @@ def test_books_trailing_slash_alias(mock_get: MagicMock) -> None:
     assert response.json()["total"] == 0
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_canonical_endpoint(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([_make_book_doc(0)]))
 
@@ -128,7 +128,7 @@ def test_books_canonical_endpoint(mock_get: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_response_structure(mock_get: MagicMock) -> None:
     docs = [_make_book_doc(0)]
     _mock_solr_ok(mock_get, _solr_response(docs))
@@ -148,7 +148,7 @@ def test_books_response_structure(mock_get: MagicMock) -> None:
     assert "facets" in data
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_result_fields(mock_get: MagicMock) -> None:
     docs = [_make_book_doc(0)]
     _mock_solr_ok(mock_get, _solr_response(docs))
@@ -174,7 +174,7 @@ def test_books_result_fields(mock_get: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_default_pagination(mock_get: MagicMock) -> None:
     docs = [_make_book_doc(i) for i in range(5)]
     _mock_solr_ok(mock_get, _solr_response(docs, num_found=50))
@@ -186,12 +186,12 @@ def test_books_default_pagination(mock_get: MagicMock) -> None:
     assert data["page_size"] == settings.default_page_size
     assert data["total"] == 50
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["start"] == 0
     assert params["rows"] == settings.default_page_size
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_custom_page_and_page_size(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([], num_found=100))
 
@@ -202,23 +202,23 @@ def test_books_custom_page_and_page_size(mock_get: MagicMock) -> None:
     assert data["page_size"] == 25
     assert data["total_pages"] == 4
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["start"] == 50
     assert params["rows"] == 25
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_page_1_starts_at_zero(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([], num_found=10))
 
     client = get_client()
     client.get("/v1/books", params={"page": 1, "page_size": 10})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["start"] == 0
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_total_pages_calculated(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([], num_found=51))
 
@@ -257,7 +257,7 @@ def test_books_page_size_exceeds_max_returns_422() -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_default_sort_is_title_asc(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
@@ -265,11 +265,11 @@ def test_books_default_sort_is_title_asc(mock_get: MagicMock) -> None:
     data = client.get("/v1/books").json()
 
     assert data["sort"] == {"by": "title", "order": "asc"}
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["sort"] == "title_s asc"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_sort_by_year_desc(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
@@ -277,29 +277,29 @@ def test_books_sort_by_year_desc(mock_get: MagicMock) -> None:
     data = client.get("/v1/books", params={"sort_by": "year", "sort_order": "desc"}).json()
 
     assert data["sort"] == {"by": "year", "order": "desc"}
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["sort"] == "year_i desc"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_sort_by_author_asc(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books", params={"sort_by": "author", "sort_order": "asc"})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["sort"] == "author_s asc"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_sort_by_category(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books", params={"sort_by": "category"})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["sort"] == "category_s asc"
 
 
@@ -320,59 +320,59 @@ def test_books_invalid_sort_order_returns_422() -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_filter_by_author(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books", params={"fq_author": "Joan Amades"})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert any("author_s:" in fq for fq in params["fq"])
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_filter_by_category(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books", params={"fq_category": "Folklore"})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert any("category_s:" in fq for fq in params["fq"])
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_filter_by_language(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books", params={"fq_language": "ca"})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     fq_list = params["fq"]
     assert any("language_detected_s:ca" in fq or "language_s:ca" in fq for fq in fq_list)
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_filter_by_year(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books", params={"fq_year": "1950"})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert any("year_i:" in fq for fq in params["fq"])
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_multiple_filters(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books", params={"fq_author": "Amades", "fq_category": "Folklore"})
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     fq_list = params["fq"]
     assert "author_s:Amades" in fq_list
     assert "category_s:Folklore" in fq_list
@@ -380,18 +380,18 @@ def test_books_multiple_filters(mock_get: MagicMock) -> None:
     assert len(fq_list) == 3
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_no_filters_sends_no_fq(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([]))
 
     client = get_client()
     client.get("/v1/books")
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["fq"] == ["-parent_id_s:[* TO *]"]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_uses_wildcard_query(mock_get: MagicMock) -> None:
     """The books endpoint must query Solr with *:* to match all documents."""
     _mock_solr_ok(mock_get, _solr_response([]))
@@ -399,7 +399,7 @@ def test_books_uses_wildcard_query(mock_get: MagicMock) -> None:
     client = get_client()
     client.get("/v1/books")
 
-    params = mock_get.call_args[1]["params"]
+    params = mock_get.call_args[1]["data"]
     assert params["q"] == "*:*"
 
 
@@ -408,7 +408,7 @@ def test_books_uses_wildcard_query(mock_get: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_returns_facets(mock_get: MagicMock) -> None:
     facets = {
         "author_s": ["Author A", 3, "Author B", 2],
@@ -438,7 +438,7 @@ def test_books_returns_facets(mock_get: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_solr_timeout_returns_504(mock_get: MagicMock) -> None:
     mock_get.side_effect = req_lib.Timeout("Connection timeout")
 
@@ -449,7 +449,7 @@ def test_books_solr_timeout_returns_504(mock_get: MagicMock) -> None:
     assert "Timed out" in response.json()["detail"]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_solr_connection_error_returns_502(mock_get: MagicMock) -> None:
     mock_get.side_effect = req_lib.ConnectionError("Cannot connect to Solr")
 
@@ -460,7 +460,7 @@ def test_books_solr_connection_error_returns_502(mock_get: MagicMock) -> None:
     assert "failed" in response.json()["detail"]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_solr_invalid_json_returns_502(mock_get: MagicMock) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -479,7 +479,7 @@ def test_books_solr_invalid_json_returns_502(mock_get: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_empty_results(mock_get: MagicMock) -> None:
     _mock_solr_ok(mock_get, _solr_response([], num_found=0))
 
@@ -492,7 +492,7 @@ def test_books_empty_results(mock_get: MagicMock) -> None:
     assert data["results"] == []
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_single_result(mock_get: MagicMock) -> None:
     docs = [_make_book_doc(0, title="Only Book", author="Solo Author")]
     _mock_solr_ok(mock_get, _solr_response(docs, num_found=1))
@@ -507,7 +507,7 @@ def test_books_single_result(mock_get: MagicMock) -> None:
     assert data["results"][0]["author"] == "Solo Author"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_missing_title_falls_back_to_filename(mock_get: MagicMock) -> None:
     doc = _make_book_doc(0)
     doc["title_s"] = None
@@ -519,7 +519,7 @@ def test_books_missing_title_falls_back_to_filename(mock_get: MagicMock) -> None
     assert result["title"] == "book0"  # stem of file_path_s
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_missing_author_falls_back_to_unknown(mock_get: MagicMock) -> None:
     doc = _make_book_doc(0)
     doc["author_s"] = None
@@ -531,7 +531,7 @@ def test_books_missing_author_falls_back_to_unknown(mock_get: MagicMock) -> None
     assert result["author"] == "Unknown"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_document_url_present(mock_get: MagicMock) -> None:
     docs = [_make_book_doc(0)]
     _mock_solr_ok(mock_get, _solr_response(docs))
@@ -543,7 +543,7 @@ def test_books_document_url_present(mock_get: MagicMock) -> None:
     assert isinstance(result["document_url"], str)
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_missing_file_path_returns_null_url(mock_get: MagicMock) -> None:
     doc = _make_book_doc(0)
     doc["file_path_s"] = None
@@ -555,7 +555,7 @@ def test_books_missing_file_path_returns_null_url(mock_get: MagicMock) -> None:
     assert result["document_url"] is None
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_large_page_beyond_results(mock_get: MagicMock) -> None:
     """Requesting a page beyond available results returns empty results."""
     _mock_solr_ok(mock_get, _solr_response([], num_found=5))
@@ -568,7 +568,7 @@ def test_books_large_page_beyond_results(mock_get: MagicMock) -> None:
     assert data["page"] == 100
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_books_highlighting_empty_dict(mock_get: MagicMock) -> None:
     """Highlighting should always be an empty list for books (no query)."""
     docs = [_make_book_doc(0)]

--- a/src/solr-search/tests/test_circuit_breaker.py
+++ b/src/solr-search/tests/test_circuit_breaker.py
@@ -262,7 +262,7 @@ class TestHealthEndpointCircuitBreakers:
 
 class TestSolrCircuitBreaker:
 
-    @patch("main.requests.get")
+    @patch("main.requests.post")
     def test_solr_failure_trips_circuit(self, mock_get: MagicMock) -> None:
         import main
         main.solr_circuit.reset()
@@ -278,7 +278,7 @@ class TestSolrCircuitBreaker:
         assert "circuit breaker" in resp.json()["detail"].lower()
         main.solr_circuit.reset()
 
-    @patch("main.requests.get")
+    @patch("main.requests.post")
     def test_solr_recovers_after_timeout(self, mock_get: MagicMock) -> None:
         import main
         original_timeout = main.solr_circuit.recovery_timeout

--- a/src/solr-search/tests/test_correlation.py
+++ b/src/solr-search/tests/test_correlation.py
@@ -174,7 +174,7 @@ class TestCorrelationIdMiddleware:
     def test_correlation_id_on_authenticated_endpoint(self):
         """Verify correlation ID is returned even for auth-protected endpoints."""
         client = self._get_client()
-        with patch("main.requests.get") as mock_solr:
+        with patch("main.requests.post") as mock_solr:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {

--- a/src/solr-search/tests/test_integration.py
+++ b/src/solr-search/tests/test_integration.py
@@ -24,7 +24,7 @@ def get_client() -> TestClient:
     return create_authenticated_client()
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_returns_results_with_mocked_solr(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_response = MagicMock()
@@ -107,7 +107,7 @@ def test_search_returns_results_with_mocked_solr(mock_solr_get: MagicMock) -> No
     assert len(facets["year"]) == 2
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_v1_search_alias_supports_ui_contract_params(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_response = MagicMock()
@@ -137,7 +137,7 @@ def test_v1_search_alias_supports_ui_contract_params(mock_solr_get: MagicMock) -
     assert data["limit"] == 10
     assert data["total"] == 2
 
-    params = mock_solr_get.call_args[1]["params"]
+    params = mock_solr_get.call_args[1]["data"]
     assert params["start"] == 10
     assert params["rows"] == 10
     assert params["sort"] == "year_i asc"
@@ -148,7 +148,7 @@ def test_v1_search_alias_supports_ui_contract_params(mock_solr_get: MagicMock) -
     ]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_handles_empty_query(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_response = MagicMock()
@@ -169,10 +169,10 @@ def test_search_handles_empty_query(mock_solr_get: MagicMock) -> None:
 
     mock_solr_get.assert_called_once()
     call_args = mock_solr_get.call_args
-    assert call_args[1]["params"]["q"] == "*:*"
+    assert call_args[1]["data"]["q"] == "*:*"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_facets_endpoint_returns_facet_counts(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_response = MagicMock()
@@ -209,7 +209,7 @@ def test_facets_endpoint_returns_facet_counts(mock_solr_get: MagicMock) -> None:
     ]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_handles_solr_timeout(mock_solr_get: MagicMock) -> None:
     import requests
 
@@ -222,7 +222,7 @@ def test_search_handles_solr_timeout(mock_solr_get: MagicMock) -> None:
     assert "Timed out" in response.json()["detail"]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_handles_solr_connection_error(mock_solr_get: MagicMock) -> None:
     import requests
 
@@ -235,7 +235,7 @@ def test_search_handles_solr_connection_error(mock_solr_get: MagicMock) -> None:
     assert "failed" in response.json()["detail"]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_handles_invalid_solr_response(mock_solr_get: MagicMock) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -293,7 +293,7 @@ def test_version_endpoint_returns_build_metadata() -> None:
     }
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_pagination_parameters_passed_correctly(mock_solr_get: MagicMock) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -315,11 +315,11 @@ def test_search_pagination_parameters_passed_correctly(mock_solr_get: MagicMock)
 
     mock_solr_get.assert_called_once()
     call_args = mock_solr_get.call_args
-    assert call_args[1]["params"]["start"] == 50
-    assert call_args[1]["params"]["rows"] == 25
+    assert call_args[1]["data"]["start"] == 50
+    assert call_args[1]["data"]["rows"] == 25
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_sorting_parameters_applied(mock_solr_get: MagicMock) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -337,7 +337,7 @@ def test_search_sorting_parameters_applied(mock_solr_get: MagicMock) -> None:
 
     mock_solr_get.assert_called_once()
     call_args = mock_solr_get.call_args
-    assert call_args[1]["params"]["sort"] == "year_i asc"
+    assert call_args[1]["data"]["sort"] == "year_i asc"
 
 
 # ---------------------------------------------------------------------------
@@ -381,7 +381,7 @@ def _solr_payload(docs: list[dict], facets: dict | None = None) -> dict:
     }
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_keyword_mode_explicit(mock_solr_get: MagicMock) -> None:
     """?mode=keyword must behave identically to the default search."""
     mock_response = MagicMock()
@@ -399,7 +399,7 @@ def test_search_keyword_mode_explicit(mock_solr_get: MagicMock) -> None:
     assert "facets" in data
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_default_mode_is_keyword(mock_solr_get: MagicMock) -> None:
     """Default mode (no ?mode param) should be 'keyword'."""
     mock_response = MagicMock()
@@ -415,14 +415,12 @@ def test_search_default_mode_is_keyword(mock_solr_get: MagicMock) -> None:
 
 
 @patch("main.requests.post")
-@patch("main.requests.get")
-def test_search_semantic_mode_calls_embeddings_and_knn(mock_solr_get: MagicMock, mock_emb_post: MagicMock) -> None:
+def test_search_semantic_mode_calls_embeddings_and_knn(mock_post: MagicMock) -> None:
     """Semantic mode must call embeddings server then Solr kNN."""
     mock_emb_resp = MagicMock()
     mock_emb_resp.status_code = 200
     mock_emb_resp.json.return_value = {"data": [{"embedding": [0.1] * 512}]}
     mock_emb_resp.raise_for_status = MagicMock()
-    mock_emb_post.return_value = mock_emb_resp
 
     mock_solr_resp = MagicMock()
     mock_solr_resp.status_code = 200
@@ -431,7 +429,13 @@ def test_search_semantic_mode_calls_embeddings_and_knn(mock_solr_get: MagicMock,
         "highlighting": {},
         "facet_counts": {"facet_fields": {}},
     }
-    mock_solr_get.return_value = mock_solr_resp
+
+    def _dispatch(url, **kwargs):
+        if "json" in kwargs:
+            return mock_emb_resp
+        return mock_solr_resp
+
+    mock_post.side_effect = _dispatch
 
     client = get_client()
     response = client.get("/search", params={"q": "catalan history", "mode": "semantic"})
@@ -446,29 +450,29 @@ def test_search_semantic_mode_calls_embeddings_and_knn(mock_solr_get: MagicMock,
 
 
 @patch("main.requests.post")
-@patch("main.requests.get")
-def test_search_semantic_empty_query_returns_empty_results(mock_solr_get: MagicMock, mock_emb_post: MagicMock) -> None:
+def test_search_semantic_empty_query_returns_empty_results(mock_post: MagicMock) -> None:
     client = get_client()
     response = client.get("/search", params={"q": "", "mode": "semantic"})
     assert response.status_code == 400
-    mock_emb_post.assert_not_called()
-    mock_solr_get.assert_not_called()
+    mock_post.assert_not_called()
 
 
 @patch("main.requests.post")
-@patch("main.requests.get")
 def test_search_semantic_falls_back_to_keyword_when_embeddings_fail(
-    mock_solr_get: MagicMock,
-    mock_emb_post: MagicMock,
+    mock_post: MagicMock,
 ) -> None:
     import requests
-
-    mock_emb_post.side_effect = requests.ConnectionError("embeddings unavailable")
 
     mock_solr_resp = MagicMock()
     mock_solr_resp.status_code = 200
     mock_solr_resp.json.return_value = _solr_payload(_make_solr_docs(2))
-    mock_solr_get.return_value = mock_solr_resp
+
+    def _dispatch(url, **kwargs):
+        if "json" in kwargs:
+            raise requests.ConnectionError("embeddings unavailable")
+        return mock_solr_resp
+
+    mock_post.side_effect = _dispatch
 
     client = get_client()
     response = client.get("/search", params={"q": "catalan history", "mode": "semantic"})
@@ -481,15 +485,14 @@ def test_search_semantic_falls_back_to_keyword_when_embeddings_fail(
     assert data["message"] == "Embeddings unavailable — showing keyword results"
     assert len(data["results"]) == 2
 
-    mock_solr_get.assert_called_once()
-    assert mock_solr_get.call_args[1]["params"]["q"] == "catalan history"
+    solr_calls = [c for c in mock_post.call_args_list if "data" in c.kwargs]
+    assert len(solr_calls) == 1
+    assert solr_calls[0].kwargs["data"]["q"] == "catalan history"
 
 
 @patch("main.requests.post")
-@patch("main.requests.get")
 def test_search_semantic_degrades_when_circuit_open(
-    mock_solr_get: MagicMock,
-    mock_emb_post: MagicMock,
+    mock_post: MagicMock,
 ) -> None:
     """When the embeddings circuit breaker is open, semantic search should degrade to keyword."""
     from circuit_breaker import CircuitOpenError
@@ -497,7 +500,7 @@ def test_search_semantic_degrades_when_circuit_open(
     mock_solr_resp = MagicMock()
     mock_solr_resp.status_code = 200
     mock_solr_resp.json.return_value = _solr_payload(_make_solr_docs(1))
-    mock_solr_get.return_value = mock_solr_resp
+    mock_post.return_value = mock_solr_resp
 
     with patch("main.embeddings_circuit") as mock_cb:
         mock_cb.call.side_effect = CircuitOpenError("embeddings", 15.0)
@@ -512,14 +515,12 @@ def test_search_semantic_degrades_when_circuit_open(
 
 
 @patch("main.requests.post")
-@patch("main.requests.get")
-def test_search_hybrid_mode_fuses_both_legs(mock_solr_get: MagicMock, mock_emb_post: MagicMock) -> None:
+def test_search_hybrid_mode_fuses_both_legs(mock_post: MagicMock) -> None:
     """Hybrid mode must combine keyword + kNN results using RRF."""
     mock_emb_resp = MagicMock()
     mock_emb_resp.status_code = 200
     mock_emb_resp.json.return_value = {"data": [{"embedding": [0.1] * 512}]}
     mock_emb_resp.raise_for_status = MagicMock()
-    mock_emb_post.return_value = mock_emb_resp
 
     kw_docs = _make_solr_docs(3)
     knn_docs = [
@@ -540,11 +541,14 @@ def test_search_hybrid_mode_fuses_both_legs(mock_solr_get: MagicMock, mock_emb_p
 
     solr_call_count = [0]
 
-    def _solr_side_effect(url: str, params: dict, timeout: float):
+    def _dispatch(url, **kwargs):
+        if "json" in kwargs:
+            return mock_emb_resp
+        data = kwargs.get("data", {})
         mock_r = MagicMock()
         mock_r.status_code = 200
         solr_call_count[0] += 1
-        if "{!knn" in str(params.get("q", "")):
+        if "{!knn" in str(data.get("q", "")):
             mock_r.json.return_value = {
                 "response": {"numFound": len(knn_docs), "docs": knn_docs},
                 "highlighting": {},
@@ -554,7 +558,7 @@ def test_search_hybrid_mode_fuses_both_legs(mock_solr_get: MagicMock, mock_emb_p
             mock_r.json.return_value = _solr_payload(kw_docs)
         return mock_r
 
-    mock_solr_get.side_effect = _solr_side_effect
+    mock_post.side_effect = _dispatch
 
     client = get_client()
     response = client.get("/search", params={"q": "folklore", "mode": "hybrid", "page_size": 5})
@@ -571,29 +575,29 @@ def test_search_hybrid_mode_fuses_both_legs(mock_solr_get: MagicMock, mock_emb_p
 
 
 @patch("main.requests.post")
-@patch("main.requests.get")
-def test_search_hybrid_empty_query_returns_empty_results(mock_solr_get: MagicMock, mock_emb_post: MagicMock) -> None:
+def test_search_hybrid_empty_query_returns_empty_results(mock_post: MagicMock) -> None:
     client = get_client()
     response = client.get("/search", params={"q": "", "mode": "hybrid"})
     assert response.status_code == 400
-    mock_emb_post.assert_not_called()
-    mock_solr_get.assert_not_called()
+    mock_post.assert_not_called()
 
 
 @patch("main.requests.post")
-@patch("main.requests.get")
 def test_search_hybrid_falls_back_to_keyword_when_embeddings_fail(
-    mock_solr_get: MagicMock,
-    mock_emb_post: MagicMock,
+    mock_post: MagicMock,
 ) -> None:
     import requests
-
-    mock_emb_post.side_effect = requests.Timeout("embeddings timeout")
 
     mock_solr_resp = MagicMock()
     mock_solr_resp.status_code = 200
     mock_solr_resp.json.return_value = _solr_payload(_make_solr_docs(3))
-    mock_solr_get.return_value = mock_solr_resp
+
+    def _dispatch(url, **kwargs):
+        if "json" in kwargs:
+            raise requests.Timeout("embeddings timeout")
+        return mock_solr_resp
+
+    mock_post.side_effect = _dispatch
 
     client = get_client()
     response = client.get("/search", params={"q": "folklore", "mode": "hybrid", "page_size": 2})
@@ -605,8 +609,9 @@ def test_search_hybrid_falls_back_to_keyword_when_embeddings_fail(
     assert data["degraded"] is True
     assert data["message"] == "Embeddings unavailable — showing keyword results"
     assert len(data["results"]) == 3
-    assert mock_solr_get.call_count == 2
-    assert all("{!knn" not in call[1]["params"]["q"] for call in mock_solr_get.call_args_list)
+    solr_calls = [c for c in mock_post.call_args_list if "data" in c.kwargs]
+    assert len(solr_calls) == 2
+    assert all("{!knn" not in c.kwargs["data"]["q"] for c in solr_calls)
 
 
 # ---------------------------------------------------------------------------
@@ -627,7 +632,7 @@ def test_search_invalid_mode_returns_400() -> None:
     assert "hybrid" in detail
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_keyword_mode_returns_200(mock_solr_get: MagicMock) -> None:
     """GET /v1/search?q=test&mode=keyword must return 200 (control case)."""
     mock_response = MagicMock()
@@ -688,7 +693,7 @@ def _make_mock_response(docs: list[dict], num_found: int | None = None) -> Magic
     return mock_resp
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_returns_200_with_results(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -704,7 +709,7 @@ def test_similar_returns_200_with_results(mock_solr_get: MagicMock) -> None:
     assert len(body["results"]) == 2
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_v1_similar_alias_returns_results(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -718,7 +723,7 @@ def test_v1_similar_alias_returns_results(mock_solr_get: MagicMock) -> None:
     assert len(response.json()["results"]) == 2
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_result_contains_required_fields(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -734,7 +739,7 @@ def test_similar_result_contains_required_fields(mock_solr_get: MagicMock) -> No
         assert field in result, f"Missing required field: {field}"
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_excludes_source_document_via_fq(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -745,13 +750,13 @@ def test_similar_excludes_source_document_via_fq(mock_solr_get: MagicMock) -> No
     client.get("/books/source-doc-id/similar")
 
     assert mock_solr_get.call_count == 2
-    knn_call_params = mock_solr_get.call_args_list[1][1]["params"]
+    knn_call_params = mock_solr_get.call_args_list[1][1]["data"]
     fq = knn_call_params.get("fq", "")
     assert "source" in fq
     assert fq.startswith("-id:")
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_uses_knn_query_parser(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -761,13 +766,13 @@ def test_similar_uses_knn_query_parser(mock_solr_get: MagicMock) -> None:
 
     client.get("/books/source-doc-id/similar")
 
-    knn_call_params = mock_solr_get.call_args_list[1][1]["params"]
+    knn_call_params = mock_solr_get.call_args_list[1][1]["data"]
     q = knn_call_params.get("q", "")
     assert "{!knn" in q
     assert "embedding_v" in q
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_retrieves_embedding_field_from_source(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -777,12 +782,12 @@ def test_similar_retrieves_embedding_field_from_source(mock_solr_get: MagicMock)
 
     client.get("/books/source-doc-id/similar")
 
-    source_call_params = mock_solr_get.call_args_list[0][1]["params"]
+    source_call_params = mock_solr_get.call_args_list[0][1]["data"]
     fl = source_call_params.get("fl", "")
     assert "embedding_v" in fl
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_limit_controls_rows_in_knn_query(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -792,11 +797,11 @@ def test_similar_limit_controls_rows_in_knn_query(mock_solr_get: MagicMock) -> N
 
     client.get("/books/source-doc-id/similar?limit=3")
 
-    knn_call_params = mock_solr_get.call_args_list[1][1]["params"]
+    knn_call_params = mock_solr_get.call_args_list[1][1]["data"]
     assert knn_call_params.get("rows") == 3
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_min_score_filters_results(mock_solr_get: MagicMock) -> None:
     client = get_client()
     low_score_doc = {**SIMILAR_BOOKS_DOCS[1], "score": 0.50}
@@ -813,7 +818,7 @@ def test_similar_min_score_filters_results(mock_solr_get: MagicMock) -> None:
     assert len(scores) == 1
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_returns_404_for_unknown_id(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.return_value = _make_mock_response([])
@@ -823,7 +828,7 @@ def test_similar_returns_404_for_unknown_id(mock_solr_get: MagicMock) -> None:
     assert response.status_code == 404
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_returns_422_when_embedding_missing(mock_solr_get: MagicMock) -> None:
     client = get_client()
     doc_no_embedding = {"id": "source-doc-id"}
@@ -834,7 +839,7 @@ def test_similar_returns_422_when_embedding_missing(mock_solr_get: MagicMock) ->
     assert response.status_code == 422
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_returns_empty_list_when_no_similar_found(mock_solr_get: MagicMock) -> None:
     client = get_client()
     mock_solr_get.side_effect = [
@@ -848,7 +853,7 @@ def test_similar_returns_empty_list_when_no_similar_found(mock_solr_get: MagicMo
     assert response.json()["results"] == []
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_similar_returns_502_on_solr_error(mock_solr_get: MagicMock) -> None:
     import requests as req
 
@@ -899,7 +904,7 @@ _STATS_SOLR_PAYLOAD = {
 }
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_stats_returns_200_with_correct_shape(mock_solr_get: MagicMock) -> None:
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -923,7 +928,7 @@ def test_stats_returns_200_with_correct_shape(mock_solr_get: MagicMock) -> None:
     assert data["page_stats"]["avg"] == 158
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_stats_no_slash_alias_returns_200(mock_solr_get: MagicMock) -> None:
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -936,7 +941,7 @@ def test_stats_no_slash_alias_returns_200(mock_solr_get: MagicMock) -> None:
     assert response.status_code == 200
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_stats_legacy_path_returns_200(mock_solr_get: MagicMock) -> None:
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -949,7 +954,7 @@ def test_stats_legacy_path_returns_200(mock_solr_get: MagicMock) -> None:
     assert response.status_code == 200
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_stats_sends_correct_solr_params(mock_solr_get: MagicMock) -> None:
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -960,7 +965,7 @@ def test_stats_sends_correct_solr_params(mock_solr_get: MagicMock) -> None:
     client.get("/v1/stats/")
 
     mock_solr_get.assert_called_once()
-    params = mock_solr_get.call_args[1]["params"]
+    params = mock_solr_get.call_args[1]["data"]
     assert params["q"] == "*:*"
     assert params["rows"] == 0
     assert params["group"] == "true"
@@ -975,7 +980,7 @@ def test_stats_sends_correct_solr_params(mock_solr_get: MagicMock) -> None:
     assert "language_detected_s" in params["facet.field"]
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_stats_handles_empty_collection(mock_solr_get: MagicMock) -> None:
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -997,7 +1002,7 @@ def test_stats_handles_empty_collection(mock_solr_get: MagicMock) -> None:
     assert data["page_stats"] == {"total": 0, "avg": 0, "min": 0, "max": 0}
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_stats_returns_504_on_solr_timeout(mock_solr_get: MagicMock) -> None:
     import requests as req
 
@@ -1009,7 +1014,7 @@ def test_stats_returns_504_on_solr_timeout(mock_solr_get: MagicMock) -> None:
     assert response.status_code == 504
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_stats_returns_502_on_solr_error(mock_solr_get: MagicMock) -> None:
     import requests as req
 
@@ -1026,7 +1031,7 @@ def test_stats_returns_502_on_solr_error(mock_solr_get: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_chunk_hits_include_page_range(mock_solr_get: MagicMock) -> None:
     """Chunk documents with page_start_i/page_end_i must expose pages in results."""
     client = get_client()
@@ -1073,7 +1078,7 @@ def test_search_chunk_hits_include_page_range(mock_solr_get: MagicMock) -> None:
     assert full_result["pages"] is None
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_solr_field_list_includes_page_fields(mock_solr_get: MagicMock) -> None:
     """Solr queries must request page_start_i and page_end_i fields."""
     client = get_client()
@@ -1088,7 +1093,7 @@ def test_search_solr_field_list_includes_page_fields(mock_solr_get: MagicMock) -
 
     client.get("/search", params={"q": "test"})
 
-    params = mock_solr_get.call_args[1]["params"]
+    params = mock_solr_get.call_args[1]["data"]
     assert "page_start_i" in params["fl"]
     assert "page_end_i" in params["fl"]
 

--- a/src/solr-search/tests/test_metrics.py
+++ b/src/solr-search/tests/test_metrics.py
@@ -86,7 +86,7 @@ def test_metrics_endpoint_returns_prometheus_format(
     return_value=({"total_discovered": 0, "indexed": 0, "failed": 0, "pending": 0}, set()),
 )
 @patch("main._get_solr_status", return_value={"status": "ok", "nodes": 3, "docs_indexed": 0})
-@patch("main.requests.get")
+@patch("main.requests.post")
 def test_search_requests_counter_increments(
     mock_solr_get: MagicMock,
     _mock_solr_status: MagicMock,

--- a/src/solr-search/tests/test_rate_limiting.py
+++ b/src/solr-search/tests/test_rate_limiting.py
@@ -162,7 +162,7 @@ def test_rate_limiter_fails_open_on_redis_error(mock_redis: MagicMock) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 @patch("main.RedisRateLimiter.check_rate_limit")
 def test_search_endpoint_allows_requests_within_limit(mock_rate_limit: MagicMock, mock_get: MagicMock) -> None:
     """Search endpoint should allow requests within rate limit."""
@@ -176,7 +176,7 @@ def test_search_endpoint_allows_requests_within_limit(mock_rate_limit: MagicMock
     mock_rate_limit.assert_called_once()
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 @patch("main.RedisRateLimiter.check_rate_limit")
 def test_search_endpoint_returns_429_when_limit_exceeded(mock_rate_limit: MagicMock, mock_get: MagicMock) -> None:
     """Search endpoint should return 429 when rate limit is exceeded."""
@@ -194,7 +194,7 @@ def test_search_endpoint_returns_429_when_limit_exceeded(mock_rate_limit: MagicM
     mock_rate_limit.assert_called_once()
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 @patch("main.RedisRateLimiter.check_rate_limit")
 def test_search_endpoint_works_when_redis_fails(mock_rate_limit: MagicMock, mock_get: MagicMock) -> None:
     """Search endpoint should still work (fail open) when Redis is unavailable."""
@@ -228,7 +228,7 @@ def test_rate_limit_only_applies_to_search_endpoint(mock_get: MagicMock) -> None
     assert response.status_code == 200
 
 
-@patch("main.requests.get")
+@patch("main.requests.post")
 @patch("main.RedisRateLimiter.check_rate_limit")
 def test_rate_limit_dependency_called_for_all_search_routes(mock_rate_limit: MagicMock, mock_get: MagicMock) -> None:
     """Rate limiting should be applied to all search endpoint routes."""


### PR DESCRIPTION
## Problem

Solr logs show `URI is too large >8192` when performing semantic or hybrid search. The kNN embedding vector (768+ floats) is sent as URL query parameters via `requests.get`, exceeding Solr's 8KB URI limit.

## Root Cause

In `_raw_solr_query()`, the search parameters (including the full embedding vector) were passed as URL query parameters:
```python
response = requests.get(settings.select_url, params=params, ...)
```

## Fix

Switch to `requests.post` with form-encoded body (`data=`) instead of URL parameters (`params=`):
```python
response = requests.post(settings.select_url, data=params, ...)
```

Solr's `/select` endpoint accepts both GET and POST for search queries. POST sends parameters in the request body, bypassing the URI size limit entirely.

### What changed
- **`main.py`**: `_raw_solr_query` now uses `requests.post` with `data=params`
- **All test files**: Updated mocks from `requests.get` → `requests.post` for search-related tests. Tests for health checks, admin endpoints, and `_get_solr_status` correctly remain as `requests.get`.
- Refactored 7 semantic/hybrid tests that previously had separate embeddings (`requests.post`) and Solr (`requests.get`) mocks into single-mock tests with URL-dispatching side effects.

### Test results
All 504 tests pass with 93.97% coverage.

Closes #704