### PR TITLE
feat: backup/restore API endpoints

### DIFF
--- a/src/solr-search/backup_service.py
+++ b/src/solr-search/backup_service.py
@@ -1,0 +1,441 @@
+"""Backup/Restore management service for Aithena BCDR.
+
+Provides in-memory state tracking for backup and restore operations,
+backup inventory scanning, and subprocess execution for backup scripts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import threading
+import uuid
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("aithena.backup")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_TIERS = frozenset({"critical", "high", "medium", "all"})
+BACKUP_BASE_DIR = Path(os.environ.get("BACKUP_DEST", "/source/backups"))
+SCRIPTS_DIR = Path(os.environ.get("BACKUP_SCRIPTS_DIR", "/source/aithena/scripts"))
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Models
+# ---------------------------------------------------------------------------
+
+
+class BackupTier(Enum):
+    critical = "critical"
+    high = "high"
+    medium = "medium"
+    all = "all"
+
+
+class OperationStatus(Enum):
+    in_progress = "in_progress"
+    completed = "completed"
+    failed = "failed"
+
+
+class BackupRequest(BaseModel):
+    tier: BackupTier = BackupTier.all
+    dry_run: bool = False
+
+
+class RestoreRequest(BaseModel):
+    backup_id: str
+    dry_run: bool = False
+
+
+class BackupInfo(BaseModel):
+    id: str
+    tier: str
+    timestamp: str
+    path: str
+    size_bytes: int = 0
+    files: list[str] = Field(default_factory=list)
+
+
+class OperationRecord(BaseModel):
+    id: str
+    operation: str  # "backup" or "restore"
+    tier: str
+    status: OperationStatus
+    started_at: str
+    finished_at: str | None = None
+    dry_run: bool = False
+    error: str | None = None
+    backup_id: str | None = None
+
+
+class BackupStatusResponse(BaseModel):
+    tiers: dict[str, dict[str, Any]]
+
+
+class BackupListResponse(BaseModel):
+    backups: list[BackupInfo]
+    total: int
+
+
+class BackupConfigRequest(BaseModel):
+    retention_days: int | None = None
+    tier: BackupTier | None = None
+
+
+class BackupConfig(BaseModel):
+    retention_days: int = 7
+    backup_base_dir: str = str(BACKUP_BASE_DIR)
+    scripts_dir: str = str(SCRIPTS_DIR)
+
+
+# ---------------------------------------------------------------------------
+# In-memory operation tracking
+# ---------------------------------------------------------------------------
+
+_lock = threading.Lock()
+_operations: dict[str, OperationRecord] = {}
+_config = BackupConfig()
+
+
+def _record_operation(record: OperationRecord) -> None:
+    with _lock:
+        _operations[record.id] = record
+
+
+def get_operation(operation_id: str) -> OperationRecord | None:
+    with _lock:
+        return _operations.get(operation_id)
+
+
+def list_operations(
+    operation_type: str | None = None,
+    limit: int = 50,
+) -> list[OperationRecord]:
+    with _lock:
+        ops = list(_operations.values())
+    if operation_type:
+        ops = [o for o in ops if o.operation == operation_type]
+    ops.sort(key=lambda o: o.started_at, reverse=True)
+    return ops[:limit]
+
+
+def get_config() -> BackupConfig:
+    with _lock:
+        return _config.model_copy()
+
+
+def update_config(updates: BackupConfigRequest) -> BackupConfig:
+    global _config  # noqa: PLW0603
+    with _lock:
+        data = _config.model_dump()
+        if updates.retention_days is not None:
+            data["retention_days"] = updates.retention_days
+        _config = BackupConfig(**data)
+        return _config.model_copy()
+
+
+# ---------------------------------------------------------------------------
+# Backup directory scanning
+# ---------------------------------------------------------------------------
+
+_TIMESTAMP_PATTERN = re.compile(r"(\d{8}-\d{4})")
+
+
+def _dir_size(path: Path) -> int:
+    """Return total size in bytes of all files under *path*."""
+    total = 0
+    if path.is_file():
+        return path.stat().st_size
+    if path.is_dir():
+        for f in path.rglob("*"):
+            if f.is_file():
+                total += f.stat().st_size
+    return total
+
+
+def _list_files(path: Path) -> list[str]:
+    """Return relative file paths under *path*."""
+    if path.is_file():
+        return [path.name]
+    if path.is_dir():
+        return sorted(str(f.relative_to(path)) for f in path.rglob("*") if f.is_file())
+    return []
+
+
+def scan_backups(base_dir: Path | None = None) -> list[BackupInfo]:
+    """Scan backup directories and return inventory of available backups."""
+    base = base_dir or Path(get_config().backup_base_dir)
+    backups: list[BackupInfo] = []
+
+    for tier in ("critical", "high", "medium"):
+        tier_dir = base / tier
+        if not tier_dir.is_dir():
+            continue
+
+        for entry in sorted(tier_dir.iterdir(), reverse=True):
+            if entry.name.startswith("."):
+                continue
+            match = _TIMESTAMP_PATTERN.search(entry.name)
+            timestamp = match.group(1) if match else entry.name
+            backup_id = f"{tier}-{entry.name}"
+            backups.append(
+                BackupInfo(
+                    id=backup_id,
+                    tier=tier,
+                    timestamp=timestamp,
+                    path=str(entry),
+                    size_bytes=_dir_size(entry),
+                    files=_list_files(entry),
+                )
+            )
+
+    backups.sort(key=lambda b: b.timestamp, reverse=True)
+    return backups
+
+
+def get_backup_by_id(backup_id: str, base_dir: Path | None = None) -> BackupInfo | None:
+    """Find a specific backup by its ID."""
+    for backup in scan_backups(base_dir):
+        if backup.id == backup_id:
+            return backup
+    return None
+
+
+def get_tier_status(base_dir: Path | None = None) -> dict[str, dict[str, Any]]:
+    """Return per-tier status summary: last backup, count, total size."""
+    all_backups = scan_backups(base_dir)
+    result: dict[str, dict[str, Any]] = {}
+
+    for tier in ("critical", "high", "medium"):
+        tier_backups = [b for b in all_backups if b.tier == tier]
+        last = tier_backups[0] if tier_backups else None
+
+        last_op = None
+        with _lock:
+            for op in sorted(_operations.values(), key=lambda o: o.started_at, reverse=True):
+                if op.tier == tier and op.operation == "backup":
+                    last_op = op
+                    break
+
+        result[tier] = {
+            "backup_count": len(tier_backups),
+            "total_size_bytes": sum(b.size_bytes for b in tier_backups),
+            "last_backup_timestamp": last.timestamp if last else None,
+            "last_operation_status": last_op.status.value if last_op else None,
+            "last_operation_id": last_op.id if last_op else None,
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Subprocess execution
+# ---------------------------------------------------------------------------
+
+
+async def run_backup(tier: BackupTier, dry_run: bool = False) -> OperationRecord:
+    """Trigger a backup subprocess and track its progress."""
+    operation_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+
+    record = OperationRecord(
+        id=operation_id,
+        operation="backup",
+        tier=tier.value,
+        status=OperationStatus.in_progress,
+        started_at=now,
+        dry_run=dry_run,
+    )
+    _record_operation(record)
+
+    asyncio.create_task(_execute_backup(operation_id, tier, dry_run))
+    return record
+
+
+async def _execute_backup(operation_id: str, tier: BackupTier, dry_run: bool) -> None:
+    """Execute the backup script as a subprocess."""
+    config = get_config()
+    script = Path(config.scripts_dir) / "backup.sh"
+
+    cmd = [str(script), "--tier", tier.value]
+    if dry_run:
+        cmd.append("--dry-run")
+
+    env = {**os.environ, "BACKUP_DEST": config.backup_base_dir}
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await process.communicate()
+
+        now = datetime.now(UTC).isoformat()
+        with _lock:
+            record = _operations[operation_id]
+            if process.returncode == 0:
+                updated = record.model_copy(
+                    update={"status": OperationStatus.completed, "finished_at": now}
+                )
+            else:
+                error_msg = stderr.decode(errors="replace").strip() or f"Exit code {process.returncode}"
+                updated = record.model_copy(
+                    update={
+                        "status": OperationStatus.failed,
+                        "finished_at": now,
+                        "error": error_msg[:500],
+                    }
+                )
+            _operations[operation_id] = updated
+
+        logger.info("Backup %s finished: %s", operation_id, updated.status.value)
+
+    except Exception as exc:
+        now = datetime.now(UTC).isoformat()
+        with _lock:
+            record = _operations[operation_id]
+            _operations[operation_id] = record.model_copy(
+                update={
+                    "status": OperationStatus.failed,
+                    "finished_at": now,
+                    "error": str(exc)[:500],
+                }
+            )
+        logger.exception("Backup %s failed with exception", operation_id)
+
+
+async def run_restore(backup_id: str, dry_run: bool = False) -> OperationRecord:
+    """Trigger a restore subprocess and track its progress."""
+    backup = get_backup_by_id(backup_id)
+    if backup is None:
+        raise ValueError(f"Backup not found: {backup_id}")
+
+    operation_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+
+    record = OperationRecord(
+        id=operation_id,
+        operation="restore",
+        tier=backup.tier,
+        status=OperationStatus.in_progress,
+        started_at=now,
+        dry_run=dry_run,
+        backup_id=backup_id,
+    )
+    _record_operation(record)
+
+    asyncio.create_task(_execute_restore(operation_id, backup, dry_run))
+    return record
+
+
+async def _execute_restore(operation_id: str, backup: BackupInfo, dry_run: bool) -> None:
+    """Execute the appropriate restore script as a subprocess."""
+    config = get_config()
+    script_name = f"restore-{backup.tier}.sh"
+    script = Path(config.scripts_dir) / script_name
+
+    if not script.exists():
+        script = Path(config.scripts_dir) / "restore.sh"
+
+    env = {
+        **os.environ,
+        "BACKUP_DEST": config.backup_base_dir,
+        "RESTORE_SOURCE": backup.path,
+    }
+    if dry_run:
+        env["DRY_RUN"] = "1"
+
+    cmd = [str(script)]
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await process.communicate()
+
+        now = datetime.now(UTC).isoformat()
+        with _lock:
+            record = _operations[operation_id]
+            if process.returncode == 0:
+                updated = record.model_copy(
+                    update={"status": OperationStatus.completed, "finished_at": now}
+                )
+            else:
+                error_msg = stderr.decode(errors="replace").strip() or f"Exit code {process.returncode}"
+                updated = record.model_copy(
+                    update={
+                        "status": OperationStatus.failed,
+                        "finished_at": now,
+                        "error": error_msg[:500],
+                    }
+                )
+            _operations[operation_id] = updated
+
+        logger.info("Restore %s finished: %s", operation_id, updated.status.value)
+
+    except Exception as exc:
+        now = datetime.now(UTC).isoformat()
+        with _lock:
+            record = _operations[operation_id]
+            _operations[operation_id] = record.model_copy(
+                update={
+                    "status": OperationStatus.failed,
+                    "finished_at": now,
+                    "error": str(exc)[:500],
+                }
+            )
+        logger.exception("Restore %s failed with exception", operation_id)
+
+
+async def run_test_restore(dry_run: bool = True) -> OperationRecord:
+    """Run an automated restore drill using the most recent backup."""
+    backups = scan_backups()
+    if not backups:
+        raise ValueError("No backups available for test restore")
+
+    latest = backups[0]
+    operation_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+
+    record = OperationRecord(
+        id=operation_id,
+        operation="test-restore",
+        tier=latest.tier,
+        status=OperationStatus.in_progress,
+        started_at=now,
+        dry_run=True,
+        backup_id=latest.id,
+    )
+    _record_operation(record)
+
+    asyncio.create_task(_execute_restore(operation_id, latest, dry_run=True))
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_state() -> None:
+    """Clear all in-memory state. Only for testing."""
+    global _config  # noqa: PLW0603
+    with _lock:
+        _operations.clear()
+        _config = BackupConfig()

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -40,6 +40,27 @@ from auth import (
     set_auth_cookie,
     update_user,
 )
+from backup_service import (
+    BackupConfigRequest,
+    BackupInfo,
+    BackupListResponse,
+    BackupRequest,
+    BackupStatusResponse,
+    OperationRecord,
+    RestoreRequest,
+    get_backup_by_id,
+    get_tier_status,
+    run_backup,
+    run_restore,
+    run_test_restore,
+    scan_backups,
+)
+from backup_service import (
+    get_config as get_backup_config,
+)
+from backup_service import (
+    update_config as update_backup_config,
+)
 from circuit_breaker import CircuitBreaker, CircuitOpenError, CircuitState
 from collections_models import (
     AddItemsRequest,
@@ -2450,6 +2471,162 @@ def delete_collection_item(collection_id: str, item_id: str, request: Request):
     if not removed:
         raise HTTPException(status_code=404, detail="Item not found")
     return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Backup / Restore Admin Endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get(
+    "/v1/admin/backups/",
+    include_in_schema=False,
+    name="admin_backups_list_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get(
+    "/v1/admin/backups",
+    include_in_schema=False,
+    name="admin_backups_list_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_list_backups() -> BackupListResponse:
+    """List all available backups across tiers."""
+    backups = scan_backups()
+    return BackupListResponse(backups=backups, total=len(backups))
+
+
+@app.post(
+    "/v1/admin/backups/",
+    include_in_schema=False,
+    name="admin_backups_trigger_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.post(
+    "/v1/admin/backups",
+    include_in_schema=False,
+    name="admin_backups_trigger_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+async def admin_trigger_backup(body: BackupRequest) -> OperationRecord:
+    """Trigger an immediate backup of the specified tier."""
+    record = await run_backup(tier=body.tier, dry_run=body.dry_run)
+    return record
+
+
+@app.get(
+    "/v1/admin/backups/status/",
+    include_in_schema=False,
+    name="admin_backups_status_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get(
+    "/v1/admin/backups/status",
+    include_in_schema=False,
+    name="admin_backups_status_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_backup_status() -> BackupStatusResponse:
+    """Return per-tier backup status summary."""
+    return BackupStatusResponse(tiers=get_tier_status())
+
+
+@app.get(
+    "/v1/admin/backups/config/",
+    include_in_schema=False,
+    name="admin_backups_config_get_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get(
+    "/v1/admin/backups/config",
+    include_in_schema=False,
+    name="admin_backups_config_get_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_get_backup_config() -> dict[str, Any]:
+    """Return current backup configuration."""
+    return get_backup_config().model_dump()
+
+
+@app.put(
+    "/v1/admin/backups/config/",
+    include_in_schema=False,
+    name="admin_backups_config_update_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.put(
+    "/v1/admin/backups/config",
+    include_in_schema=False,
+    name="admin_backups_config_update_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_update_backup_config(body: BackupConfigRequest) -> dict[str, Any]:
+    """Update backup schedule/retention settings."""
+    updated = update_backup_config(body)
+    return updated.model_dump()
+
+
+@app.post(
+    "/v1/admin/backups/test-restore/",
+    include_in_schema=False,
+    name="admin_backups_test_restore_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.post(
+    "/v1/admin/backups/test-restore",
+    include_in_schema=False,
+    name="admin_backups_test_restore_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+async def admin_test_restore() -> OperationRecord:
+    """Run an automated restore drill using the most recent backup."""
+    try:
+        record = await run_test_restore()
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return record
+
+
+@app.get(
+    "/v1/admin/backups/{backup_id}/",
+    include_in_schema=False,
+    name="admin_backup_detail_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get(
+    "/v1/admin/backups/{backup_id}",
+    include_in_schema=False,
+    name="admin_backup_detail_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_backup_detail(backup_id: str) -> BackupInfo:
+    """Return details for a specific backup."""
+    backup = get_backup_by_id(backup_id)
+    if backup is None:
+        raise HTTPException(status_code=404, detail=f"Backup not found: {backup_id}")
+    return backup
+
+
+@app.post(
+    "/v1/admin/backups/{backup_id}/restore/",
+    include_in_schema=False,
+    name="admin_backup_restore_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.post(
+    "/v1/admin/backups/{backup_id}/restore",
+    include_in_schema=False,
+    name="admin_backup_restore_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+async def admin_restore_backup(backup_id: str, body: RestoreRequest | None = None) -> OperationRecord:
+    """Start a restore for the specified backup."""
+    dry_run = body.dry_run if body else False
+    try:
+        record = await run_restore(backup_id=backup_id, dry_run=dry_run)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return record
 
 
 if __name__ == "__main__":

--- a/src/solr-search/pyproject.toml
+++ b/src/solr-search/pyproject.toml
@@ -23,10 +23,10 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=search_service --cov=main --cov=auth --cov=admin_auth --cov=config --cov=metrics --cov=correlation --cov=logging_config --cov=reset_password --cov=password_policy --cov=collections_service --cov=collections_models --cov-report=term-missing --cov-report=html -ra"
+addopts = "--cov=search_service --cov=main --cov=auth --cov=admin_auth --cov=config --cov=metrics --cov=correlation --cov=logging_config --cov=reset_password --cov=password_policy --cov=collections_service --cov=collections_models --cov=backup_service --cov-report=term-missing --cov-report=html -ra"
 
 [tool.coverage.run]
-source = ["search_service", "main", "auth", "admin_auth", "config", "metrics", "correlation", "logging_config", "reset_password", "password_policy", "collections_service", "collections_models"]
+source = ["search_service", "main", "auth", "admin_auth", "config", "metrics", "correlation", "logging_config", "reset_password", "password_policy", "collections_service", "collections_models", "backup_service"]
 omit = ["tests/*", "__pycache__/*"]
 
 [tool.coverage.report]

--- a/src/solr-search/tests/test_backup_service.py
+++ b/src/solr-search/tests/test_backup_service.py
@@ -1,0 +1,363 @@
+"""Tests for backup/restore API endpoints and backup_service module."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("AUTH_DB_PATH", "/tmp/test-auth.db")  # noqa: S108
+os.environ.setdefault("AUTH_JWT_SECRET", "test-auth-secret")
+os.environ.setdefault("AUTH_JWT_TTL", "24h")
+os.environ.setdefault("AUTH_COOKIE_NAME", "aithena_auth")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import backup_service  # noqa: E402
+import pytest  # noqa: E402
+from backup_service import (  # noqa: E402
+    BackupConfig,
+    BackupConfigRequest,
+    BackupTier,
+    OperationRecord,
+    OperationStatus,
+    _reset_state,
+    get_backup_by_id,
+    get_config,
+    get_tier_status,
+    list_operations,
+    scan_backups,
+    update_config,
+)
+
+from tests.auth_helpers import create_authenticated_client  # noqa: E402
+
+ADMIN_API_KEY = "test-backup-admin-key"
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Reset backup service state before each test."""
+    _reset_state()
+    yield
+    _reset_state()
+
+
+@pytest.fixture()
+def client():
+    """Return an authenticated TestClient with admin API key."""
+    with patch("admin_auth._get_admin_api_key", return_value=ADMIN_API_KEY):
+        c = create_authenticated_client()
+        c.headers["x-api-key"] = ADMIN_API_KEY
+        yield c
+
+
+@pytest.fixture()
+def backup_tree(tmp_path: Path):
+    """Create a fake backup directory tree for scanning."""
+    for tier in ("critical", "high", "medium"):
+        tier_dir = tmp_path / tier
+        tier_dir.mkdir()
+        for i, ts in enumerate(["20240115-0200", "20240116-0200"]):
+            entry = tier_dir / ts
+            entry.mkdir()
+            (entry / f"backup-{tier}-{i}.dat").write_text(f"data-{tier}-{i}")
+    return tmp_path
+
+
+class TestScanBackups:
+    def test_empty_dir(self, tmp_path: Path):
+        assert scan_backups(tmp_path) == []
+
+    def test_scans_tiers(self, backup_tree: Path):
+        backups = scan_backups(backup_tree)
+        assert len(backups) == 6
+
+    def test_backup_has_correct_fields(self, backup_tree: Path):
+        backups = scan_backups(backup_tree)
+        b = backups[0]
+        assert b.tier in ("critical", "high", "medium")
+        assert b.id.startswith(f"{b.tier}-")
+        assert b.size_bytes > 0
+        assert len(b.files) > 0
+
+    def test_sorted_by_timestamp_descending(self, backup_tree: Path):
+        backups = scan_backups(backup_tree)
+        timestamps = [b.timestamp for b in backups]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_hidden_dirs_excluded(self, backup_tree: Path):
+        (backup_tree / "critical" / ".hidden-backup").mkdir()
+        backups = scan_backups(backup_tree)
+        assert not any(".hidden" in b.id for b in backups)
+
+
+class TestGetBackupById:
+    def test_found(self, backup_tree: Path):
+        backups = scan_backups(backup_tree)
+        target = backups[0]
+        result = get_backup_by_id(target.id, backup_tree)
+        assert result is not None
+        assert result.id == target.id
+
+    def test_not_found(self, backup_tree: Path):
+        assert get_backup_by_id("nonexistent-backup", backup_tree) is None
+
+
+class TestTierStatus:
+    def test_returns_all_tiers(self, backup_tree: Path):
+        status = get_tier_status(backup_tree)
+        assert set(status.keys()) == {"critical", "high", "medium"}
+
+    def test_tier_counts(self, backup_tree: Path):
+        status = get_tier_status(backup_tree)
+        for tier_info in status.values():
+            assert tier_info["backup_count"] == 2
+
+    def test_empty_dir(self, tmp_path: Path):
+        status = get_tier_status(tmp_path)
+        for tier_info in status.values():
+            assert tier_info["backup_count"] == 0
+            assert tier_info["last_backup_timestamp"] is None
+
+
+class TestOperationTracking:
+    def test_list_operations_empty(self):
+        assert list_operations() == []
+
+    def test_record_and_list(self):
+        record = OperationRecord(
+            id="op-1",
+            operation="backup",
+            tier="critical",
+            status=OperationStatus.completed,
+            started_at="2024-01-15T02:00:00Z",
+            finished_at="2024-01-15T02:01:00Z",
+        )
+        backup_service._record_operation(record)
+        ops = list_operations()
+        assert len(ops) == 1
+        assert ops[0].id == "op-1"
+
+    def test_filter_by_type(self):
+        backup_service._record_operation(
+            OperationRecord(
+                id="op-b", operation="backup", tier="high",
+                status=OperationStatus.completed, started_at="2024-01-15T02:00:00Z",
+            )
+        )
+        backup_service._record_operation(
+            OperationRecord(
+                id="op-r", operation="restore", tier="high",
+                status=OperationStatus.completed, started_at="2024-01-15T03:00:00Z",
+            )
+        )
+        assert len(list_operations("backup")) == 1
+        assert len(list_operations("restore")) == 1
+
+
+class TestConfig:
+    def test_default_config(self):
+        config = get_config()
+        assert config.retention_days == 7
+
+    def test_update_retention(self):
+        updated = update_config(BackupConfigRequest(retention_days=30))
+        assert updated.retention_days == 30
+        assert get_config().retention_days == 30
+
+    def test_partial_update(self):
+        update_config(BackupConfigRequest(retention_days=14))
+        updated = update_config(BackupConfigRequest(tier=BackupTier.critical))
+        assert updated.retention_days == 14
+
+
+class TestListBackupsEndpoint:
+    def test_returns_200(self, client, backup_tree):
+        with patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(backup_tree))):
+            resp = client.get("/v1/admin/backups")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "backups" in data
+        assert "total" in data
+        assert data["total"] == 6
+
+    def test_empty(self, client, tmp_path):
+        with patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(tmp_path))):
+            resp = client.get("/v1/admin/backups")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    def test_requires_admin_api_key(self):
+        with patch("admin_auth._get_admin_api_key", return_value=ADMIN_API_KEY):
+            c = create_authenticated_client()
+            resp = c.get("/v1/admin/backups")
+        assert resp.status_code == 401
+
+
+class TestTriggerBackupEndpoint:
+    def test_returns_operation_record(self, client):
+        with patch("main.run_backup", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = OperationRecord(
+                id="op-123",
+                operation="backup",
+                tier="all",
+                status=OperationStatus.in_progress,
+                started_at="2024-01-15T02:00:00Z",
+            )
+            resp = client.post("/v1/admin/backups", json={"tier": "all"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "op-123"
+        assert data["status"] == "in_progress"
+
+    def test_invalid_tier(self, client):
+        resp = client.post("/v1/admin/backups", json={"tier": "invalid"})
+        assert resp.status_code == 422
+
+    def test_dry_run(self, client):
+        with patch("main.run_backup", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = OperationRecord(
+                id="op-dry",
+                operation="backup",
+                tier="critical",
+                status=OperationStatus.in_progress,
+                started_at="2024-01-15T02:00:00Z",
+                dry_run=True,
+            )
+            resp = client.post("/v1/admin/backups", json={"tier": "critical", "dry_run": True})
+        assert resp.status_code == 200
+        assert resp.json()["dry_run"] is True
+
+
+class TestBackupStatusEndpoint:
+    def test_returns_tier_status(self, client, backup_tree):
+        with patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(backup_tree))):
+            resp = client.get("/v1/admin/backups/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "tiers" in data
+        assert set(data["tiers"].keys()) == {"critical", "high", "medium"}
+
+
+class TestBackupDetailEndpoint:
+    def test_found(self, client, backup_tree):
+        with patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(backup_tree))):
+            list_resp = client.get("/v1/admin/backups")
+            backup_id = list_resp.json()["backups"][0]["id"]
+            resp = client.get(f"/v1/admin/backups/{backup_id}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == backup_id
+
+    def test_not_found(self, client, tmp_path):
+        with patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(tmp_path))):
+            resp = client.get("/v1/admin/backups/nonexistent-id")
+        assert resp.status_code == 404
+
+
+class TestRestoreEndpoint:
+    def test_returns_operation_record(self, client, backup_tree):
+        with (
+            patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(backup_tree))),
+            patch("main.run_restore", new_callable=AsyncMock) as mock_run,
+        ):
+            mock_run.return_value = OperationRecord(
+                id="op-restore-1",
+                operation="restore",
+                tier="critical",
+                status=OperationStatus.in_progress,
+                started_at="2024-01-15T03:00:00Z",
+                backup_id="critical-20240116-0200",
+            )
+            resp = client.post(
+                "/v1/admin/backups/critical-20240116-0200/restore",
+                json={"backup_id": "critical-20240116-0200"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["operation"] == "restore"
+
+    def test_not_found(self, client, tmp_path):
+        with (
+            patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(tmp_path))),
+            patch(
+                "main.run_restore",
+                new_callable=AsyncMock,
+                side_effect=ValueError("Backup not found: bad-id"),
+            ),
+        ):
+            resp = client.post(
+                "/v1/admin/backups/bad-id/restore",
+                json={"backup_id": "bad-id"},
+            )
+        assert resp.status_code == 404
+
+
+class TestBackupConfigEndpoint:
+    def test_get_config(self, client):
+        resp = client.get("/v1/admin/backups/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "retention_days" in data
+
+    def test_update_config(self, client):
+        resp = client.put("/v1/admin/backups/config", json={"retention_days": 30})
+        assert resp.status_code == 200
+        assert resp.json()["retention_days"] == 30
+
+
+class TestTestRestoreEndpoint:
+    def test_returns_operation(self, client, backup_tree):
+        with (
+            patch.object(backup_service, "_config", BackupConfig(backup_base_dir=str(backup_tree))),
+            patch("main.run_test_restore", new_callable=AsyncMock) as mock_run,
+        ):
+            mock_run.return_value = OperationRecord(
+                id="op-test-1",
+                operation="test-restore",
+                tier="critical",
+                status=OperationStatus.in_progress,
+                started_at="2024-01-15T04:00:00Z",
+                dry_run=True,
+            )
+            resp = client.post("/v1/admin/backups/test-restore")
+        assert resp.status_code == 200
+        assert resp.json()["operation"] == "test-restore"
+
+    def test_no_backups_returns_404(self, client, tmp_path):
+        with patch(
+            "main.run_test_restore",
+            new_callable=AsyncMock,
+            side_effect=ValueError("No backups available for test restore"),
+        ):
+            resp = client.post("/v1/admin/backups/test-restore")
+        assert resp.status_code == 404
+
+
+class TestAuthRequired:
+    """All backup endpoints require admin API key auth."""
+
+    ENDPOINTS = [
+        ("GET", "/v1/admin/backups"),
+        ("POST", "/v1/admin/backups"),
+        ("GET", "/v1/admin/backups/status"),
+        ("GET", "/v1/admin/backups/config"),
+        ("PUT", "/v1/admin/backups/config"),
+        ("POST", "/v1/admin/backups/test-restore"),
+        ("GET", "/v1/admin/backups/some-id"),
+        ("POST", "/v1/admin/backups/some-id/restore"),
+    ]
+
+    @pytest.mark.parametrize("method,path", ENDPOINTS)
+    def test_returns_403_when_api_key_not_configured(self, method, path):
+        with patch("admin_auth._get_admin_api_key", return_value=None):
+            c = create_authenticated_client()
+            resp = getattr(c, method.lower())(path)
+        assert resp.status_code == 403
+
+    @pytest.mark.parametrize("method,path", ENDPOINTS)
+    def test_returns_401_without_api_key_header(self, method, path):
+        with patch("admin_auth._get_admin_api_key", return_value=ADMIN_API_KEY):
+            c = create_authenticated_client()
+            resp = getattr(c, method.lower())(path)
+        assert resp.status_code == 401


### PR DESCRIPTION
Closes #676

## Summary
Implements the backup management REST API in `src/solr-search/backup_service.py` per the issue spec.

Working as **Brett** (backend developer).

## API Endpoints (all admin-auth protected)

| Method | Endpoint | Purpose |
|--------|----------|---------|
| `GET` | `/v1/admin/backups` | List all available backups with timestamps, sizes, components |
| `POST` | `/v1/admin/backups` | Trigger immediate backup of selected tier |
| `GET` | `/v1/admin/backups/{id}` | Backup details: creation time, size, file list |
| `POST` | `/v1/admin/backups/{id}/restore` | Start restore for selected backup |
| `GET` | `/v1/admin/backups/status` | Current backup status per tier |
| `GET/PUT` | `/v1/admin/backups/config` | Get/update backup settings |
| `POST` | `/v1/admin/backups/test-restore` | Run automated restore drill |

## Implementation Details
- New `backup_service.py` module with Pydantic models, backup directory scanning, async subprocess execution, and in-memory operation tracking
- Backup/restore operations run as `asyncio` background tasks (non-blocking)
- Scans `/source/backups/{critical,high,medium}/` directories for inventory
- All endpoints use `include_in_schema=False` and `Depends(require_admin_auth)` per project conventions
- 47 new tests (unit + endpoint + auth enforcement)
- All 770 tests pass, 91.57% coverage (threshold: 88%)

## Files Changed
- `src/solr-search/backup_service.py` — new service module
- `src/solr-search/main.py` — backup endpoint routes + imports
- `src/solr-search/pyproject.toml` — coverage config for new module
- `src/solr-search/tests/test_backup_service.py` — 47 tests
