### PR TITLE
fix: enable real collections API in Docker build and fix E2E tests

### DIFF
--- a/e2e/playwright/tests/collections.spec.ts
+++ b/e2e/playwright/tests/collections.spec.ts
@@ -264,9 +264,9 @@ test.describe('create collection flow', () => {
     // Modal should close
     await expect(modal).toBeHidden();
 
-    // Collection should appear in the grid
-    const card = page.locator('.collection-card', { hasText: collName });
-    await expect(card).toBeVisible({ timeout: 10_000 });
+    // After creation the UI navigates to the detail page
+    await expect(page).toHaveURL(/\/collections\//, { timeout: 10_000 });
+    await expect(page.locator('h2', { hasText: collName })).toBeVisible({ timeout: 10_000 });
 
     // Cleanup via API
     const resp = await request.get(`${apiBaseURL}/v1/collections`, { headers, timeout: 10_000 });

--- a/src/aithena-ui/Dockerfile
+++ b/src/aithena-ui/Dockerfile
@@ -14,7 +14,8 @@ RUN npm ci
 
 COPY . .
 
-ENV VERSION=${VERSION}
+ENV VERSION=${VERSION} \
+    VITE_COLLECTIONS_API=real
 RUN npm run build
 
 # ---------- runtime stage ----------


### PR DESCRIPTION
## Problem

The Playwright E2E collections tests all fail in CI because:

1. **Mock API in Docker**: `VITE_COLLECTIONS_API` was not set during Docker build, so the UI used in-memory mocks instead of the real collections API. Collections created via the API never appeared in the UI.

2. **Create test assertion mismatch**: After creating a collection, the UI navigates to the detail page (`/collections/{id}`), but the test expected the collection grid (`.collection-card`) to be visible.

## Fixes

1. **Dockerfile**: Set `VITE_COLLECTIONS_API=real` as build-time env var so Vite inlines the real API calls into the bundle.

2. **E2E test**: Updated 'create collection' test to verify navigation to the detail page instead of looking for a grid card.

## Impact
- 10 failing Playwright E2E tests should now pass
- Python E2E tests already pass (they hit the API directly)