### PR TITLE
fix(squad): heartbeat Dependabot triage permissions + remove false-positive

### DIFF
--- a/.github/actions/squad-heartbeat-triage/action.yml
+++ b/.github/actions/squad-heartbeat-triage/action.yml
@@ -80,8 +80,7 @@ runs:
             return !memberLabels.some(ml => issueLabels.includes(ml));
           });
 
-          // 2. Find assigned but unstarted issues (has squad:{member} label, no assignee)
-          const unstarted = [];
+          // 2. Fix orphaned squad:* labels (ensure parent 'squad' label is present)
           for (const member of members) {
             try {
               const { data: memberIssues } = await github.rest.issues.listForRepo({
@@ -92,7 +91,6 @@ runs:
                 per_page: 10
               });
               for (const issue of memberIssues) {
-                // Ensure parent 'squad' label is present (fix orphaned squad:* labels)
                 const hasSquadLabel = issue.labels.some(l => l.name === 'squad');
                 if (!hasSquadLabel) {
                   await github.rest.issues.addLabels({
@@ -102,9 +100,6 @@ runs:
                     labels: ['squad']
                   });
                   core.info(`Fixed orphaned label: added 'squad' to #${issue.number}`);
-                }
-                if (!issue.assignees || issue.assignees.length === 0) {
-                  unstarted.push({ issue, member });
                 }
               }
             } catch (e) {
@@ -195,9 +190,6 @@ runs:
           const summary = [];
           if (untriaged.length > 0) {
             summary.push(`🔴 **${untriaged.length} untriaged issue(s)** need triage`);
-          }
-          if (unstarted.length > 0) {
-            summary.push(`🟡 **${unstarted.length} assigned issue(s)** have no assignee`);
           }
           if (missingVerdict.length > 0) {
             summary.push(`⚪ **${missingVerdict.length} issue(s)** missing triage verdict (no \`go:\` label)`);

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -17,7 +17,7 @@ on:
 permissions:
   issues: write
   contents: read
-  pull-requests: read
+  pull-requests: write
   checks: read
 
 jobs:


### PR DESCRIPTION
## Problem

Two issues in the squad heartbeat action:

1. **Dependabot PR triage fails** with `Resource not accessible by integration` — the workflow had `pull-requests: read` but the action needs `write` to add labels and comments.

2. **False-positive warning** — `🟡 2 assigned issue(s) have no assignee` fires because squad agents aren't GitHub users. Issues routed via `squad:*` labels will never have a GitHub assignee.

## Fix

1. `squad-heartbeat.yml`: upgrade `pull-requests: read` → `pull-requests: write`
2. `squad-heartbeat-triage/action.yml`: remove the "unstarted" check (kept the orphaned-label fix logic)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>