### PR TITLE
fix(e2e): always render stats page title regardless of loading state

### DIFF
--- a/src/aithena-ui/src/Components/CollectionStats.tsx
+++ b/src/aithena-ui/src/Components/CollectionStats.tsx
@@ -49,30 +49,6 @@ function CollectionStats() {
   const intl = useIntl();
   const { stats, loading, error } = useStats();
 
-  if (loading) {
-    return (
-      <main className="stats-main">
-        <p className="stats-loading">{intl.formatMessage({ id: 'stats.loading' })}</p>
-      </main>
-    );
-  }
-
-  if (error) {
-    return (
-      <main className="stats-main">
-        <div className="search-error" role="alert">
-          <AlertTriangle size={20} aria-hidden="true" /> {error}
-        </div>
-      </main>
-    );
-  }
-
-  if (!stats) {
-    return null;
-  }
-
-  const { total_books, by_language, by_author, by_year, by_category, page_stats } = stats;
-
   return (
     <main className="stats-main">
       <header className="stats-header">
@@ -81,47 +57,65 @@ function CollectionStats() {
         </h2>
       </header>
 
-      <section className="stats-summary-row">
-        <div className="stats-big-number">
-          <span className="stats-big-value">{total_books.toLocaleString()}</span>
-          <span className="stats-big-label">
-            {intl.formatMessage({ id: 'stats.booksIndexed' })}
-          </span>
-        </div>
+      {loading && <p className="stats-loading">{intl.formatMessage({ id: 'stats.loading' })}</p>}
 
-        <div className="stats-page-summary">
-          <h3 className="stats-table-title">{intl.formatMessage({ id: 'stats.pageStats' })}</h3>
-          <dl className="stats-dl">
-            <div className="stats-dl-row">
-              <dt className="stats-dt">{intl.formatMessage({ id: 'stats.totalPages' })}</dt>
-              <dd className="stats-dd">{page_stats.total.toLocaleString()}</dd>
-            </div>
-            <div className="stats-dl-row">
-              <dt className="stats-dt">{intl.formatMessage({ id: 'stats.average' })}</dt>
-              <dd className="stats-dd">{page_stats.avg.toLocaleString()}</dd>
-            </div>
-            <div className="stats-dl-row">
-              <dt className="stats-dt">{intl.formatMessage({ id: 'stats.min' })}</dt>
-              <dd className="stats-dd">{page_stats.min.toLocaleString()}</dd>
-            </div>
-            <div className="stats-dl-row">
-              <dt className="stats-dt">{intl.formatMessage({ id: 'stats.max' })}</dt>
-              <dd className="stats-dd">{page_stats.max.toLocaleString()}</dd>
-            </div>
-          </dl>
+      {error && !loading && (
+        <div className="search-error" role="alert">
+          <AlertTriangle size={20} aria-hidden="true" /> {error}
         </div>
-      </section>
+      )}
 
-      <section className="stats-tables-grid">
-        <FacetTable title={intl.formatMessage({ id: 'stats.byLanguage' })} rows={by_language} />
-        <FacetTable
-          title={intl.formatMessage({ id: 'stats.byAuthorTop' }, { count: TOP_AUTHORS })}
-          rows={by_author}
-          limit={TOP_AUTHORS}
-        />
-        <FacetTable title={intl.formatMessage({ id: 'stats.byYear' })} rows={by_year} />
-        <FacetTable title={intl.formatMessage({ id: 'stats.byCategory' })} rows={by_category} />
-      </section>
+      {stats && !loading && !error && (
+        <>
+          <section className="stats-summary-row">
+            <div className="stats-big-number">
+              <span className="stats-big-value">{stats.total_books.toLocaleString()}</span>
+              <span className="stats-big-label">
+                {intl.formatMessage({ id: 'stats.booksIndexed' })}
+              </span>
+            </div>
+
+            <div className="stats-page-summary">
+              <h3 className="stats-table-title">{intl.formatMessage({ id: 'stats.pageStats' })}</h3>
+              <dl className="stats-dl">
+                <div className="stats-dl-row">
+                  <dt className="stats-dt">{intl.formatMessage({ id: 'stats.totalPages' })}</dt>
+                  <dd className="stats-dd">{stats.page_stats.total.toLocaleString()}</dd>
+                </div>
+                <div className="stats-dl-row">
+                  <dt className="stats-dt">{intl.formatMessage({ id: 'stats.average' })}</dt>
+                  <dd className="stats-dd">{stats.page_stats.avg.toLocaleString()}</dd>
+                </div>
+                <div className="stats-dl-row">
+                  <dt className="stats-dt">{intl.formatMessage({ id: 'stats.min' })}</dt>
+                  <dd className="stats-dd">{stats.page_stats.min.toLocaleString()}</dd>
+                </div>
+                <div className="stats-dl-row">
+                  <dt className="stats-dt">{intl.formatMessage({ id: 'stats.max' })}</dt>
+                  <dd className="stats-dd">{stats.page_stats.max.toLocaleString()}</dd>
+                </div>
+              </dl>
+            </div>
+          </section>
+
+          <section className="stats-tables-grid">
+            <FacetTable
+              title={intl.formatMessage({ id: 'stats.byLanguage' })}
+              rows={stats.by_language}
+            />
+            <FacetTable
+              title={intl.formatMessage({ id: 'stats.byAuthorTop' }, { count: TOP_AUTHORS })}
+              rows={stats.by_author}
+              limit={TOP_AUTHORS}
+            />
+            <FacetTable title={intl.formatMessage({ id: 'stats.byYear' })} rows={stats.by_year} />
+            <FacetTable
+              title={intl.formatMessage({ id: 'stats.byCategory' })}
+              rows={stats.by_category}
+            />
+          </section>
+        </>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Problem

The Playwright E2E navigation test (`navigation.spec.ts` line 58) was failing because it expects to find `.stats-page-title` with text "Collection Stats" when navigating to `/stats`. However, the `CollectionStats` component had early returns for loading and error states that **did not render the title element at all**.

In the Docker Compose integration environment, if the `/v1/stats/` API is slow or unavailable, the component stays in a loading/error state and the `.stats-page-title` selector is never found → test failure.

## Root Cause

`CollectionStats.tsx` used early-return pattern for loading/error states:
- **Loading**: rendered only a loading message, no `.stats-page-title`
- **Error**: rendered only an error alert, no `.stats-page-title`
- **No data**: returned `null`

The title was only rendered in the success path (line 79).

## Fix

Restructured the component to **always render the page title header first**, then conditionally render loading, error, or data content below it. This follows the same pattern used by `LibraryPage` which always renders its `.page-title` regardless of data state.

## Validation

- ✅ ESLint: 0 errors
- ✅ Prettier: formatted
- ✅ Vite build: succeeds
- ✅ Vitest: all 584 tests pass (53 test files)

## Unblocks

This fix unblocks the v1.11.0 release PR (#854 targeting main). Once merged to dev, it will flow into #854.