### PR TITLE
fix: suppress noisy PDFBox font-fallback warnings in Solr logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -551,6 +551,7 @@ services:
       - solr-data:/var/solr/data
       - document-data:/data/documents:ro
       - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
+      - ./src/solr/log4j2.xml:/opt/solr/server/resources/log4j2.xml:ro
     environment:
       SOLR_MODULES: extraction,langid
       SOLR_SECURITY_MANAGER_ENABLED: "false"
@@ -606,6 +607,7 @@ services:
       - solr-data2:/var/solr/data
       - document-data:/data/documents:ro
       - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
+      - ./src/solr/log4j2.xml:/opt/solr/server/resources/log4j2.xml:ro
     environment:
       SOLR_MODULES: extraction,langid
       SOLR_SECURITY_MANAGER_ENABLED: "false"
@@ -660,6 +662,7 @@ services:
       - solr-data3:/var/solr/data
       - document-data:/data/documents:ro
       - ./src/solr/entrypoint-sasl.sh:/entrypoint-sasl.sh:ro
+      - ./src/solr/log4j2.xml:/opt/solr/server/resources/log4j2.xml:ro
     environment:
       SOLR_MODULES: extraction,langid
       SOLR_SECURITY_MANAGER_ENABLED: "false"

--- a/src/solr/log4j2.xml
+++ b/src/solr/log4j2.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Custom Solr log4j2 configuration for Aithena.
+  Based on the Solr 9.7 default with added suppression of
+  noisy PDFBox font-fallback warnings during PDF extraction.
+-->
+<Configuration>
+  <Appenders>
+
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout>
+        <Pattern>
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ t:%X{trace_id}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+        </Pattern>
+      </PatternLayout>
+    </Console>
+
+    <RollingRandomAccessFile
+        name="MainLogFile"
+        fileName="${sys:solr.log.dir}/solr.log"
+        filePattern="${sys:solr.log.dir}/solr.log.%i" >
+      <PatternLayout>
+        <Pattern>
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ t:%X{trace_id}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+        </Pattern>
+      </PatternLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy />
+        <SizeBasedTriggeringPolicy size="32 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingRandomAccessFile>
+
+    <RollingRandomAccessFile
+        name="SlowLogFile"
+        fileName="${sys:solr.log.dir}/solr_slow_requests.log"
+        filePattern="${sys:solr.log.dir}/solr_slow_requests.log.%i" >
+      <PatternLayout>
+        <Pattern>
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ t:%X{trace_id}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+        </Pattern>
+      </PatternLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy />
+        <SizeBasedTriggeringPolicy size="32 MB"/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingRandomAccessFile>
+
+  </Appenders>
+  <Loggers>
+    <AsyncLogger name="org.apache.hadoop" level="warn"/>
+    <AsyncLogger name="org.apache.solr.update.LoggingInfoStream" level="off"/>
+    <AsyncLogger name="org.apache.zookeeper" level="warn"/>
+    <AsyncLogger name="org.apache.solr.servlet.HttpSolrCall" level="info">
+      <MarkerFilter marker="org.apache.solr.handler.admin.MetricsHandler" onMatch="DENY" onMismatch="ACCEPT"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.apache.solr.core.SolrCore.SlowRequest" level="info" additivity="false">
+      <AppenderRef ref="SlowLogFile"/>
+    </AsyncLogger>
+    <AsyncLogger name="org.eclipse.jetty.deploy" level="warn"/>
+    <AsyncLogger name="org.eclipse.jetty.webapp" level="warn"/>
+    <AsyncLogger name="org.eclipse.jetty.server.session" level="warn"/>
+
+    <!-- Suppress noisy PDFBox font-fallback warnings during PDF extraction -->
+    <AsyncLogger name="org.apache.pdfbox.pdmodel.font" level="error"/>
+    <AsyncLogger name="org.apache.fontbox" level="error"/>
+
+    <AsyncRoot level="info">
+      <AppenderRef ref="MainLogFile"/>
+      <AppenderRef ref="STDOUT"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
## Problem

During PDF extraction (via Solr's `/update/extract` handler), Apache PDFBox emits hundreds of WARN-level messages like:

```
o.a.p.p.f.PDType1Font Using fallback font LiberationSans for Helvetica
o.a.p.p.f.PDType1Font Using fallback font LiberationSans for Times-Roman
```

These are **harmless** — LiberationSans is a correct metric-compatible substitute for the standard PDF base-14 fonts. But they flood Docker logs (~90% of all output during indexing), making real issues hard to spot.

## Fix

- **New file:** `src/solr/log4j2.xml` — custom Solr logging config based on the Solr 9.7 default, with two additional loggers:
  - `org.apache.pdfbox.pdmodel.font` → ERROR (suppresses font fallback warnings)
  - `org.apache.fontbox` → ERROR (suppresses related font-box warnings)
- **Updated:** `docker-compose.yml` — mounts the custom log4j2.xml into all 3 Solr containers at `/opt/solr/server/resources/log4j2.xml:ro`

## Tested

- All 3 Solr containers restart healthy with the new config
- PDF indexing continues to work correctly
- Font fallback warnings are eliminated from Docker logs
- All other Solr log levels remain at their defaults (INFO for root, WARN for Hadoop/ZK/Jetty)