### PR TITLE
feat(security): add ZooKeeper SASL DIGEST-MD5 authentication (#904)

### DIFF
--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -340,3 +340,15 @@ Created comprehensive rollback plan for the embedding model A/B test.
 2. **nginx:** Built-in nginx user + non-privileged port (8080)
 3. **TLS Configuration:** Dedicated HTTPS server block; HSTS enforcement; security header re-declaration in location blocks
 
+
+### 4. ZooKeeper SASL DIGEST-MD5 Authentication (Issue #904)
+- **What:** Implemented SASL authentication between ZooKeeper ensemble and SolrCloud nodes
+- **Pattern:** JAAS template files with `${ZK_SASL_USER}`/`${ZK_SASL_PASS}` placeholders, substituted at container startup via entrypoint wrapper scripts using `sed`
+- **ZK Config:** QuorumServer + QuorumLearner (inter-node auth) + Server (client auth); `ZOO_CFG_EXTRA` for quorum SASL settings; `SERVER_JVMFLAGS` for JAAS config path
+- **Solr Config:** Client JAAS section + `SOLR_ZK_CREDS_AND_ACLS` for DigestZkCredentialsProvider/DigestZkACLProvider + `SOLR_OPTS` for JAAS path
+- **solr-init:** Inline JAAS generation in entrypoint script before `solr zk` commands
+- **Credentials:** `ZK_SASL_USER` (default: `solr`) and `ZK_SASL_PASS` (default: `SolrZkPass_dev`); prod overrides via .env
+- **Key Files:** `src/zookeeper/zk-server-jaas.conf`, `src/zookeeper/entrypoint-sasl.sh`, `src/solr/solr-jaas.conf`, `src/solr/entrypoint-sasl.sh`
+- **Health Checks:** Unaffected — ZK `ruok` 4LW doesn't require SASL; Solr health checks use HTTP
+- **Decision:** Recorded in `.squad/decisions/inbox/brett-zk-sasl-impl.md`
+

--- a/.squad/decisions/inbox/brett-zk-sasl-impl.md
+++ b/.squad/decisions/inbox/brett-zk-sasl-impl.md
@@ -1,0 +1,38 @@
+# Decision: ZooKeeper SASL DIGEST-MD5 Implementation
+
+**Author:** Brett (Infrastructure Architect)
+**Date:** 2026-03-22
+**Issue:** #904
+**Status:** Implemented
+
+## Context
+
+ZooKeeper ensemble was previously unauthenticated — any container on the Docker network could connect and read/write znodes. This is a security hardening requirement for v1.13.0.
+
+## Decision
+
+1. **SASL DIGEST-MD5** chosen over Kerberos — no KDC infrastructure needed, supported natively by ZK 3.9 and Solr 9.7.
+2. **Template + entrypoint wrapper pattern** for JAAS files — JAAS doesn't support env vars natively, so entrypoint scripts use `sed` to substitute `${ZK_SASL_USER}` and `${ZK_SASL_PASS}` at startup. This follows the same pattern as RabbitMQ's `init-definitions.sh`.
+3. **Shared credentials** between ZK quorum auth and client auth — single `ZK_SASL_USER`/`ZK_SASL_PASS` pair for simplicity. Can be split later if needed.
+4. **Dev defaults** follow project convention: `ZK_SASL_USER=solr`, `ZK_SASL_PASS=SolrZkPass_dev`. Production must override via `.env`.
+5. **DigestZkCredentialsProvider + DigestZkACLProvider** on Solr side to enforce znode ACLs matching the SASL user.
+6. **Explicit `command: []`** on ZK services to prevent the entrypoint override from losing the default command.
+7. **Explicit `command: ["solr-foreground"]`** on Solr services for the same reason.
+
+## Affected Services
+
+- zoo1, zoo2, zoo3 — JAAS template mount, entrypoint wrapper, `ZOO_CFG_EXTRA` quorum SASL props, `SERVER_JVMFLAGS`
+- solr, solr2, solr3 — JAAS template mount, entrypoint wrapper, `SOLR_ZK_CREDS_AND_ACLS`, `SOLR_OPTS`
+- solr-init — inline JAAS generation + `SOLR_ZK_CREDS_AND_ACLS`, `SOLR_OPTS`
+- Both `docker-compose.yml` and `docker-compose.prod.yml`
+
+## Risks
+
+- **Existing ZK data:** If upgrading an existing deployment, ZK znodes created before SASL won't have ACLs. A migration step may be needed to re-ACL existing znodes.
+- **Credential rotation:** Requires restarting all ZK and Solr containers simultaneously. Document in operations runbook.
+
+## Team Impact
+
+- Parker/Dallas: No app code changes needed — Solr HTTP API is unchanged.
+- Ash: Solr query logic unaffected — SASL is transport-level between Solr ↔ ZK only.
+- Lambert: No new test requirements — SASL is infra-level, not testable without Docker daemon.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -373,20 +373,27 @@ services:
       - document-data:/data/documents:ro
   zoo1:
     image: zookeeper:3.9
+    entrypoint: /entrypoint-sasl.sh
+    command: []
     expose:
       - "2181"
     networks:
       - default
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
-      ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_CFG_EXTRA: "admin.enableServer=false quorum.auth.enableSasl=true quorum.auth.learnerRequireSasl=true quorum.auth.serverRequireSasl=true authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider requireClientAuthScheme=sasl"
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SERVER_JVMFLAGS: "-Djava.security.auth.login.config=/conf/jaas.conf -Dzookeeper.requireClientAuthScheme=sasl"
     volumes:
       - zoo-data1_logs:/logs
       - zoo-data1_data:/data
       - zoo-data1_datalog:/datalog
       - zoo-backup:/backup
+      - ./src/zookeeper/zk-server-jaas.conf:/conf/jaas-template.conf:ro
+      - ./src/zookeeper/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "printf ruok | nc -w 2 localhost 2181 | grep -q imok"]
       interval: 10s
