### PR TITLE
feat: add collections-db Docker volume and mount for solr-search

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -244,8 +244,10 @@ services:
       - AUTH_JWT_SECRET=${AUTH_JWT_SECRET:?error Run python -m installer to generate secrets}
       - AUTH_JWT_TTL=${AUTH_JWT_TTL:-24h}
       - AUTH_COOKIE_NAME=${AUTH_COOKIE_NAME:-aithena_auth}
+      - COLLECTIONS_DB_PATH=${COLLECTIONS_DB_PATH:-/data/collections/collections.db}
     volumes:
       - document-data:/data/documents
+      - collections-db:/data/collections
       - type: bind
         source: ${AUTH_DB_DIR:?AUTH_DB_DIR is not set. Run 'python3 -m installer' to generate auth configuration}
         target: /data/auth
@@ -637,6 +639,12 @@ volumes:
       type: "none"
       o: "bind"
       device: "${BOOKS_PATH:-/data/booklibrary}"
+  collections-db:
+    driver: local
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${COLLECTIONS_DB_DIR:-/source/volumes/collections-db}"
   solr-data:
     driver: local
     driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,8 +274,10 @@ services:
       - ADMIN_API_KEY=${ADMIN_API_KEY:-}
       - RATE_LIMIT_REQUESTS_PER_MINUTE=${RATE_LIMIT_REQUESTS_PER_MINUTE:-100}
       - ZOOKEEPER_HOSTS=zoo1:2181,zoo2:2181,zoo3:2181
+      - COLLECTIONS_DB_PATH=${COLLECTIONS_DB_PATH:-/data/collections/collections.db}
     volumes:
       - document-data:/data/documents
+      - collections-db:/data/collections
       - type: bind
         source: ${AUTH_DB_DIR:?AUTH_DB_DIR is not set. Run 'python3 -m installer' to generate auth configuration}
         target: /data/auth
@@ -743,6 +745,12 @@ volumes:
       type: "none"
       o: "bind"
       device: "${BOOKS_PATH:-/data/booklibrary}"
+  collections-db:
+    driver: local
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${COLLECTIONS_DB_DIR:-/source/volumes/collections-db}"
   solr-data:
     driver: local
     driver_opts:


### PR DESCRIPTION
## Summary

Add Docker infrastructure for the user collections SQLite database (PRD: `docs/prd/user-document-collections.md` §3.2, §5.2).

### Changes

**`docker-compose.yml` and `docker-compose.prod.yml`:**

1. **New named volume `collections-db`** — bind-mounted to host path `${COLLECTIONS_DB_DIR:-/source/volumes/collections-db}`, following the same pattern as `redis-data`, `solr-data`, etc.
2. **Volume mount on `solr-search` service** — `collections-db:/data/collections` so the collections SQLite database is persisted across container restarts.
3. **New environment variable `COLLECTIONS_DB_PATH`** — set on `solr-search` with default `/data/collections/collections.db`, matching the default already in `config.py` (added in #711).

### Verification

- `config.py` already reads `COLLECTIONS_DB_PATH` (line 134, added in #711)
- YAML validated with `python3 -c "import yaml; yaml.safe_load(open(...))"` (no Docker daemon available)
- `docker-compose.override.yml` inherits the volume from the base file — no changes needed there

### Not included

- `docker-compose.e2e.yml` — E2E tests don't exercise collections yet; volume will be inherited from base compose when needed

Closes #670
