### PR TITLE
fix: use absolute base path in Vite for nested route assets

### DIFF
--- a/src/aithena-ui/vite.config.ts
+++ b/src/aithena-ui/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(getVersion()),
   },
   plugins: [react({ fastRefresh: false })],
-  base: '',
+  base: '/',
   server: {
     proxy: {
       '/documents': {


### PR DESCRIPTION
## Problem

Playwright E2E tests for collections fail in CI because navigating to `/collections/{uuid}` (2-level deep path) breaks asset loading.

With `base: ''` (relative), the built HTML generates relative asset references like `assets/index-REg-FVQx.js`. At `/collections` this resolves to `/assets/index-REg-FVQx.js` (correct), but at `/collections/{uuid}` it resolves to `/collections/assets/index-REg-FVQx.js` (broken — nginx serves index.html for all SPA routes, so the browser gets HTML instead of JavaScript).

## Fix

Changed `base: ''` to `base: '/'` in `vite.config.ts`. This makes all asset references absolute (`/assets/...`) in the built HTML, working at any URL depth.

## Verification
- `npm run build` — all assets referenced as `/assets/...` in index.html
- `npx vitest run` — 480 tests passed
- `npm run lint` + `npm run format:check` — clean