@@ -408,20 +415,27 @@ services:
         max-file: "3"
   zoo2:
     image: zookeeper:3.9
+    entrypoint: /entrypoint-sasl.sh
+    command: []
     expose:
       - "2181"
     networks:
       - default
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
-      ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_CFG_EXTRA: "admin.enableServer=false quorum.auth.enableSasl=true quorum.auth.learnerRequireSasl=true quorum.auth.serverRequireSasl=true authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider requireClientAuthScheme=sasl"
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SERVER_JVMFLAGS: "-Djava.security.auth.login.config=/conf/jaas.conf -Dzookeeper.requireClientAuthScheme=sasl"
     volumes:
       - zoo-data2_logs:/logs
       - zoo-data2_data:/data
       - zoo-data2_datalog:/datalog
       - zoo-backup:/backup
+      - ./src/zookeeper/zk-server-jaas.conf:/conf/jaas-template.conf:ro
+      - ./src/zookeeper/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "printf ruok | nc -w 2 localhost 2181 | grep -q imok"]
       interval: 10s
@@ -443,20 +457,27 @@ services:
         max-file: "3"
   zoo3:
     image: zookeeper:3.9
+    entrypoint: /entrypoint-sasl.sh
+    command: []
     expose:
       - "2181"
     networks:
       - default
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
-      ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_CFG_EXTRA: "admin.enableServer=false quorum.auth.enableSasl=true quorum.auth.learnerRequireSasl=true quorum.auth.serverRequireSasl=true authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider requireClientAuthScheme=sasl"
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SERVER_JVMFLAGS: "-Djava.security.auth.login.config=/conf/jaas.conf -Dzookeeper.requireClientAuthScheme=sasl"
     volumes:
       - zoo-data3_logs:/logs
       - zoo-data3_data:/data
       - zoo-data3_datalog:/datalog
       - zoo-backup:/backup
+      - ./src/zookeeper/zk-server-jaas.conf:/conf/jaas-template.conf:ro
+      - ./src/zookeeper/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "printf ruok | nc -w 2 localhost 2181 | grep -q imok"]
       interval: 10s
