### PR TITLE
fix(ci): add Solr basic auth to E2E test suite

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -96,13 +96,19 @@ def solr_url() -> str:
 
 
 @pytest.fixture(scope="session")
-def solr_available(solr_url: str) -> None:
+def solr_auth() -> tuple[str, str]:
+    """Solr basic auth credentials (username, password)."""
+    return (SOLR_ADMIN_USER, SOLR_ADMIN_PASS)
+
+
+@pytest.fixture(scope="session")
+def solr_available(solr_url: str, solr_auth: tuple[str, str]) -> None:
     """Fail fast if the Solr books collection is not reachable."""
     try:
         resp = requests.get(
             f"{solr_url}/admin/ping",
             params={"distrib": "true"},
-            auth=(SOLR_ADMIN_USER, SOLR_ADMIN_PASS),
+            auth=solr_auth,
             timeout=5,
         )
         resp.raise_for_status()
@@ -201,18 +207,22 @@ def wait_for_solr_doc(
     doc_id: str,
     timeout: int = 90,
     poll_interval: int = 5,
+    auth: tuple[str, str] | None = None,
 ) -> dict | None:
     """
     Poll Solr until a document with *doc_id* appears or *timeout* seconds pass.
 
     Returns the Solr document dict on success, or None on timeout.
     """
+    if auth is None:
+        auth = (SOLR_ADMIN_USER, SOLR_ADMIN_PASS)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
             resp = requests.get(
                 f"{solr_url}/select",
                 params={"q": f"id:{doc_id}", "wt": "json"},
+                auth=auth,
                 timeout=10,
             )
             resp.raise_for_status()

--- a/e2e/test_upload_index_search.py
+++ b/e2e/test_upload_index_search.py
@@ -33,10 +33,13 @@ from pathlib import Path
 
 import requests
 from conftest import (
+    SOLR_ADMIN_PASS,
+    SOLR_ADMIN_USER,
     wait_for_solr_doc,
 )
 
 SOLR_TIMEOUT = 60  # seconds to wait for a Solr document to appear
+SOLR_AUTH = (SOLR_ADMIN_USER, SOLR_ADMIN_PASS)
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +93,7 @@ def _index_pdf(solr_url: str, pdf_path: Path, base_path: Path) -> requests.Respo
             f"{solr_url}/update/extract",
             params=params,
             files={"file": (pdf_path.name, fh, "application/pdf")},
+            auth=SOLR_AUTH,
             timeout=60,
         )
     return resp
@@ -104,6 +108,7 @@ def _capture_diagnostics(solr_url: str, label: str) -> None:
         info = requests.get(
             f"{solr_url}/select",
             params={"q": "*:*", "rows": "5", "wt": "json", "sort": "id asc"},
+            auth=SOLR_AUTH,
             timeout=10,
         )
         print(f"[Solr recent docs] status={info.status_code}")
@@ -206,6 +211,7 @@ class TestUploadIndexSearchView:
                 "wt": "json",
                 "fl": "id,title_s,author_s,year_i,file_path_s,folder_path_s",
             },
+            auth=SOLR_AUTH,
             timeout=10,
         )
         resp.raise_for_status()
@@ -255,6 +261,7 @@ class TestUploadIndexSearchView:
                 "wt": "json",
                 "fl": "file_path_s",
             },
+            auth=SOLR_AUTH,
             timeout=10,
         )
         resp.raise_for_status()
@@ -288,6 +295,7 @@ class TestUploadIndexSearchView:
             f"{solr_url}/update",
             params={"commitWithin": "2000", "wt": "json"},
             json={"delete": {"id": fixture_solr_id}},
+            auth=SOLR_AUTH,
             timeout=30,
         )
         # A 200 or 404 are both acceptable (document may not exist)


### PR DESCRIPTION
## Problem

The E2E integration tests in `test_upload_index_search.py` make direct Solr HTTP requests (select, update/extract, update/delete) that return 401 Unauthorized after the Solr 9.7 security bootstrap (`solr auth enable`) introduced in #964.

This is the second part of the CI auth fix — PR #975 fixed the health check step, this fixes the actual E2E test suite.

## Changes

- **`e2e/conftest.py`**: Added `solr_auth` session fixture; pass auth to `wait_for_solr_doc` helper; export `SOLR_ADMIN_USER`/`SOLR_ADMIN_PASS` constants
- **`e2e/test_upload_index_search.py`**: Added `SOLR_AUTH` tuple; pass `auth=SOLR_AUTH` to all `requests.get/post` calls that hit Solr directly

## Testing

The CI integration test should now pass end-to-end.