### PR TITLE
docs: add mandatory PR comment resolution to merge checklist

### DIFF
--- a/.squad/decisions/inbox/copilot-directive-pr-comments.md
+++ b/.squad/decisions/inbox/copilot-directive-pr-comments.md
@@ -1,0 +1,4 @@
+### 2026-03-22T11:00:00Z: User directive
+**By:** Juanma (via Copilot)
+**What:** All PR comments must be resolved before merging. This is mandatory. For each comment, one of three actions: (1) apply it, (2) postpone to a new issue, (3) do not apply — and document the decision with reasoning when resolving the comment. Add this to the PR merge checklist.
+**Why:** User request — squad has been closing PRs without resolving comments, repeated directive.

--- a/docs/deployment/release-checklist.md
+++ b/docs/deployment/release-checklist.md
@@ -194,9 +194,29 @@ If a check fails:
 
 **Do NOT merge with failing checks.** Branch protection enforces this.
 
+### [ ] Resolve All PR Comments
+
+**⚠️ MANDATORY: No PR may be merged with unresolved comments.**
+
+Before merging, review every comment on the PR. For each comment, take ONE of these actions:
+
+1. **Apply it** — make the requested change, reply confirming it's done
+2. **Postpone it** — create a new GitHub issue for follow-up, reply with the issue link
+3. **Do not apply** — reply with the reasoning for not applying, then resolve the thread
+
+Every comment thread must be resolved before proceeding to merge. This applies to:
+- Review comments (inline code comments)
+- PR-level review comments
+- Conversation comments
+
+```bash
+# Check for unresolved review threads
+gh api "repos/{owner}/{repo}/pulls/{number}/reviews" --jq '[.[] | select(.state == "CHANGES_REQUESTED")] | length'
+```
+
 ### [ ] Merge the Release PR
 
-Once all CI checks pass:
+Once all CI checks pass AND all comments are resolved:
 
 ```bash
 gh pr merge <number> --merge


### PR DESCRIPTION
Adds a mandatory checklist step requiring all PR comments to be resolved before merging.

For each comment, one of three actions:
1. Apply it
2. Postpone to a new issue
3. Do not apply — document the decision with reasoning

This is a PO directive after repeated instances of merging PRs with unresolved comments.