@@ -478,14 +499,22 @@ services:
         max-file: "3"
   solr:
     image: solr:9.7
+    entrypoint: /entrypoint-sasl.sh
+    command: ["solr-foreground"]
     restart: unless-stopped
     stop_grace_period: 60s
     volumes:
       - solr-data:/var/solr/data
       - document-data:/data/documents:ro
+      - ./src/solr/solr-jaas.conf:/opt/solr/server/etc/solr-jaas-template.conf:ro
+      - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SOLR_ZK_CREDS_AND_ACLS: "-DzkCredentialsProvider=org.apache.solr.common.cloud.DigestZkCredentialsProvider -DzkACLProvider=org.apache.solr.common.cloud.DigestZkACLProvider -DzkDigestUsername=${ZK_SASL_USER:-solr} -DzkDigestPassword=${ZK_SASL_PASS:-SolrZkPass_dev}"
+      SOLR_OPTS: "-Djava.security.auth.login.config=/opt/solr/server/etc/solr-jaas.conf"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
     expose:
@@ -519,14 +548,22 @@ services:
         condition: service_healthy
   solr2:
     image: solr:9.7
+    entrypoint: /entrypoint-sasl.sh
+    command: ["solr-foreground"]
     restart: unless-stopped
     stop_grace_period: 60s
     volumes:
       - solr-data2:/var/solr/data
       - document-data:/data/documents:ro
+      - ./src/solr/solr-jaas.conf:/opt/solr/server/etc/solr-jaas-template.conf:ro
+      - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SOLR_ZK_CREDS_AND_ACLS: "-DzkCredentialsProvider=org.apache.solr.common.cloud.DigestZkCredentialsProvider -DzkACLProvider=org.apache.solr.common.cloud.DigestZkACLProvider -DzkDigestUsername=${ZK_SASL_USER:-solr} -DzkDigestPassword=${ZK_SASL_PASS:-SolrZkPass_dev}"
+      SOLR_OPTS: "-Djava.security.auth.login.config=/opt/solr/server/etc/solr-jaas.conf"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
     expose:
@@ -560,14 +597,22 @@ services:
         condition: service_healthy
   solr3:
     image: solr:9.7
+    entrypoint: /entrypoint-sasl.sh
+    command: ["solr-foreground"]
     restart: unless-stopped
     stop_grace_period: 60s
     volumes:
       - solr-data3:/var/solr/data
       - document-data:/data/documents:ro
+      - ./src/solr/solr-jaas.conf:/opt/solr/server/etc/solr-jaas-template.conf:ro
+      - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SOLR_ZK_CREDS_AND_ACLS: "-DzkCredentialsProvider=org.apache.solr.common.cloud.DigestZkCredentialsProvider -DzkACLProvider=org.apache.solr.common.cloud.DigestZkACLProvider -DzkDigestUsername=${ZK_SASL_USER:-solr} -DzkDigestPassword=${ZK_SASL_PASS:-SolrZkPass_dev}"
+      SOLR_OPTS: "-Djava.security.auth.login.config=/opt/solr/server/etc/solr-jaas.conf"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
     expose:
@@ -612,7 +657,12 @@ services:
       - ./src/solr/books:/configsets/books:ro
       - ./src/solr/add-conf-overlay.sh:/scripts/add-conf-overlay.sh:ro
       - ./src/solr/security.json:/scripts/security.json:ro
+      - ./src/solr/solr-jaas.conf:/opt/solr/server/etc/solr-jaas-template.conf:ro
     environment:
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SOLR_ZK_CREDS_AND_ACLS: "-DzkCredentialsProvider=org.apache.solr.common.cloud.DigestZkCredentialsProvider -DzkACLProvider=org.apache.solr.common.cloud.DigestZkACLProvider -DzkDigestUsername=${ZK_SASL_USER:-solr} -DzkDigestPassword=${ZK_SASL_PASS:-SolrZkPass_dev}"
+      SOLR_OPTS: "-Djava.security.auth.login.config=/opt/solr/server/etc/solr-jaas.conf"
       SOLR_ADMIN_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_ADMIN_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
       SOLR_READONLY_USER: ${SOLR_READONLY_USER:?Set SOLR_READONLY_USER}
