### PR TITLE
feat: enforce release checklist as CI gate

### DIFF
--- a/.github/workflows/release-pr-validation.yml
+++ b/.github/workflows/release-pr-validation.yml
@@ -1,0 +1,67 @@
+name: Release PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-checklist:
+    name: Validate release checklist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check required files exist
+        shell: bash
+        run: |
+          missing=()
+          for f in VERSION CHANGELOG.md docker-compose.yml; do
+            if [[ ! -f "$f" ]]; then
+              missing+=("$f")
+            fi
+          done
+
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Missing required files: ${missing[*]}"
+            exit 1
+          fi
+
+          echo "✅ All required files present"
+
+      - name: Validate VERSION is stable semver
+        id: version
+        shell: bash
+        run: |
+          version="$(tr -d '[:space:]' < VERSION)"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::VERSION must be stable semver (X.Y.Z). Found: '$version'"
+            exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "✅ VERSION=$version is valid semver"
+
+      - name: Validate CHANGELOG.md has entry for VERSION
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          if ! grep -qE "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing an entry for version ${VERSION}"
+            echo "::error::Expected a heading like: ## [${VERSION}]"
+            exit 1
+          fi
+
+          echo "✅ CHANGELOG.md contains entry for version ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,14 +246,40 @@ jobs:
           name: release-package
           path: .
 
+      - name: Extract release notes from CHANGELOG.md
+        id: release_notes
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        shell: bash
+        run: |
+          # Extract the section for this version from CHANGELOG.md
+          # Matches from "## [X.Y.Z]" until the next "## [" heading or end of file
+          notes=$(sed -n "/^## \[${VERSION}\]/,/^## \[/{/^## \[${VERSION}\]/d;/^## \[/d;p;}" CHANGELOG.md)
+
+          if [[ -z "$notes" ]]; then
+            echo "::warning::No CHANGELOG.md entry found for ${VERSION}, falling back to auto-generated notes"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            # Write to a temp file to avoid shell quoting issues
+            echo "$notes" > "$RUNNER_TEMP/release-notes.md"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub release with artifacts
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}
           VERSION: ${{ needs.validate-tag.outputs.version }}
+          NOTES_FOUND: ${{ steps.release_notes.outputs.found }}
         run: |
-          gh release create "$TAG_NAME" \
-            --generate-notes \
-            --verify-tag \
+          release_args=("$TAG_NAME" --verify-tag)
+
+          if [[ "$NOTES_FOUND" == "true" ]]; then
+            release_args+=(--notes-file "$RUNNER_TEMP/release-notes.md")
+          else
+            release_args+=(--generate-notes)
+          fi
+
+          gh release create "${release_args[@]}" \
             "aithena-v${VERSION}-release.tar.gz#Production Release Package" \
             "aithena-v${VERSION}-release.tar.gz.sha256#SHA256 Checksum"


### PR DESCRIPTION
Closes #1014

## Summary

Working as Brett (Infrastructure Architect)

Adds automated release checklist enforcement to prevent the recurring release issues (v1.14.0 wrong tag, v1.14.1 false positives, v1.13.0 late CI failures).

### Changes

**New workflow: `release-pr-validation.yml`**
- Triggers on PRs targeting `main` (the release PR path: dev → main)
- Validates VERSION file contains stable semver (X.Y.Z)
- Validates CHANGELOG.md has a `## [X.Y.Z]` entry matching VERSION
- Checks required files exist (VERSION, CHANGELOG.md, docker-compose.yml)

**Enhanced: `release.yml`**
- Extracts release notes from CHANGELOG.md for the tagged version
- Uses extracted notes in GitHub release (falls back to auto-generated if not found)

### Conventions followed
- Pinned actions with SHA + version comments
- `persist-credentials: false` on checkouts
- Concurrency groups with `cancel-in-progress: true`
- Explicit `permissions` block
- `shell: bash` on run steps