### PR TITLE
fix: PDF viewer close hides similar-books panel + fix stale test selector

### DIFF
--- a/e2e/playwright/tests/search.spec.ts
+++ b/e2e/playwright/tests/search.spec.ts
@@ -107,7 +107,7 @@ test('pdf viewer opens from a search result and loads the document iframe', asyn
 
   const viewer = page.locator('.pdf-viewer-overlay');
   await expect(viewer).toBeVisible({ timeout: 10_000 });
-  await expect(viewer.locator('.pdf-viewer-title strong')).toContainText(scenario.result.title, { timeout: 10_000 });
+  await expect(viewer.locator('.pdf-viewer-toolbar__title strong')).toContainText(scenario.result.title, { timeout: 10_000 });
   await expect(viewer.locator('.pdf-viewer-frame')).toBeVisible({ timeout: 10_000 });
   await expect(viewer.locator('.pdf-viewer-frame')).toHaveAttribute('src', /\/documents\//);
 

--- a/src/aithena-ui/src/pages/SearchPage.tsx
+++ b/src/aithena-ui/src/pages/SearchPage.tsx
@@ -301,6 +301,7 @@ function SearchPage() {
 
   const handleClosePdf = useCallback(() => {
     setSelectedBook(null);
+    setFocusedBookId(null);
 
     window.requestAnimationFrame(() => {
       lastPdfTriggerRef.current?.focus();


### PR DESCRIPTION
Fixes the 2 remaining Playwright test failures blocking v1.14.1 release.

**Root cause analysis:**
Both bugs were masked because the RabbitMQ indexer lacked `queue_bind` permission (#995), preventing proper document indexing. With no indexed documents having `document_url`, `pdfScenario` was null and these tests were skipped. After fixing RabbitMQ permissions, documents are properly indexed and these tests actually run — revealing:

1. **Stale selector** (`search.spec.ts`): PR #836 renamed `.pdf-viewer-title` → `.pdf-viewer-toolbar__title` but the E2E test was never updated. Fix: update selector.

2. **Similar books not hiding** (`similar-books.spec.ts`): `handleClosePdf` cleared `selectedBook` (hiding PdfViewer) but not `focusedBookId` (SimilarBooks stayed visible). Fix: also clear `focusedBookId` on PDF close.

This is exactly the kind of cascading bug that the v1.15.0 release quality milestone (#1004-#1022) aims to prevent.