@@ -624,6 +674,13 @@ services:
       - -ceu
       - |
           set -o pipefail
+
+          # Generate JAAS config from template for solr zk commands
+          sed \
+            -e "s|\$${ZK_SASL_USER}|$${ZK_SASL_USER}|g" \
+            -e "s|\$${ZK_SASL_PASS}|$${ZK_SASL_PASS}|g" \
+            /opt/solr/server/etc/solr-jaas-template.conf > /opt/solr/server/etc/solr-jaas.conf
+
           ZK_HOST="zoo1:2181,zoo2:2181,zoo3:2181"
           SOLR_URL="http://solr:8983"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -507,20 +507,27 @@ services:
       - document-data:/data/documents:ro
   zoo1:
     image: zookeeper:3.9
+    entrypoint: /entrypoint-sasl.sh
+    command: []
     expose:
       - "2181"
     networks:
       - default
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
-      ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_CFG_EXTRA: "admin.enableServer=false quorum.auth.enableSasl=true quorum.auth.learnerRequireSasl=true quorum.auth.serverRequireSasl=true authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider requireClientAuthScheme=sasl"
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SERVER_JVMFLAGS: "-Djava.security.auth.login.config=/conf/jaas.conf -Dzookeeper.requireClientAuthScheme=sasl"
     volumes:
       - zoo-data1_logs:/logs
       - zoo-data1_data:/data
       - zoo-data1_datalog:/datalog
       - zoo-backup:/backup
+      - ./src/zookeeper/zk-server-jaas.conf:/conf/jaas-template.conf:ro
+      - ./src/zookeeper/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     healthcheck:
       # ruok is the canonical ZK liveness check; the previous mntr-based
       # leader/follower test caused broken-pipe noise because grep exits
@@ -546,20 +553,27 @@ services:
         max-file: "3"
   zoo2:
     image: zookeeper:3.9
+    entrypoint: /entrypoint-sasl.sh
+    command: []
     expose:
       - "2181"
     networks:
       - default
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
-      ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_CFG_EXTRA: "admin.enableServer=false quorum.auth.enableSasl=true quorum.auth.learnerRequireSasl=true quorum.auth.serverRequireSasl=true authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider requireClientAuthScheme=sasl"
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SERVER_JVMFLAGS: "-Djava.security.auth.login.config=/conf/jaas.conf -Dzookeeper.requireClientAuthScheme=sasl"
     volumes:
       - zoo-data2_logs:/logs
       - zoo-data2_data:/data
       - zoo-data2_datalog:/datalog
       - zoo-backup:/backup
+      - ./src/zookeeper/zk-server-jaas.conf:/conf/jaas-template.conf:ro
+      - ./src/zookeeper/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "printf ruok | nc -w 2 localhost 2181 | grep -q imok"]
       interval: 10s
@@ -581,20 +595,27 @@ services:
         max-file: "3"
   zoo3:
     image: zookeeper:3.9
+    entrypoint: /entrypoint-sasl.sh
+    command: []
     expose:
       - "2181"
     networks:
       - default
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
-      ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_CFG_EXTRA: "admin.enableServer=false quorum.auth.enableSasl=true quorum.auth.learnerRequireSasl=true quorum.auth.serverRequireSasl=true authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider requireClientAuthScheme=sasl"
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SERVER_JVMFLAGS: "-Djava.security.auth.login.config=/conf/jaas.conf -Dzookeeper.requireClientAuthScheme=sasl"
     volumes:
       - zoo-data3_logs:/logs
       - zoo-data3_data:/data
       - zoo-data3_datalog:/datalog
       - zoo-backup:/backup
+      - ./src/zookeeper/zk-server-jaas.conf:/conf/jaas-template.conf:ro
+      - ./src/zookeeper/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "printf ruok | nc -w 2 localhost 2181 | grep -q imok"]
       interval: 10s
