### PR TITLE
infra: Wire HF_TOKEN through embeddings-server Docker build

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -74,6 +74,7 @@ jobs:
       FALLBACK_BASE_URL: http://localhost
       SEARCH_API_URL: http://localhost:8080
       SOLR_URL: http://localhost:8983/solr/books
+      HF_TOKEN: ${{ secrets.HF_TOKEN || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.squad/decisions/inbox/brett-hf-token.md
+++ b/.squad/decisions/inbox/brett-hf-token.md
@@ -1,0 +1,45 @@
+# HF_TOKEN Build Integration
+
+**Author:** Brett (Infrastructure Architect)
+**Date:** 2025-03-22
+
+## Decision
+
+Wire HuggingFace API token through Docker build for faster model downloads in embeddings-server.
+
+## Context
+
+The embeddings-server Dockerfile pre-downloads a large SentenceTransformer model (~500MB) during the build stage. Without authentication to HuggingFace Hub, downloads are rate-limited and slow. With HF_TOKEN, authenticated requests get prioritized bandwidth.
+
+## Implementation
+
+1. **Dockerfile** (`src/embeddings-server/Dockerfile`):
+   - Added `ARG HF_TOKEN` to the builder stage (line 9)
+   - Set `ENV HF_TOKEN=${HF_TOKEN}` in the builder environment (line 16)
+   - HF_TOKEN is NOT persisted in the runtime stage (multi-stage isolation)
+   - Runtime stage sets `HF_HUB_OFFLINE=1` to prevent runtime downloads
+
+2. **docker-compose.yml**:
+   - Added `HF_TOKEN: ${HF_TOKEN:-}` to embeddings-server build args
+   - Falls back to empty string if not set (prevents build failures)
+
+3. **buildall.sh**:
+   - Added `source .env` at script start to load environment variables
+   - This ensures HF_TOKEN from `.env` is available to docker compose
+
+4. **GitHub Actions** (`.github/workflows/integration-test.yml`):
+   - Added `HF_TOKEN: ${{ secrets.HF_TOKEN || '' }}` to job env
+   - Pulls from GitHub Secrets (must be configured by user/org)
+   - Defaults to empty string if secret is not set
+
+## Security
+
+- HF_TOKEN is only used at build time (builder stage)
+- Not persisted in final image layers (multi-stage benefit)
+- Treated as a secret in CI/CD (GitHub Actions secrets mechanism)
+- Optional: builds continue without token, just slower
+
+## Notes
+
+- `docker-compose.prod.yml` uses prebuilt GHCR images, not local builds—no changes needed
+- Integration test workflow calls `docker compose build`, which will now use HF_TOKEN if set

--- a/buildall.sh
+++ b/buildall.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Load .env if it exists
+if [[ -f .env ]]; then
+  set +a
+  source .env
+  set -a
+fi
+
 VERSION_FILE="$SCRIPT_DIR/VERSION"
 
 if git_tag="$(git describe --tags --exact-match 2>/dev/null)"; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
         VERSION: ${VERSION:-dev}
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
         BUILD_DATE: ${BUILD_DATE:-unknown}
+        HF_TOKEN: ${HF_TOKEN:-}
     expose:
       - "8080"
     healthcheck:

--- a/src/embeddings-server/Dockerfile
+++ b/src/embeddings-server/Dockerfile
@@ -6,12 +6,14 @@ ARG BUILD_DATE=unknown
 FROM python:3.12-slim AS builder
 
 ARG MODEL_NAME=sentence-transformers/distiluse-base-multilingual-cased-v2
+ARG HF_TOKEN
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     MODEL_NAME=${MODEL_NAME} \
     HF_HOME=/models/huggingface \
-    SENTENCE_TRANSFORMERS_HOME=/models/sentence_transformers
+    SENTENCE_TRANSFORMERS_HOME=/models/sentence_transformers \
+    HF_TOKEN=${HF_TOKEN}
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 


### PR DESCRIPTION
## Changes

- Add ARG HF_TOKEN to builder stage in Dockerfile (not persisted in runtime)
- Pass HF_TOKEN as build arg in docker-compose.yml  
- Update buildall.sh to source .env for environment variables
- Add HF_TOKEN from GitHub Secrets to integration test workflow

## Why

Enables authenticated HuggingFace Hub API downloads during Docker builds, providing prioritized bandwidth for model caching. Significantly faster builds, especially in CI environments.

## Security

- HF_TOKEN only used at Docker build time (builder stage)
- Secret not persisted in final image (multi-stage build isolation)
- Treated as GitHub secret in CI/CD
- Builds continue without token (fallback to unauthenticated, just slower)

## Testing

The integration test workflow will use HF_TOKEN from GitHub Secrets when building embeddings-server image. Local builds use HF_TOKEN from `.env` if present.

## Notes

- `docker-compose.prod.yml` uses prebuilt GHCR images—no changes needed
- Closes request from jmservera for faster HF model downloads