### PR TITLE
fix(ci): add Solr basic auth to integration test health checks

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -213,16 +213,28 @@ jobs:
 
       - name: Wait for services to become healthy
         run: |
+          # Solr admin credentials (defaults from docker-compose.yml)
+          SOLR_ADMIN_USER="${SOLR_ADMIN_USER:-solr_admin}"
+          SOLR_ADMIN_PASS="${SOLR_ADMIN_PASS:-SolrAdmin_dev2024!}"
+
           wait_for_url() {
             local url="$1"
             local label="$2"
             local attempts="${3:-60}"
             local sleep_seconds="${4:-5}"
+            local auth="${5:-}"
 
             for ((attempt=1; attempt<=attempts; attempt+=1)); do
-              if curl --fail --silent --show-error "$url" >/dev/null; then
-                echo "$label is ready ($url)"
-                return 0
+              if [ -n "$auth" ]; then
+                curl_result=$(curl --fail --silent --show-error -u "$auth" "$url" 2>&1) && {
+                  echo "$label is ready ($url)"
+                  return 0
+                }
+              else
+                curl_result=$(curl --fail --silent --show-error "$url" 2>&1) && {
+                  echo "$label is ready ($url)"
+                  return 0
+                }
               fi
 
               echo "[$attempt/$attempts] Waiting for $label at $url"
@@ -239,6 +251,7 @@ jobs:
 
             for ((attempt=1; attempt<=attempts; attempt+=1)); do
               status=$(curl --fail --silent \
+                -u "${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}" \
                 "http://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS&wt=json" \
                 2>/dev/null) || true
 
@@ -271,8 +284,10 @@ jobs:
             return 1
           }
 
-          wait_for_url "http://localhost:8983/solr/admin/info/system" "Solr" 90
-          wait_for_url "http://localhost:8983/solr/books/admin/ping?distrib=true" "Solr books collection" 90
+          # Solr endpoints require basic auth after security bootstrap
+          SOLR_AUTH="${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}"
+          wait_for_url "http://localhost:8983/solr/admin/info/system" "Solr" 90 5 "$SOLR_AUTH"
+          wait_for_url "http://localhost:8983/solr/books/admin/ping?distrib=true" "Solr books collection" 90 5 "$SOLR_AUTH"
           wait_for_solr_cluster 30 10
           wait_for_url "http://localhost:8080/health" "solr-search API"
           wait_for_url "http://localhost/health" "nginx"

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -25,6 +25,8 @@ import requests
 # ---------------------------------------------------------------------------
 
 SOLR_URL: str = os.environ.get("SOLR_URL", "http://localhost:8983/solr/books")
+SOLR_ADMIN_USER: str = os.environ.get("SOLR_ADMIN_USER", "solr_admin")
+SOLR_ADMIN_PASS: str = os.environ.get("SOLR_ADMIN_PASS", "SolrAdmin_dev2024!")
 SEARCH_API_URL: str = os.environ.get("SEARCH_API_URL", "http://localhost:8080")
 E2E_LIBRARY_PATH: str = os.environ.get("E2E_LIBRARY_PATH", "/tmp/aithena-e2e-library")
 
@@ -97,7 +99,12 @@ def solr_url() -> str:
 def solr_available(solr_url: str) -> None:
     """Fail fast if the Solr books collection is not reachable."""
     try:
-        resp = requests.get(f"{solr_url}/admin/ping", params={"distrib": "true"}, timeout=5)
+        resp = requests.get(
+            f"{solr_url}/admin/ping",
+            params={"distrib": "true"},
+            auth=(SOLR_ADMIN_USER, SOLR_ADMIN_PASS),
+            timeout=5,
+        )
         resp.raise_for_status()
     except Exception as exc:
         pytest.skip(


### PR DESCRIPTION
## Problem

After the Solr 9.7 security bootstrap (`solr auth enable`) in #964, all Solr endpoints require basic auth. The CI integration test workflow's health check step and E2E conftest were using unauthenticated requests, causing 401 failures that block the dev→main release PR (#971).

## Changes

- **`.github/workflows/integration-test.yml`**: Added optional `auth` parameter to `wait_for_url()` helper; pass Solr admin credentials to Solr health check URLs; added auth to `wait_for_solr_cluster` CLUSTERSTATUS call
- **`e2e/conftest.py`**: Added `SOLR_ADMIN_USER`/`SOLR_ADMIN_PASS` config vars; pass auth to `solr_available` fixture's ping request

## Testing

This will be verified by the CI integration test itself passing.