@@ -619,14 +640,22 @@ services:
     # build:
     #   context: .
     #   dockerfile: ./src/solr/Dockerfile
+    entrypoint: /entrypoint-sasl.sh
+    command: ["solr-foreground"]
     restart: unless-stopped
     stop_grace_period: 60s
     volumes:
       - solr-data:/var/solr/data
       - document-data:/data/documents:ro
+      - ./src/solr/solr-jaas.conf:/opt/solr/server/etc/solr-jaas-template.conf:ro
+      - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SOLR_ZK_CREDS_AND_ACLS: "-DzkCredentialsProvider=org.apache.solr.common.cloud.DigestZkCredentialsProvider -DzkACLProvider=org.apache.solr.common.cloud.DigestZkACLProvider -DzkDigestUsername=${ZK_SASL_USER:-solr} -DzkDigestPassword=${ZK_SASL_PASS:-SolrZkPass_dev}"
+      SOLR_OPTS: "-Djava.security.auth.login.config=/opt/solr/server/etc/solr-jaas.conf"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:-solr_admin}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:-SolrAdmin_dev2024!}
     expose:
@@ -665,14 +694,22 @@ services:
     # build:
     #   context: .
     #   dockerfile: ./src/solr/Dockerfile
+    entrypoint: /entrypoint-sasl.sh
+    command: ["solr-foreground"]
     restart: unless-stopped
     stop_grace_period: 60s
     volumes:
       - solr-data2:/var/solr/data
       - document-data:/data/documents:ro
+      - ./src/solr/solr-jaas.conf:/opt/solr/server/etc/solr-jaas-template.conf:ro
+      - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SOLR_ZK_CREDS_AND_ACLS: "-DzkCredentialsProvider=org.apache.solr.common.cloud.DigestZkCredentialsProvider -DzkACLProvider=org.apache.solr.common.cloud.DigestZkACLProvider -DzkDigestUsername=${ZK_SASL_USER:-solr} -DzkDigestPassword=${ZK_SASL_PASS:-SolrZkPass_dev}"
+      SOLR_OPTS: "-Djava.security.auth.login.config=/opt/solr/server/etc/solr-jaas.conf"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:-solr_admin}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:-SolrAdmin_dev2024!}
     expose:
@@ -710,14 +747,22 @@ services:
     # build:
     #   context: .
     #   dockerfile: ./src/solr/Dockerfile
+    entrypoint: /entrypoint-sasl.sh
+    command: ["solr-foreground"]
     restart: unless-stopped
     stop_grace_period: 60s
     volumes:
       - solr-data3:/var/solr/data
       - document-data:/data/documents:ro
+      - ./src/solr/solr-jaas.conf:/opt/solr/server/etc/solr-jaas-template.conf:ro
+      - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
+      ZK_SASL_USER: ${ZK_SASL_USER:-solr}
+      ZK_SASL_PASS: ${ZK_SASL_PASS:-SolrZkPass_dev}
+      SOLR_ZK_CREDS_AND_ACLS: "-DzkCredentialsProvider=org.apache.solr.common.cloud.DigestZkCredentialsProvider -DzkACLProvider=org.apache.solr.common.cloud.DigestZkACLProvider -DzkDigestUsername=${ZK_SASL_USER:-solr} -DzkDigestPassword=${ZK_SASL_PASS:-SolrZkPass_dev}"
+      SOLR_OPTS: "-Djava.security.auth.login.config=/opt/solr/server/etc/solr-jaas.conf"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:-solr_admin}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:-SolrAdmin_dev2024!}
     expose:

