### PR TITLE
feat: automate main→dev sync after release merges

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,193 @@
+# GitHub Action: Sync main → dev after release merges
+#
+# Triggers on: push to main
+#
+# What it does:
+# 1. Checks if main has commits not yet in dev
+# 2. Attempts to merge main into dev via a temporary branch
+# 3. If no conflicts: creates a PR with `automerge` label and auto-merges it
+# 4. If conflicts: creates a PR with `conflict` label for manual resolution
+#
+# This eliminates the manual sync PR that was needed after every release merge
+# (dev→main creates a merge commit on main not present in dev).
+
+name: Sync main → dev
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync main to dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Check if sync is needed
+        id: check
+        run: |
+          git fetch origin main
+          BEHIND=$(git rev-list --count dev..origin/main)
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+          if [ "$BEHIND" -eq 0 ]; then
+            echo "✅ dev is up-to-date with main — nothing to sync"
+          else
+            echo "🔄 dev is $BEHIND commit(s) behind main — sync needed"
+          fi
+
+      - name: Attempt merge
+        if: steps.check.outputs.behind != '0'
+        id: merge
+        run: |
+          SYNC_BRANCH="automation/sync-main-to-dev"
+          echo "branch=$SYNC_BRANCH" >> "$GITHUB_OUTPUT"
+
+          # Clean up any leftover remote branch from a previous run
+          git push origin --delete "$SYNC_BRANCH" 2>/dev/null || true
+
+          git checkout -b "$SYNC_BRANCH"
+
+          if git merge origin/main --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "✅ Merge succeeded without conflicts"
+          else
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Merge conflicts detected — committing conflict markers"
+            git add -A
+            git commit --no-edit -m "chore: sync main → dev (conflicts need resolution)" || true
+          fi
+
+          git push origin "$SYNC_BRANCH"
+
+      - name: Create PR (no conflicts)
+        if: steps.check.outputs.behind != '0' && steps.merge.outputs.conflict == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SYNC_BRANCH: ${{ steps.merge.outputs.branch }}
+        run: |
+          # Check if a sync PR already exists
+          EXISTING=$(gh pr list --head "$SYNC_BRANCH" --base dev --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            echo "ℹ️ Sync PR #$EXISTING already exists — skipping creation"
+            exit 0
+          fi
+
+          PR_URL=$(gh pr create \
+            --base dev \
+            --head "$SYNC_BRANCH" \
+            --title "chore: sync main → dev" \
+            --body "$(cat <<'EOF'
+          ## 🔄 Automated sync: main → dev
+
+          This PR brings dev up-to-date with main after a release merge.
+
+          **Merge completed cleanly — no conflicts detected.**
+
+          This PR will be auto-merged.
+
+          ---
+          _Created automatically by the sync-main-to-dev workflow._
+          EOF
+          )" \
+            --label "automerge")
+
+          echo "✅ Created sync PR: $PR_URL"
+
+      - name: Auto-merge PR (no conflicts)
+        if: steps.check.outputs.behind != '0' && steps.merge.outputs.conflict == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SYNC_BRANCH: ${{ steps.merge.outputs.branch }}
+        run: |
+          PR_NUMBER=$(gh pr list --head "$SYNC_BRANCH" --base dev --state open --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::warning::Could not find sync PR to auto-merge"
+            exit 0
+          fi
+
+          gh pr review "$PR_NUMBER" --approve \
+            --body "Auto-approved: clean sync from main to dev (no conflicts)"
+          gh pr merge "$PR_NUMBER" --auto --merge
+          echo "✅ Auto-merge enabled for PR #$PR_NUMBER"
+
+      - name: Create PR (with conflicts)
+        if: steps.check.outputs.behind != '0' && steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SYNC_BRANCH: ${{ steps.merge.outputs.branch }}
+        run: |
+          # Check if a sync PR already exists
+          EXISTING=$(gh pr list --head "$SYNC_BRANCH" --base dev --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            echo "ℹ️ Sync PR #$EXISTING already exists — skipping creation"
+            exit 0
+          fi
+
+          PR_URL=$(gh pr create \
+            --base dev \
+            --head "$SYNC_BRANCH" \
+            --title "chore: sync main → dev (conflicts)" \
+            --body "$(cat <<'EOF'
+          ## ⚠️ Automated sync: main → dev (conflicts detected)
+
+          This PR brings dev up-to-date with main after a release merge, but **merge conflicts were detected**.
+
+          ### What to do
+          1. Check out this branch locally
+          2. Resolve the conflicts
+          3. Push the resolution
+          4. Merge this PR
+
+          ---
+          _Created automatically by the sync-main-to-dev workflow._
+          EOF
+          )" \
+            --label "conflict")
+
+          echo "⚠️ Created sync PR with conflicts: $PR_URL"
+
+      - name: Workflow summary
+        if: always()
+        env:
+          BEHIND: ${{ steps.check.outputs.behind }}
+          CONFLICT: ${{ steps.merge.outputs.conflict }}
+          SYNC_BRANCH: ${{ steps.merge.outputs.branch }}
+        run: |
+          {
+            echo "## 🔄 Sync main → dev"
+            echo ""
+            if [ "${BEHIND:-0}" -eq 0 ]; then
+              echo "✅ **No sync needed** — dev is already up-to-date with main."
+            elif [ "$CONFLICT" = "true" ]; then
+              echo "⚠️ **Sync PR created with conflicts** — manual resolution required."
+              echo ""
+              echo "- Commits behind: $BEHIND"
+              echo "- Branch: \`$SYNC_BRANCH\`"
+            else
+              echo "✅ **Sync PR created and auto-merge enabled.**"
+              echo ""
+              echo "- Commits behind: $BEHIND"
+              echo "- Branch: \`$SYNC_BRANCH\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🔄 Automate main→dev sync after release merges

Closes #1013

Working as Dallas (Frontend & CI Specialist)

### What this does

Adds a new GitHub Actions workflow (`.github/workflows/sync-main-to-dev.yml`) that automatically creates a sync PR whenever commits are pushed to `main`. This eliminates the manual sync step required after every release merge (dev→main creates a merge commit on main not present in dev).

### How it works

1. **Triggers** on any push to `main`
2. **Checks** if main has commits not yet in dev (`git rev-list --count dev..origin/main`)
3. **Attempts merge** of main into a temporary `automation/sync-main-to-dev` branch
4. **No conflicts** → Creates PR with `automerge` label and enables auto-merge
5. **Conflicts detected** → Creates PR with `conflict` label for manual resolution

### Conventions followed

- Uses `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) pinned to SHA
- Uses `${{ github.token }}` via `GH_TOKEN` env var (repo standard)
- Includes concurrency group to prevent parallel runs
- Includes `GITHUB_STEP_SUMMARY` reporting
- Uses `persist-credentials: true` (needed for git push, same as update-screenshots)
- Follows the bot commit identity pattern (`github-actions[bot]`)

### Testing

- YAML validated with Python yaml parser
- Structure verified: 8 steps covering all scenarios (no sync needed, clean merge, conflict merge)
