### PR TITLE
feat: collections backend SQLite model & CRUD API

### DIFF
--- a/src/solr-search/collections_models.py
+++ b/src/solr-search/collections_models.py
@@ -1,0 +1,58 @@
+"""Pydantic models for the Collections CRUD API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CreateCollectionRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=1000)
+
+
+class UpdateCollectionRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=1000)
+
+
+class AddItemsRequest(BaseModel):
+    document_ids: list[str] = Field(..., min_length=1, max_length=50)
+
+
+class UpdateItemRequest(BaseModel):
+    note: str | None = None
+    position: int | None = None
+
+
+class ReorderItemsRequest(BaseModel):
+    item_ids: list[str] = Field(..., min_length=1)
+
+
+class CollectionItemResponse(BaseModel):
+    id: str
+    collection_id: str
+    document_id: str
+    position: int | None
+    note: str | None
+    added_at: str
+    updated_at: str
+
+
+class CollectionResponse(BaseModel):
+    id: str
+    user_id: str
+    name: str
+    description: str | None
+    item_count: int
+    created_at: str
+    updated_at: str
+
+
+class CollectionDetailResponse(BaseModel):
+    id: str
+    user_id: str
+    name: str
+    description: str | None
+    created_at: str
+    updated_at: str
+    items: list[CollectionItemResponse]

--- a/src/solr-search/collections_service.py
+++ b/src/solr-search/collections_service.py
@@ -1,0 +1,346 @@
+"""Collections service — SQLite CRUD for user document collections."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Schema initialisation
+# ---------------------------------------------------------------------------
+
+
+def init_collections_db(db_path: Path) -> None:
+    """Ensure the collections database and tables exist."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    from migrations import _collections_init as migration  # noqa: PLC0415 (late import)
+
+    with sqlite3.connect(db_path) as connection:
+        migration.upgrade(connection)
+        connection.commit()
+    logger.info("Collections DB initialised at %s", db_path)
+
+
+# ---------------------------------------------------------------------------
+# Internal: import alias for the migration module
+# ---------------------------------------------------------------------------
+# The migration file lives at migrations/001_collections_init.py which is
+# not a valid Python identifier.  We re-export it under a private alias
+# inside the migrations package so that a normal ``import`` works.
+# The alias is set up in _register_collections_migration() below.
+
+
+def _register_collections_migration() -> None:  # pragma: no cover — bootstrapping
+    """Make ``migrations._collections_init`` importable."""
+    import importlib
+    import sys
+
+    if "migrations._collections_init" not in sys.modules:
+        mod = importlib.import_module("migrations.001_collections_init")
+        sys.modules["migrations._collections_init"] = mod
+
+
+_register_collections_migration()
+
+
+# ---------------------------------------------------------------------------
+# Collection CRUD
+# ---------------------------------------------------------------------------
+
+
+def create_collection(db_path: Path, user_id: str, name: str, description: str | None) -> dict:
+    now = _utcnow()
+    collection_id = _new_id()
+    with _connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO collections (id, user_id, name, description, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (collection_id, user_id, name, description, now, now),
+        )
+        conn.commit()
+    return {
+        "id": collection_id,
+        "user_id": user_id,
+        "name": name,
+        "description": description,
+        "item_count": 0,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def list_collections(db_path: Path, user_id: str) -> list[dict]:
+    with _connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT c.id, c.user_id, c.name, c.description, c.created_at, c.updated_at,
+                   (SELECT COUNT(*) FROM collection_items ci WHERE ci.collection_id = c.id) AS item_count
+            FROM collections c
+            WHERE c.user_id = ?
+            ORDER BY c.created_at DESC
+            """,
+            (user_id,),
+        ).fetchall()
+    return [
+        {
+            "id": r["id"],
+            "user_id": r["user_id"],
+            "name": r["name"],
+            "description": r["description"],
+            "item_count": r["item_count"],
+            "created_at": r["created_at"],
+            "updated_at": r["updated_at"],
+        }
+        for r in rows
+    ]
+
+
+def get_collection(db_path: Path, collection_id: str, user_id: str) -> dict | None:
+    """Return collection with items, or None if not found / not owned."""
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT id, user_id, name, description, created_at, updated_at FROM collections WHERE id = ?",
+            (collection_id,),
+        ).fetchone()
+        if row is None or row["user_id"] != user_id:
+            return None
+
+        items = conn.execute(
+            """
+            SELECT id, collection_id, document_id, position, note, added_at, updated_at
+            FROM collection_items
+            WHERE collection_id = ?
+            ORDER BY position ASC NULLS LAST, added_at ASC
+            """,
+            (collection_id,),
+        ).fetchall()
+
+    return {
+        "id": row["id"],
+        "user_id": row["user_id"],
+        "name": row["name"],
+        "description": row["description"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "items": [
+            {
+                "id": i["id"],
+                "collection_id": i["collection_id"],
+                "document_id": i["document_id"],
+                "position": i["position"],
+                "note": i["note"],
+                "added_at": i["added_at"],
+                "updated_at": i["updated_at"],
+            }
+            for i in items
+        ],
+    }
+
+
+def update_collection(
+    db_path: Path, collection_id: str, user_id: str, *, name: str | None = None, description: str | None = None
+) -> dict | None:
+    """Update a collection's name/description. Returns None if not found/not owned."""
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT user_id FROM collections WHERE id = ?",
+            (collection_id,),
+        ).fetchone()
+        if row is None or row["user_id"] != user_id:
+            return None
+
+        sets: list[str] = []
+        params: list[str] = []
+        if name is not None:
+            sets.append("name = ?")
+            params.append(name)
+        if description is not None:
+            sets.append("description = ?")
+            params.append(description)
+
+        if sets:
+            now = _utcnow()
+            sets.append("updated_at = ?")
+            params.append(now)
+            params.append(collection_id)
+            conn.execute(f"UPDATE collections SET {', '.join(sets)} WHERE id = ?", params)  # noqa: S608
+            conn.commit()
+
+    return get_collection(db_path, collection_id, user_id)
+
+
+def delete_collection(db_path: Path, collection_id: str, user_id: str) -> bool:
+    """Delete a collection (cascade deletes items). Returns False if not found/not owned."""
+    with _connect(db_path) as conn:
+        row = conn.execute("SELECT user_id FROM collections WHERE id = ?", (collection_id,)).fetchone()
+        if row is None or row["user_id"] != user_id:
+            return False
+        conn.execute("DELETE FROM collections WHERE id = ?", (collection_id,))
+        conn.commit()
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Collection Items CRUD
+# ---------------------------------------------------------------------------
+
+
+def _verify_collection_owner(conn: sqlite3.Connection, collection_id: str, user_id: str) -> bool:
+    row = conn.execute("SELECT user_id FROM collections WHERE id = ?", (collection_id,)).fetchone()
+    return row is not None and row["user_id"] == user_id
+
+
+def add_items(db_path: Path, collection_id: str, user_id: str, document_ids: list[str]) -> list[dict]:
+    """Add documents to a collection, skipping duplicates. Returns added items."""
+    now = _utcnow()
+    added: list[dict] = []
+    with _connect(db_path) as conn:
+        if not _verify_collection_owner(conn, collection_id, user_id):
+            return []
+
+        # Determine the next position
+        row = conn.execute(
+            "SELECT MAX(position) AS max_pos FROM collection_items WHERE collection_id = ?",
+            (collection_id,),
+        ).fetchone()
+        next_pos = (row["max_pos"] or 0) + 1 if row and row["max_pos"] is not None else 1
+
+        for doc_id in document_ids:
+            item_id = _new_id()
+            try:
+                conn.execute(
+                    "INSERT INTO collection_items"
+                    " (id, collection_id, document_id, position, note, added_at, updated_at)"
+                    " VALUES (?, ?, ?, ?, NULL, ?, ?)",
+                    (item_id, collection_id, doc_id, next_pos, now, now),
+                )
+                added.append(
+                    {
+                        "id": item_id,
+                        "collection_id": collection_id,
+                        "document_id": doc_id,
+                        "position": next_pos,
+                        "note": None,
+                        "added_at": now,
+                        "updated_at": now,
+                    }
+                )
+                next_pos += 1
+            except sqlite3.IntegrityError:
+                # Duplicate (collection_id, document_id) — skip
+                continue
+        conn.commit()
+    return added
+
+
+def remove_item(db_path: Path, collection_id: str, user_id: str, item_id: str) -> bool:
+    with _connect(db_path) as conn:
+        if not _verify_collection_owner(conn, collection_id, user_id):
+            return False
+        cursor = conn.execute(
+            "DELETE FROM collection_items WHERE id = ? AND collection_id = ?",
+            (item_id, collection_id),
+        )
+        conn.commit()
+    return cursor.rowcount > 0
+
+
+def update_item(
+    db_path: Path,
+    collection_id: str,
+    user_id: str,
+    item_id: str,
+    *,
+    note: str | None = None,
+    position: int | None = None,
+    note_max_length: int = 1000,
+) -> dict | None:
+    """Update an item's note and/or position. Returns the updated item or None."""
+    with _connect(db_path) as conn:
+        if not _verify_collection_owner(conn, collection_id, user_id):
+            return None
+
+        row = conn.execute(
+            "SELECT id FROM collection_items WHERE id = ? AND collection_id = ?",
+            (item_id, collection_id),
+        ).fetchone()
+        if row is None:
+            return None
+
+        sets: list[str] = []
+        params: list = []
+        if note is not None:
+            if len(note) > note_max_length:
+                raise ValueError(f"Note exceeds maximum length of {note_max_length} characters")
+            sets.append("note = ?")
+            params.append(note)
+        if position is not None:
+            sets.append("position = ?")
+            params.append(position)
+
+        if sets:
+            now = _utcnow()
+            sets.append("updated_at = ?")
+            params.append(now)
+            params.append(item_id)
+            conn.execute(f"UPDATE collection_items SET {', '.join(sets)} WHERE id = ?", params)  # noqa: S608
+            conn.commit()
+
+        updated = conn.execute(
+            "SELECT id, collection_id, document_id, position, note, added_at, updated_at "
+            "FROM collection_items WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        if updated is None:
+            return None  # pragma: no cover
+        return {
+            "id": updated["id"],
+            "collection_id": updated["collection_id"],
+            "document_id": updated["document_id"],
+            "position": updated["position"],
+            "note": updated["note"],
+            "added_at": updated["added_at"],
+            "updated_at": updated["updated_at"],
+        }
+
+
+def reorder_items(db_path: Path, collection_id: str, user_id: str, item_ids: list[str]) -> bool:
+    """Re-assign positions 1..N according to the supplied item_ids order."""
+    with _connect(db_path) as conn:
+        if not _verify_collection_owner(conn, collection_id, user_id):
+            return False
+
+        now = _utcnow()
+        for position, item_id in enumerate(item_ids, start=1):
+            conn.execute(
+                "UPDATE collection_items SET position = ?, updated_at = ? WHERE id = ? AND collection_id = ?",
+                (position, now, item_id, collection_id),
+            )
+        conn.commit()
+    return True

--- a/src/solr-search/config.py
+++ b/src/solr-search/config.py
@@ -67,6 +67,8 @@ class Settings:
     zookeeper_hosts: str
     auth_default_admin_username: str
     auth_default_admin_password: str | None
+    collections_db_path: Path
+    collections_note_max_length: int
 
     @property
     def select_url(self) -> str:
@@ -129,4 +131,6 @@ settings = Settings(
     zookeeper_hosts=os.environ.get("ZOOKEEPER_HOSTS", "zoo1:2181"),
     auth_default_admin_username=os.environ.get("AUTH_DEFAULT_ADMIN_USERNAME", "admin").strip() or "admin",
     auth_default_admin_password=os.environ.get("AUTH_DEFAULT_ADMIN_PASSWORD") or None,
+    collections_db_path=Path(os.environ.get("COLLECTIONS_DB_PATH", "/data/collections/collections.db")).resolve(),
+    collections_note_max_length=int(os.environ.get("COLLECTIONS_NOTE_MAX_LENGTH", "1000")),
 )

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -41,6 +41,42 @@ from auth import (
     update_user,
 )
 from circuit_breaker import CircuitBreaker, CircuitOpenError, CircuitState
+from collections_models import (
+    AddItemsRequest,
+    CollectionDetailResponse,
+    CollectionResponse,
+    CreateCollectionRequest,
+    ReorderItemsRequest,
+    UpdateCollectionRequest,
+    UpdateItemRequest,
+)
+from collections_service import (
+    add_items as svc_add_items,
+)
+from collections_service import (
+    create_collection as svc_create_collection,
+)
+from collections_service import (
+    delete_collection as svc_delete_collection,
+)
+from collections_service import (
+    get_collection as svc_get_collection,
+)
+from collections_service import (
+    list_collections as svc_list_collections,
+)
+from collections_service import (
+    remove_item as svc_remove_item,
+)
+from collections_service import (
+    reorder_items as svc_reorder_items,
+)
+from collections_service import (
+    update_collection as svc_update_collection,
+)
+from collections_service import (
+    update_item as svc_update_item,
+)
 from config import settings
 from correlation import CorrelationIdMiddleware, get_correlation_id
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, UploadFile
@@ -89,6 +125,9 @@ async def lifespan(_app: FastAPI):
             "Set a strong random secret via the AUTH_JWT_SECRET environment variable."
         )
     init_auth_db(settings.auth_db_path)
