### PR TITLE
fix: pass ADMIN_API_KEY to Docker Compose in integration test CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -199,6 +199,8 @@ jobs:
             build
 
       - name: Start full stack
+        env:
+          ADMIN_API_KEY: ci-admin-api-key
         run: |
           docker compose \
             -f docker-compose.yml \


### PR DESCRIPTION
Fixes admin containers E2E test 401 failures.

The `ADMIN_API_KEY` env var was set for the pytest runner step but not passed to the Docker Compose stack. The solr-search container received `ADMIN_API_KEY=''` which caused all admin endpoint tests to get 401 responses.

**Fix:** Set `ADMIN_API_KEY: ci-admin-api-key` as an environment variable on the 'Start full stack' step so Docker Compose passes it to the solr-search container.

**Blocking:** Release v1.10.0 merge to main.