### PR TITLE
feat: enforce release pipeline — validate tags on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,22 +43,16 @@ jobs:
           echo "Validating that tag $TAG_NAME ($TAG_SHA) is on the main branch..."
 
           # Use GitHub API to check if main branch contains the tagged commit
-          status_code=$(curl -s -o /dev/null -w '%{http_code}' \
+          compare_json=$(curl -sf \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/compare/main...$TAG_SHA")
-
-          if [ "$status_code" != "200" ]; then
-            echo "::error::Failed to query GitHub API (HTTP $status_code). Cannot verify tag branch."
+            "https://api.github.com/repos/$REPO/compare/main...$TAG_SHA" 2>/dev/null) || {
+            echo "::error::Failed to query GitHub API. Cannot verify tag branch."
             exit 1
-          fi
+          }
 
           # "behind" or "identical" means the tag commit is reachable from main
-          ahead_by=$(curl -s \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/compare/main...$TAG_SHA" \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['ahead_by'])")
+          ahead_by=$(echo "$compare_json" | python3 -c "import sys,json; print(json.load(sys.stdin)['ahead_by'])")
 
           if [ "$ahead_by" != "0" ]; then
             echo "::error::Tag $TAG_NAME points to a commit that is $ahead_by commit(s) ahead of main."

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -55,8 +55,8 @@ After the PR is merged to `main`, a semver tag is created on `main`:
 ```bash
 git checkout main
 git pull origin main
-git tag v1.X.0
-git push origin v1.X.0
+git tag v1.2.3
+git push origin v1.2.3
 ```
 
 - **CI trigger:** Tag push matching `v*.*.*` runs **release.yml**
@@ -82,7 +82,7 @@ This prevents accidental releases from `dev` or feature branches.
 
 ### Integration tests required for `main`
 
-PRs targeting `main` trigger the integration-test workflow, which runs the full E2E suite. This is a required check — PRs cannot be merged to `main` without passing integration tests.
+PRs targeting `main` trigger the integration-test workflow, which runs the full E2E suite. This must be configured as a required status check in GitHub branch protection settings — PRs cannot be merged to `main` without passing integration tests.
 
 ### No direct pushes to `main`
 


### PR DESCRIPTION
Closes #687

## Changes

### release.yml — Main branch validation
Added a new **Validate tag exists on main branch** step to the `validate-tag` job. Uses the GitHub API (`/compare/main...TAG_SHA`) to verify the tagged commit is reachable from `main`. If the tag is on any other branch, the workflow fails with a clear error message explaining the required pipeline: `dev → main → tag`.

### docs/release-pipeline.md
Documents the full release pipeline:
1. **dev**: feature branches + ci.yml (unit tests)
2. **Release prep PR to dev**: VERSION bump + CHANGELOG
3. **PR dev → main**: ci.yml + integration-test.yml (E2E)
4. **Tag on main**: release.yml (build + publish)

Includes enforcement rules, quick reference table, and related files.

Working as Kane (Security Engineer) — CI/CD supply chain hardening.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>