--- a/src/solr/entrypoint-sasl.sh
+++ b/src/solr/entrypoint-sasl.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Solr SASL entrypoint wrapper
+#
+# Generates the JAAS configuration file from the template by substituting
+# environment variables, then exec's the official Solr Docker entrypoint.
+#
+# Required env vars:
+#   ZK_SASL_USER  — SASL username (must match ZooKeeper's Server section)
+#   ZK_SASL_PASS  — SASL password
+# ──────────────────────────────────────────────────────────────────────────────
+
+: "${ZK_SASL_USER:?ZK_SASL_USER is required}"
+: "${ZK_SASL_PASS:?ZK_SASL_PASS is required}"
+
+JAAS_TEMPLATE="/opt/solr/server/etc/solr-jaas-template.conf"
+JAAS_OUTPUT="/opt/solr/server/etc/solr-jaas.conf"
+
+sed \
+  -e "s|\${ZK_SASL_USER}|${ZK_SASL_USER}|g" \
+  -e "s|\${ZK_SASL_PASS}|${ZK_SASL_PASS}|g" \
+  "$JAAS_TEMPLATE" > "$JAAS_OUTPUT"
+
+echo "Solr SASL JAAS config generated at ${JAAS_OUTPUT}"
+
+exec docker-entrypoint.sh "$@"

--- a/src/solr/solr-jaas.conf
+++ b/src/solr/solr-jaas.conf
@@ -1,0 +1,5 @@
+Client {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    username="${ZK_SASL_USER}"
+    password="${ZK_SASL_PASS}";
+};

--- a/src/zookeeper/entrypoint-sasl.sh
+++ b/src/zookeeper/entrypoint-sasl.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ZooKeeper SASL entrypoint wrapper
+#
+# Generates the JAAS configuration file from the template by substituting
+# environment variables, then exec's the official ZooKeeper Docker entrypoint.
+#
+# Required env vars:
+#   ZK_SASL_USER  — SASL username (e.g. "solr")
+#   ZK_SASL_PASS  — SASL password
+# ──────────────────────────────────────────────────────────────────────────────
+
+: "${ZK_SASL_USER:?ZK_SASL_USER is required}"
+: "${ZK_SASL_PASS:?ZK_SASL_PASS is required}"
+
+JAAS_TEMPLATE="/conf/jaas-template.conf"
+JAAS_OUTPUT="/conf/jaas.conf"
+
+sed \
+  -e "s|\${ZK_SASL_USER}|${ZK_SASL_USER}|g" \
+  -e "s|\${ZK_SASL_PASS}|${ZK_SASL_PASS}|g" \
+  "$JAAS_TEMPLATE" > "$JAAS_OUTPUT"
+
+echo "ZooKeeper SASL JAAS config generated at ${JAAS_OUTPUT}"
+
+exec /docker-entrypoint.sh "$@"

--- a/src/zookeeper/zk-server-jaas.conf
+++ b/src/zookeeper/zk-server-jaas.conf
@@ -1,0 +1,13 @@
+QuorumServer {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    user_${ZK_SASL_USER}="${ZK_SASL_PASS}";
+};
+QuorumLearner {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    username="${ZK_SASL_USER}"
+    password="${ZK_SASL_PASS}";
+};
+Server {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    user_${ZK_SASL_USER}="${ZK_SASL_PASS}";
+};


### PR DESCRIPTION
## Summary

Implements SASL DIGEST-MD5 authentication between ZooKeeper ensemble and SolrCloud nodes to prevent unauthorized ZK access.

Closes #904

## Changes

- **New files:** `src/zookeeper/entrypoint-sasl.sh`, `src/zookeeper/zk-server-jaas.conf`, `src/solr/entrypoint-sasl.sh`, `src/solr/solr-jaas.conf`
- **docker-compose.yml:** Added SASL entrypoints, JAAS template mounts, ZK_SASL_USER/PASS env vars, SOLR_ZK_CREDS_AND_ACLS, and SOLR_OPTS to zoo1-3 and solr1-3
- **docker-compose.prod.yml:** Same changes + solr-init ZK SASL config
- **Docs:** Updated Brett history and added ZK SASL decision doc

## Approach

Rebased onto current dev (which includes network segmentation, Redis ACLs, RabbitMQ users, Solr BasicAuth, ASCII folding). Only additive ZK SASL changes — no existing security hardening was reverted.

## Validation

- ✅ YAML validation passes for both compose files
- ✅ ruff check passes
- ✅ solr-search tests: 928 passed (9 pre-existing failures unrelated to this change)

Working as Brett (Infrastructure Architect)