### PR TITLE
fix(squad): add 🔄 emoji to Ralph roster entry for heartbeat detection

### DIFF
--- a/.squad/team.md
+++ b/.squad/team.md
@@ -18,7 +18,7 @@
 | Ash | Search Engineer | `.squad/agents/ash/charter.md` | Active |
 | Lambert | Tester | `.squad/agents/lambert/charter.md` | Active |
 | Scribe | Session Logger | `.squad/agents/scribe/charter.md` | Active |
-| Ralph | Work Monitor | — | Monitor |
+| Ralph | Work Monitor | — | 🔄 Monitor |
 | Brett | Infra Architect | `.squad/agents/brett/charter.md` | Active |
 | Kane | Security Engineer | `.squad/agents/kane/charter.md` | Active |
 | Juanma | Product Owner | — | Human |


### PR DESCRIPTION
The `squad-heartbeat-triage` action checks for both `Ralph` AND `🔄` in team.md to confirm Ralph is on the roster. The emoji was missing from the Status column, causing heartbeat to report *"Ralph not on roster — heartbeat disabled"*.

**Fix:** Change `| Ralph | Work Monitor | — | Monitor |` → `| Ralph | Work Monitor | — | 🔄 Monitor |`