### PR TITLE
fix: ensure upload directory exists with correct permissions

### DIFF
--- a/src/solr-search/entrypoint.sh
+++ b/src/solr-search/entrypoint.sh
@@ -7,6 +7,9 @@ set -e
 if [ "$(id -u)" = "0" ]; then
     chown -R app:app /data/auth 2>/dev/null || true
     chown -R app:app /data/collections 2>/dev/null || true
+    # Ensure uploads dir exists inside the bind-mounted document volume
+    mkdir -p /data/documents/uploads 2>/dev/null || true
+    chown app:app /data/documents/uploads 2>/dev/null || true
     exec gosu app "$@"
 fi
 

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -2777,7 +2777,13 @@ async def upload_pdf(file: UploadFile, request: Request) -> dict[str, Any]:
     safe_filename = _sanitize_filename(file.filename)
 
     # Ensure upload directory exists
-    settings.upload_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        settings.upload_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Upload directory is not available. Check volume permissions.",
+        ) from exc
 
     # Handle filename collision with timestamp
     target_path = settings.upload_dir / safe_filename


### PR DESCRIPTION
Fixes PermissionError on `/data/documents/uploads` that was blocking integration tests.

**Root cause:** The entrypoint.sh fixed ownership of `/data/auth` and `/data/collections` but not the uploads directory. When `document-data` is bind-mounted, the Dockerfile's pre-created `/data/documents/uploads` is replaced, and the `app` user (UID 1000) can't create it.

**Fix:**
- `entrypoint.sh`: Create and chown `/data/documents/uploads` before dropping to unprivileged user
- `main.py`: Wrap `mkdir()` in try/except to return a clear 503 instead of unhandled 500

This was the last error blocking integration tests for PR #997 (v1.14.1 release).