### PR TITLE
fix(docker): add libstdc++ to document-indexer Alpine runtime

### DIFF
--- a/src/document-indexer/Dockerfile
+++ b/src/document-indexer/Dockerfile
@@ -33,7 +33,7 @@ ENV VERSION=${VERSION} \
 
 WORKDIR /app
 
-RUN apk add --no-cache procps
+RUN apk add --no-cache procps libstdc++ libgomp libgcc
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 COPY --from=builder /app/.venv /app/.venv


### PR DESCRIPTION
Closes #894

Adds missing native libraries to Alpine runtime stage:
- `libstdc++` (required by PyMuPDF compiled extensions)
- `libgomp` (OpenMP runtime)
- `libgcc` (GCC runtime)

These are needed for thumbnail generation via PyMuPDF.