+    from collections_service import init_collections_db
+
+    init_collections_db(settings.collections_db_path)
     logger.info("solr-search started", extra={"version": settings.version, "port": settings.port})
     yield
     logger.info("solr-search shutting down")
@@ -2115,6 +2154,107 @@ async def upload_pdf(file: UploadFile, request: Request) -> dict[str, Any]:
         "status": "accepted",
         "message": "File uploaded and queued for indexing",
     }
+
+
+# ---------------------------------------------------------------------------
+# Collections CRUD endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.post("/v1/collections", response_model=CollectionResponse, status_code=201)
+def create_collection(body: CreateCollectionRequest, request: Request):
+    user = _get_current_user(request)
+    result = svc_create_collection(settings.collections_db_path, str(user.id), body.name, body.description)
+    return result
+
+
+@app.get("/v1/collections", response_model=list[CollectionResponse])
+def list_collections(request: Request):
+    user = _get_current_user(request)
+    return svc_list_collections(settings.collections_db_path, str(user.id))
+
+
+@app.get("/v1/collections/{collection_id}", response_model=CollectionDetailResponse)
+def get_collection(collection_id: str, request: Request):
+    user = _get_current_user(request)
+    result = svc_get_collection(settings.collections_db_path, collection_id, str(user.id))
+    if result is None:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    return result
+
+
+@app.put("/v1/collections/{collection_id}", response_model=CollectionDetailResponse)
+def update_collection(collection_id: str, body: UpdateCollectionRequest, request: Request):
+    user = _get_current_user(request)
+    if body.name is None and body.description is None:
+        raise HTTPException(status_code=422, detail="At least one of name or description must be provided")
+    result = svc_update_collection(
+        settings.collections_db_path, collection_id, str(user.id), name=body.name, description=body.description
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    return result
+
+
+@app.delete("/v1/collections/{collection_id}", status_code=204)
+def delete_collection(collection_id: str, request: Request):
+    user = _get_current_user(request)
+    deleted = svc_delete_collection(settings.collections_db_path, collection_id, str(user.id))
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    return Response(status_code=204)
+
+
+@app.post("/v1/collections/{collection_id}/items", status_code=201)
+def add_collection_items(collection_id: str, body: AddItemsRequest, request: Request):
+    user = _get_current_user(request)
+    # Verify the collection exists and is owned by user
+    col = svc_get_collection(settings.collections_db_path, collection_id, str(user.id))
+    if col is None:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    added = svc_add_items(settings.collections_db_path, collection_id, str(user.id), body.document_ids)
+    return {"added": added, "added_count": len(added)}
+
+
+@app.put("/v1/collections/{collection_id}/items/reorder")
+def reorder_collection_items(collection_id: str, body: ReorderItemsRequest, request: Request):
+    user = _get_current_user(request)
+    col = svc_get_collection(settings.collections_db_path, collection_id, str(user.id))
+    if col is None:
+        raise HTTPException(status_code=404, detail="Collection not found")
+    svc_reorder_items(settings.collections_db_path, collection_id, str(user.id), body.item_ids)
+    return {"status": "reordered"}
+
+
+@app.put("/v1/collections/{collection_id}/items/{item_id}")
+def update_collection_item(collection_id: str, item_id: str, body: UpdateItemRequest, request: Request):
+    user = _get_current_user(request)
+    if body.note is not None and len(body.note) > settings.collections_note_max_length:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Note exceeds maximum length of {settings.collections_note_max_length} characters",
+        )
+    result = svc_update_item(
+        settings.collections_db_path,
+        collection_id,
+        str(user.id),
+        item_id,
+        note=body.note,
+        position=body.position,
+        note_max_length=settings.collections_note_max_length,
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return result
+
+
+@app.delete("/v1/collections/{collection_id}/items/{item_id}", status_code=204)
+def delete_collection_item(collection_id: str, item_id: str, request: Request):
+    user = _get_current_user(request)
+    removed = svc_remove_item(settings.collections_db_path, collection_id, str(user.id), item_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return Response(status_code=204)
 
 
 if __name__ == "__main__":

--- a/src/solr-search/migrations/001_collections_init.py
+++ b/src/solr-search/migrations/001_collections_init.py
@@ -1,0 +1,57 @@
+"""Collections schema migration: creates collections and collection_items tables.
+
+This migration initialises a **separate** SQLite database for user document
+collections.  It is called by ``collections_service.init_collections_db`` on
+startup and does NOT participate in the auth migration framework.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+VERSION = 1
+DESCRIPTION = "Initial schema: collections and collection_items tables"
+
+
+def upgrade(connection: sqlite3.Connection) -> None:
+    """Create the collections schema with indexes and FK support."""
+    connection.execute("PRAGMA foreign_keys = ON")
+
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS collections (
+            id TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute("CREATE INDEX IF NOT EXISTS idx_collections_user_id ON collections (user_id)")
+
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS collection_items (
+            id TEXT PRIMARY KEY,
+            collection_id TEXT NOT NULL,
+            document_id TEXT NOT NULL,
+            position INTEGER,
+            note TEXT,
+            added_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+            UNIQUE (collection_id, document_id)
+        )
+        """
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS idx_collection_items_collection_id ON collection_items (collection_id)"
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS idx_collection_items_position ON collection_items (position)"
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS idx_collection_items_document_id ON collection_items (document_id)"
+    )

--- a/src/solr-search/pyproject.toml
+++ b/src/solr-search/pyproject.toml
@@ -23,10 +23,10 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=search_service --cov=main --cov=auth --cov=admin_auth --cov=config --cov=metrics --cov=correlation --cov=logging_config --cov=reset_password --cov=password_policy --cov-report=term-missing --cov-report=html -ra"
+addopts = "--cov=search_service --cov=main --cov=auth --cov=admin_auth --cov=config --cov=metrics --cov=correlation --cov=logging_config --cov=reset_password --cov=password_policy --cov=collections_service --cov=collections_models --cov-report=term-missing --cov-report=html -ra"
 
 [tool.coverage.run]
-source = ["search_service", "main", "auth", "admin_auth", "config", "metrics", "correlation", "logging_config", "reset_password", "password_policy"]
+source = ["search_service", "main", "auth", "admin_auth", "config", "metrics", "correlation", "logging_config", "reset_password", "password_policy", "collections_service", "collections_models"]
 omit = ["tests/*", "__pycache__/*"]
 
 [tool.coverage.report]

--- a/src/solr-search/tests/test_collections.py
+++ b/src/solr-search/tests/test_collections.py
@@ -1,0 +1,505 @@
+"""Tests for Collections CRUD API endpoints and service layer."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("AUTH_DB_PATH", "/tmp/test-auth.db")  # noqa: S108
+os.environ.setdefault("AUTH_JWT_SECRET", "test-auth-secret")
+os.environ.setdefault("AUTH_JWT_TTL", "24h")
+os.environ.setdefault("AUTH_COOKIE_NAME", "aithena_auth")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from auth import AuthenticatedUser, create_access_token, init_auth_db  # noqa: E402
+from collections_service import (  # noqa: E402
+    add_items,
+    create_collection,
+    delete_collection,
+    get_collection,
+    init_collections_db,
+    list_collections,
+    remove_item,
+    reorder_items,
+    update_collection,
+    update_item,
+)
+from config import settings  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from main import app  # noqa: E402
+
+ADMIN_USER = AuthenticatedUser(id=1, username="test-admin", role="admin")
+USER_A = AuthenticatedUser(id=10, username="alice", role="user")
+USER_B = AuthenticatedUser(id=20, username="bob", role="user")
+
+
+def _auth_header(user: AuthenticatedUser) -> dict[str, str]:
+    token = create_access_token(user, settings.auth_jwt_secret, settings.auth_jwt_ttl_seconds)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def auth_db(tmp_path: Path):
+    original = settings.auth_db_path
+    db = tmp_path / "auth.db"
+    object.__setattr__(settings, "auth_db_path", db)
+    init_auth_db(db)
+    yield db
+    object.__setattr__(settings, "auth_db_path", original)
+
+
+@pytest.fixture
+def collections_db(tmp_path: Path):
+    original = settings.collections_db_path
+    db = tmp_path / "collections.db"
+    object.__setattr__(settings, "collections_db_path", db)
+    init_collections_db(db)
+    yield db
+    object.__setattr__(settings, "collections_db_path", original)
+
+
+@pytest.fixture
+def client(auth_db, collections_db) -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Service-layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionsService:
+    def test_create_and_get(self, collections_db):
+        result = create_collection(collections_db, "10", "My Books", "My favourite reads")
+        assert result["name"] == "My Books"
+        assert result["description"] == "My favourite reads"
+        assert result["user_id"] == "10"
+        assert result["item_count"] == 0
+        assert result["id"]
+
+        detail = get_collection(collections_db, result["id"], "10")
+        assert detail is not None
+        assert detail["name"] == "My Books"
+        assert detail["items"] == []
+
+    def test_list_collections(self, collections_db):
+        create_collection(collections_db, "10", "Col A", None)
+        create_collection(collections_db, "10", "Col B", None)
+        create_collection(collections_db, "20", "Col C", None)
+
+        cols = list_collections(collections_db, "10")
+        assert len(cols) == 2
+        assert all(c["user_id"] == "10" for c in cols)
+
+    def test_update_collection(self, collections_db):
+        col = create_collection(collections_db, "10", "Original", "Desc")
+        updated = update_collection(collections_db, col["id"], "10", name="Renamed")
+        assert updated is not None
+        assert updated["name"] == "Renamed"
+
+    def test_delete_collection(self, collections_db):
+        col = create_collection(collections_db, "10", "ToDelete", None)
+        assert delete_collection(collections_db, col["id"], "10") is True
+        assert get_collection(collections_db, col["id"], "10") is None
+
+    def test_other_user_cannot_access(self, collections_db):
+        col = create_collection(collections_db, "10", "Private", None)
+        assert get_collection(collections_db, col["id"], "20") is None
+        assert update_collection(collections_db, col["id"], "20", name="Hack") is None
+        assert delete_collection(collections_db, col["id"], "20") is False
+
+    def test_add_items(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1", "doc2", "doc3"])
+        assert len(added) == 3
+        assert added[0]["position"] == 1
+        assert added[2]["position"] == 3
+
+    def test_add_items_skip_duplicates(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        add_items(collections_db, col["id"], "10", ["doc1", "doc2"])
+        added = add_items(collections_db, col["id"], "10", ["doc2", "doc3"])
+        assert len(added) == 1
+        assert added[0]["document_id"] == "doc3"
+
+    def test_add_items_other_user(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "20", ["doc1"])
+        assert added == []
+
+    def test_remove_item(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1"])
+        assert remove_item(collections_db, col["id"], "10", added[0]["id"]) is True
+        detail = get_collection(collections_db, col["id"], "10")
+        assert len(detail["items"]) == 0
+
+    def test_remove_item_not_found(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        assert remove_item(collections_db, col["id"], "10", "nonexistent") is False
+
+    def test_remove_item_other_user(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1"])
+        assert remove_item(collections_db, col["id"], "20", added[0]["id"]) is False
+
+    def test_update_item_note(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1"])
+        result = update_item(collections_db, col["id"], "10", added[0]["id"], note="Great book!")
+        assert result is not None
+        assert result["note"] == "Great book!"
+
+    def test_update_item_position(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1"])
+        result = update_item(collections_db, col["id"], "10", added[0]["id"], position=5)
+        assert result is not None
+        assert result["position"] == 5
+
+    def test_update_item_not_found(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        assert update_item(collections_db, col["id"], "10", "nonexistent", note="x") is None
+
+    def test_update_item_other_user(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1"])
+        assert update_item(collections_db, col["id"], "20", added[0]["id"], note="hack") is None
+
+    def test_update_item_note_too_long(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1"])
+        with pytest.raises(ValueError, match="exceeds maximum length"):
+            update_item(collections_db, col["id"], "10", added[0]["id"], note="x" * 1001, note_max_length=1000)
+
+    def test_reorder_items(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1", "doc2", "doc3"])
+        ids = [a["id"] for a in added]
+        assert reorder_items(collections_db, col["id"], "10", list(reversed(ids))) is True
+
+        detail = get_collection(collections_db, col["id"], "10")
+        positions = {item["id"]: item["position"] for item in detail["items"]}
+        assert positions[ids[2]] == 1
+        assert positions[ids[1]] == 2
+        assert positions[ids[0]] == 3
+
+    def test_reorder_items_other_user(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        added = add_items(collections_db, col["id"], "10", ["doc1"])
+        assert reorder_items(collections_db, col["id"], "20", [added[0]["id"]]) is False
+
+    def test_cascade_delete(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", None)
+        add_items(collections_db, col["id"], "10", ["doc1", "doc2"])
+        assert delete_collection(collections_db, col["id"], "10") is True
+        assert get_collection(collections_db, col["id"], "10") is None
+
+    def test_update_collection_no_changes(self, collections_db):
+        col = create_collection(collections_db, "10", "Books", "desc")
+        updated = update_collection(collections_db, col["id"], "10")
+        assert updated is not None
+        assert updated["name"] == "Books"
+
+    def test_delete_nonexistent(self, collections_db):
+        assert delete_collection(collections_db, "no-such-id", "10") is False
+
+    def test_update_nonexistent(self, collections_db):
+        assert update_collection(collections_db, "no-such-id", "10", name="x") is None
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionsAPI:
+    def test_create_collection(self, client):
+        resp = client.post("/v1/collections", json={"name": "Favourites"}, headers=_auth_header(USER_A))
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "Favourites"
+        assert data["user_id"] == str(USER_A.id)
+        assert data["item_count"] == 0
+
+    def test_create_collection_with_description(self, client):
+        resp = client.post(
+            "/v1/collections",
+            json={"name": "Sci-Fi", "description": "Science fiction picks"},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["description"] == "Science fiction picks"
+
+    def test_create_collection_name_too_short(self, client):
+        resp = client.post("/v1/collections", json={"name": ""}, headers=_auth_header(USER_A))
+        assert resp.status_code == 422
+
+    def test_create_collection_name_too_long(self, client):
+        resp = client.post("/v1/collections", json={"name": "x" * 256}, headers=_auth_header(USER_A))
+        assert resp.status_code == 422
+
+    def test_create_collection_description_too_long(self, client):
+        resp = client.post(
+            "/v1/collections", json={"name": "Ok", "description": "x" * 1001}, headers=_auth_header(USER_A)
+        )
+        assert resp.status_code == 422
+
+    def test_list_collections(self, client):
+        client.post("/v1/collections", json={"name": "A"}, headers=_auth_header(USER_A))
+        client.post("/v1/collections", json={"name": "B"}, headers=_auth_header(USER_A))
+        client.post("/v1/collections", json={"name": "C"}, headers=_auth_header(USER_B))
+
+        resp = client.get("/v1/collections", headers=_auth_header(USER_A))
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_get_collection(self, client):
+        create = client.post("/v1/collections", json={"name": "Mine"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+
+        resp = client.get(f"/v1/collections/{col_id}", headers=_auth_header(USER_A))
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Mine"
+        assert resp.json()["items"] == []
+
+    def test_get_other_users_collection_returns_404(self, client):
+        create = client.post("/v1/collections", json={"name": "Secret"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+
+        resp = client.get(f"/v1/collections/{col_id}", headers=_auth_header(USER_B))
+        assert resp.status_code == 404
+
+    def test_update_collection(self, client):
+        create = client.post("/v1/collections", json={"name": "Old"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+
+        resp = client.put(f"/v1/collections/{col_id}", json={"name": "New"}, headers=_auth_header(USER_A))
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "New"
+
+    def test_update_collection_no_fields(self, client):
+        create = client.post("/v1/collections", json={"name": "X"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.put(f"/v1/collections/{col_id}", json={}, headers=_auth_header(USER_A))
+        assert resp.status_code == 422
+
+    def test_update_other_users_collection_returns_404(self, client):
+        create = client.post("/v1/collections", json={"name": "X"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.put(f"/v1/collections/{col_id}", json={"name": "Hacked"}, headers=_auth_header(USER_B))
+        assert resp.status_code == 404
+
+    def test_delete_collection(self, client):
+        create = client.post("/v1/collections", json={"name": "ToDelete"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+
+        resp = client.delete(f"/v1/collections/{col_id}", headers=_auth_header(USER_A))
+        assert resp.status_code == 204
+
+        resp = client.get(f"/v1/collections/{col_id}", headers=_auth_header(USER_A))
+        assert resp.status_code == 404
+
+    def test_delete_other_users_collection_returns_404(self, client):
+        create = client.post("/v1/collections", json={"name": "X"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.delete(f"/v1/collections/{col_id}", headers=_auth_header(USER_B))
+        assert resp.status_code == 404
+
+    def test_add_items(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+
+        resp = client.post(
+            f"/v1/collections/{col_id}/items",
+            json={"document_ids": ["doc1", "doc2"]},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["added_count"] == 2
+
+    def test_add_items_skip_duplicates(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+
+        client.post(
+            f"/v1/collections/{col_id}/items", json={"document_ids": ["doc1"]}, headers=_auth_header(USER_A)
+        )
+        resp = client.post(
+            f"/v1/collections/{col_id}/items",
+            json={"document_ids": ["doc1", "doc2"]},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["added_count"] == 1
+
+    def test_add_items_to_other_users_collection(self, client):
+        create = client.post("/v1/collections", json={"name": "X"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.post(
+            f"/v1/collections/{col_id}/items", json={"document_ids": ["doc1"]}, headers=_auth_header(USER_B)
+        )
+        assert resp.status_code == 404
+
+    def test_add_items_empty_list(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.post(
+            f"/v1/collections/{col_id}/items", json={"document_ids": []}, headers=_auth_header(USER_A)
+        )
+        assert resp.status_code == 422
+
+    def test_add_items_too_many(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.post(
+            f"/v1/collections/{col_id}/items",
+            json={"document_ids": [f"doc{i}" for i in range(51)]},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 422
+
+    def test_remove_item(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        add_resp = client.post(
+            f"/v1/collections/{col_id}/items", json={"document_ids": ["doc1"]}, headers=_auth_header(USER_A)
+        )
+        item_id = add_resp.json()["added"][0]["id"]
+
+        resp = client.delete(f"/v1/collections/{col_id}/items/{item_id}", headers=_auth_header(USER_A))
+        assert resp.status_code == 204
+
+    def test_remove_item_not_found(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.delete(f"/v1/collections/{col_id}/items/nonexistent", headers=_auth_header(USER_A))
+        assert resp.status_code == 404
+
+    def test_update_item(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        add_resp = client.post(
+            f"/v1/collections/{col_id}/items", json={"document_ids": ["doc1"]}, headers=_auth_header(USER_A)
+        )
+        item_id = add_resp.json()["added"][0]["id"]
+
+        resp = client.put(
+            f"/v1/collections/{col_id}/items/{item_id}",
+            json={"note": "Amazing read"},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["note"] == "Amazing read"
+
+    def test_update_item_note_too_long(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        add_resp = client.post(
+            f"/v1/collections/{col_id}/items", json={"document_ids": ["doc1"]}, headers=_auth_header(USER_A)
+        )
+        item_id = add_resp.json()["added"][0]["id"]
+
+        resp = client.put(
+            f"/v1/collections/{col_id}/items/{item_id}",
+            json={"note": "x" * 1001},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 422
+
+    def test_update_item_not_found(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.put(
+            f"/v1/collections/{col_id}/items/nonexistent", json={"note": "x"}, headers=_auth_header(USER_A)
+        )
+        assert resp.status_code == 404
+
+    def test_reorder_items(self, client):
+        create = client.post("/v1/collections", json={"name": "Books"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        add_resp = client.post(
+            f"/v1/collections/{col_id}/items",
+            json={"document_ids": ["doc1", "doc2", "doc3"]},
+            headers=_auth_header(USER_A),
+        )
+        items = add_resp.json()["added"]
+        ids = [i["id"] for i in items]
+
+        resp = client.put(
+            f"/v1/collections/{col_id}/items/reorder",
+            json={"item_ids": list(reversed(ids))},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 200
+
+        detail = client.get(f"/v1/collections/{col_id}", headers=_auth_header(USER_A)).json()
+        positions = {item["id"]: item["position"] for item in detail["items"]}
+        assert positions[ids[2]] == 1
+
+    def test_reorder_other_users_collection(self, client):
+        create = client.post("/v1/collections", json={"name": "X"}, headers=_auth_header(USER_A))
+        col_id = create.json()["id"]
+        resp = client.put(
+            f"/v1/collections/{col_id}/items/reorder",
+            json={"item_ids": ["x"]},
+            headers=_auth_header(USER_B),
+        )
+        assert resp.status_code == 404
+
+    def test_unauthenticated_returns_401(self):
+        client = TestClient(app)
+        resp = client.get("/v1/collections")
+        assert resp.status_code == 401
+
+    def test_nonexistent_collection_returns_404(self, client):
+        resp = client.get("/v1/collections/no-such-id", headers=_auth_header(USER_A))
+        assert resp.status_code == 404
+
+    def test_delete_nonexistent_collection_returns_404(self, client):
+        resp = client.delete("/v1/collections/no-such-id", headers=_auth_header(USER_A))
+        assert resp.status_code == 404
+
+    def test_add_items_to_nonexistent_collection(self, client):
+        resp = client.post(
+            "/v1/collections/no-such-id/items",
+            json={"document_ids": ["doc1"]},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 404
+
+    def test_reorder_nonexistent_collection(self, client):
+        resp = client.put(
+            "/v1/collections/no-such-id/items/reorder",
+            json={"item_ids": ["x"]},
+            headers=_auth_header(USER_A),
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionsMigration:
+    def test_init_creates_tables(self, collections_db):
+        import sqlite3
+
+        with sqlite3.connect(collections_db) as conn:
+            tables = {
+                r[0]
+                for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+            }
+        assert "collections" in tables
+        assert "collection_items" in tables
+
+    def test_init_idempotent(self, tmp_path):
+        db = tmp_path / "coll.db"
+        init_collections_db(db)
+        init_collections_db(db)  # should not raise


### PR DESCRIPTION
## Summary

Implements the collections backend with SQLite persistence and full CRUD API for user document collections.

Closes #655

### Changes

**New files:**
- `collections_service.py` — SQLite CRUD operations for collections and items
- `collections_models.py` — Pydantic request/response models
- `migrations/001_collections_init.py` — Schema migration (collections + collection_items tables)
- `tests/test_collections.py` — 54 comprehensive tests (service + API + migration)

**Modified files:**
- `config.py` — Added `collections_db_path` and `collections_note_max_length` settings
- `main.py` — Added 9 collection endpoints + DB init in lifespan
- `pyproject.toml` — Added coverage tracking for new modules

### Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | /v1/collections | Create collection |
| GET | /v1/collections | List user's collections (with item counts) |
| GET | /v1/collections/{id} | Get collection detail with items |
| PUT | /v1/collections/{id} | Update name/description |
| DELETE | /v1/collections/{id} | Delete collection (cascades items) |
| POST | /v1/collections/{id}/items | Add documents (batch, max 50, skip duplicates) |
| PUT | /v1/collections/{id}/items/reorder | Reorder items |
| PUT | /v1/collections/{id}/items/{item_id} | Update note/position |
| DELETE | /v1/collections/{id}/items/{item_id} | Remove item |

### Security
- All endpoints require JWT authentication
- Users can only access their own collections (returns 404 for others)
- Input validation on all fields (name length, description length, note length, batch size)
- Parameterized SQL queries throughout

### Tests
- 560 tests pass (all existing + 54 new)
- 94.55% coverage (above 88% threshold)
- Lint clean (ruff)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>