### PR TITLE
fix: resolve 7 failing collections E2E tests — enrich items, fix API mismatches

### DIFF
--- a/src/aithena-ui/src/Components/CollectionDetailView.tsx
+++ b/src/aithena-ui/src/Components/CollectionDetailView.tsx
@@ -21,7 +21,7 @@ function sortItems(items: CollectionItem[], key: SortKey, dir: SortDir): Collect
     let cmp = 0;
     switch (key) {
       case 'title':
-        cmp = a.title.localeCompare(b.title);
+        cmp = (a.title ?? '').localeCompare(b.title ?? '');
         break;
       case 'author':
         cmp = (a.author ?? '').localeCompare(b.author ?? '');

--- a/src/aithena-ui/src/Components/NoteEditor.tsx
+++ b/src/aithena-ui/src/Components/NoteEditor.tsx
@@ -12,7 +12,7 @@ interface NoteEditorProps {
 
 function NoteEditor({ itemId, initialNote, onSave, saving }: NoteEditorProps) {
   const intl = useIntl();
-  const [note, setNote] = useState(initialNote);
+  const [note, setNote] = useState(initialNote ?? '');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleChange = useCallback(

--- a/src/aithena-ui/src/services/collectionsApi.ts
+++ b/src/aithena-ui/src/services/collectionsApi.ts
@@ -122,6 +122,34 @@ function delay(ms = 120): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Normalize raw API item to match the CollectionItem interface. */
+function normalizeItem(raw: Record<string, unknown>): CollectionItem {
+  return {
+    id: String(raw.id ?? ''),
+    document_id: String(raw.document_id ?? ''),
+    title: String(raw.title ?? 'Untitled'),
+    author: raw.author != null ? String(raw.author) : undefined,
+    year: typeof raw.year === 'number' ? raw.year : undefined,
+    cover_url: raw.cover_url != null ? String(raw.cover_url) : null,
+    note: raw.note != null ? String(raw.note) : '',
+    added_at: String(raw.added_at ?? ''),
+  };
+}
+
+/** Normalize raw API detail to match the CollectionDetail interface. */
+function normalizeDetail(raw: Record<string, unknown>): CollectionDetail {
+  const items = Array.isArray(raw.items) ? raw.items.map(normalizeItem) : [];
+  return {
+    id: String(raw.id ?? ''),
+    name: String(raw.name ?? ''),
+    description: String(raw.description ?? ''),
+    item_count: typeof raw.item_count === 'number' ? raw.item_count : items.length,
+    created_at: String(raw.created_at ?? ''),
+    updated_at: String(raw.updated_at ?? ''),
+    items,
+  };
+}
+
 // ── API functions ─────────────────────────────────────────────────
 // Each function contains the real `apiFetch` call (commented out) and a
 // mock fallback.  Uncomment the real call and remove the mock block when
@@ -143,7 +171,7 @@ export async function fetchCollectionDetail(id: string): Promise<CollectionDetai
   if (import.meta.env.VITE_COLLECTIONS_API === 'real') {
     const res = await apiFetch(`/v1/collections/${id}`);
     if (!res.ok) throw new Error('Collection not found');
-    return (await res.json()) as CollectionDetail;
+    return normalizeDetail(await res.json());
   }
   await delay();
   const col = collections.find((c) => c.id === id);
@@ -184,7 +212,7 @@ export async function updateCollection(
   /* istanbul ignore next -- real endpoint */
   if (import.meta.env.VITE_COLLECTIONS_API === 'real') {
     const res = await apiFetch(`/v1/collections/${id}`, {
-      method: 'PATCH',
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     });
@@ -240,7 +268,7 @@ export async function updateItemNote(
 ): Promise<void> {
   /* istanbul ignore next -- real endpoint */
   if (import.meta.env.VITE_COLLECTIONS_API === 'real') {
-    const res = await apiFetch(`/v1/collections/${collectionId}/items/${itemId}/note`, {
+    const res = await apiFetch(`/v1/collections/${collectionId}/items/${itemId}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ note }),
@@ -265,10 +293,12 @@ export async function addItemToCollection(
     const res = await apiFetch(`/v1/collections/${collectionId}/items`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ document_id: documentId }),
+      body: JSON.stringify({ document_ids: [documentId] }),
     });
     if (!res.ok) throw new Error('Failed to add item');
-    return (await res.json()) as CollectionItem;
+    const body = (await res.json()) as { added: Record<string, unknown>[]; added_count: number };
+    if (!body.added || body.added.length === 0) throw new Error('No item was added');
+    return normalizeItem(body.added[0]);
   }
   await delay();
   const items = itemsByCollection[collectionId];
@@ -301,7 +331,8 @@ export async function addItemsToCollection(
       body: JSON.stringify({ document_ids: documentIds }),
     });
     if (!res.ok) throw new Error('Failed to add items');
-    return (await res.json()) as CollectionItem[];
+    const body = (await res.json()) as { added: Record<string, unknown>[]; added_count: number };
+    return (body.added ?? []).map(normalizeItem);
   }
   await delay();
   const items = itemsByCollection[collectionId];

--- a/src/solr-search/collections_models.py
+++ b/src/solr-search/collections_models.py
@@ -32,6 +32,10 @@ class CollectionItemResponse(BaseModel):
     id: str
     collection_id: str
     document_id: str
+    title: str | None = None
+    author: str | None = None
+    year: int | None = None
+    cover_url: str | None = None
     position: int | None
     note: str | None
     added_at: str
@@ -53,6 +57,7 @@ class CollectionDetailResponse(BaseModel):
     user_id: str
     name: str
     description: str | None
+    item_count: int = 0
     created_at: str
     updated_at: str
     items: list[CollectionItemResponse]

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -2387,6 +2387,51 @@ async def upload_pdf(file: UploadFile, request: Request) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _enrich_collection_items(items: list[dict[str, Any]]) -> None:
+    """Enrich collection items with document metadata from Solr."""
+    doc_ids = [item["document_id"] for item in items if item.get("document_id")]
+    if not doc_ids:
+        return
+
+    try:
+        id_query = " OR ".join(f"id:{solr_escape(did)}" for did in doc_ids)
+        result = query_solr({
+            "q": f"({id_query})",
+            "fl": "id,title_s,author_s,year_i,file_path_s",
+            "rows": len(doc_ids),
+            "wt": "json",
+        })
+
+        docs = result.get("response", {}).get("docs", [])
+        metadata_map: dict[str, dict[str, Any]] = {}
+        for doc in docs:
+            doc_id = doc.get("id")
+            if doc_id:
+                metadata_map[doc_id] = doc
+
+        for item in items:
+            doc = metadata_map.get(item["document_id"], {})
+            item["title"] = doc.get("title_s") or Path(doc.get("file_path_s", "")).stem or None
+            item["author"] = doc.get("author_s") or None
+            item["year"] = doc.get("year_i")
+            item["cover_url"] = None
+    except Exception:
+        logger.warning("Failed to enrich collection items with Solr metadata", exc_info=True)
+        for item in items:
+            item.setdefault("title", None)
+            item.setdefault("author", None)
+            item.setdefault("year", None)
+            item.setdefault("cover_url", None)
+
+
+def _prepare_collection_detail(result: dict[str, Any]) -> dict[str, Any]:
+    """Enrich items and add item_count to a collection detail response."""
+    items = result.get("items", [])
+    _enrich_collection_items(items)
+    result["item_count"] = len(items)
+    return result
+
+
 @app.post("/v1/collections", response_model=CollectionResponse, status_code=201)
 def create_collection(body: CreateCollectionRequest, request: Request):
     user = _get_current_user(request)
@@ -2406,7 +2451,7 @@ def get_collection(collection_id: str, request: Request):
     result = svc_get_collection(settings.collections_db_path, collection_id, str(user.id))
     if result is None:
         raise HTTPException(status_code=404, detail="Collection not found")
-    return result
+    return _prepare_collection_detail(result)
 
 
 @app.put("/v1/collections/{collection_id}", response_model=CollectionDetailResponse)
@@ -2419,7 +2464,7 @@ def update_collection(collection_id: str, body: UpdateCollectionRequest, request
     )
     if result is None:
         raise HTTPException(status_code=404, detail="Collection not found")
-    return result
+    return _prepare_collection_detail(result)
 
 
 @app.delete("/v1/collections/{collection_id}", status_code=204)


### PR DESCRIPTION
## Summary

Fixes 7 failing Playwright E2E tests for collections by addressing backend/frontend mismatches.

## Root Causes

1. **NoteEditor crash on null note** — Backend returns `note: null` for items without notes. `NoteEditor` did `note.length` → `TypeError`, crashing the entire React tree and making the detail page blank.

2. **Backend items lacked document metadata** — `CollectionItemResponse` only had raw DB fields (`document_id`, `position`, `note`). Frontend expected `title`, `author`, `year`, `cover_url` for rendering.

3. **Frontend used PATCH for updates** — Backend `PUT /v1/collections/{id}` rejected PATCH with 405, so the edit modal never closed.

4. **Frontend called non-existent `/note` endpoint** — `updateItemNote` called `PUT .../items/{id}/note`, but backend only has `PUT .../items/{id}`.

5. **Frontend `addItemToCollection` sent wrong payload** — Sent `{ document_id }` instead of `{ document_ids: [...] }`.

## Changes

### Backend (`src/solr-search/`)
- **`collections_models.py`**: Added optional `title`, `author`, `year`, `cover_url` to `CollectionItemResponse`; added `item_count` to `CollectionDetailResponse`
- **`main.py`**: Added `_enrich_collection_items()` to fetch document metadata from Solr for collection items; applied enrichment in `get_collection` and `update_collection` endpoints

### Frontend (`src/aithena-ui/`)
- **`collectionsApi.ts`**: Fixed HTTP method (PATCH→PUT), fixed note endpoint URL, fixed add-items payload/response parsing, added `normalizeItem`/`normalizeDetail` functions
- **`NoteEditor.tsx`**: Default `null` initialNote to empty string
- **`CollectionDetailView.tsx`**: Safe `title` sort with nullish coalescing

## Tests
- ✅ 790 Python tests pass
- ✅ 480 Vitest tests pass
- ✅ Ruff + ESLint clean