### PR TITLE
fix: strip control characters in pre-release log analyzer JSON

### DIFF
--- a/e2e/pre-release-check.sh
+++ b/e2e/pre-release-check.sh
@@ -71,7 +71,7 @@ fi
 
 # JSON escaping helper — escapes backslash, double quotes, and control chars
 json_escape() {
-  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | tr '\n' ' '
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | tr -d '\000-\011\013-\037' | tr '\n' ' '
 }
 
 # Extract service name from a Docker Compose log line (format: "service-name  | ...")


### PR DESCRIPTION
Fixes integration test failure caused by control characters in Docker Compose logs breaking JSON parsing in the pre-release log analyzer.

**Root cause:** `json_escape()` in `e2e/pre-release-check.sh` only escaped backslashes, quotes, tabs, and newlines. Application logs can contain ANSI escape sequences (`\x1b`), carriage returns (`\r`), and other control chars that are invalid in JSON strings.

**Fix:** Added `tr -d '\000-\011\013-\037'` to strip all control characters before JSON output.

**Blocking:** Release v1.10.0 merge to main (integration test must pass).