### PR TITLE
feat: add allowlist and error threshold to log analyzer

### DIFF
--- a/.github/actions/log-analyzer/action.yml
+++ b/.github/actions/log-analyzer/action.yml
@@ -10,6 +10,12 @@ inputs:
   version-file:
     description: 'Path to the VERSION file'
     default: './VERSION'
+  allowlist-path:
+    description: 'Path to the allowlist file for known false positives (optional)'
+    default: ''
+  max-errors:
+    description: 'Error threshold; only fail if errors exceed this count (default: 0)'
+    default: '0'
   create-issues:
     description: 'Whether to create GitHub issues for findings (true/false)'
     default: 'false'
@@ -43,10 +49,19 @@ runs:
       env:
         INPUT_VERSION_FILE: ${{ inputs.version-file }}
         INPUT_COMPOSE_LOGS_PATH: ${{ inputs.compose-logs-path }}
+        INPUT_ALLOWLIST_PATH: ${{ inputs.allowlist-path }}
+        INPUT_MAX_ERRORS: ${{ inputs.max-errors }}
       run: |
         set +e
+        ANALYZER_ARGS="--version-file $INPUT_VERSION_FILE"
+        if [ -n "$INPUT_ALLOWLIST_PATH" ] && [ -f "$INPUT_ALLOWLIST_PATH" ]; then
+          ANALYZER_ARGS="$ANALYZER_ARGS --allowlist $INPUT_ALLOWLIST_PATH"
+        fi
+        if [ -n "$INPUT_MAX_ERRORS" ]; then
+          ANALYZER_ARGS="$ANALYZER_ARGS --max-errors $INPUT_MAX_ERRORS"
+        fi
         sh e2e/pre-release-check.sh \
-          --version-file "$INPUT_VERSION_FILE" \
+          $ANALYZER_ARGS \
           "$INPUT_COMPOSE_LOGS_PATH" \
           > "$RUNNER_TEMP/findings.json" 2>"$RUNNER_TEMP/analyzer-summary.txt"
         EXIT_CODE=$?

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -403,6 +403,8 @@ jobs:
         with:
           compose-logs-path: ${{ runner.temp }}/compose-logs.txt
           version-file: ./VERSION
+          allowlist-path: ./e2e/pre-release-allowlist.txt
+          max-errors: '0'
           create-issues: 'true'
           milestone: ''
           artifact-name: integration-test-log-analysis

--- a/e2e/pre-release-allowlist.txt
+++ b/e2e/pre-release-allowlist.txt
@@ -1,0 +1,30 @@
+# Pre-release Log Analyzer — Allowlist of known false positives
+#
+# Format: category:pattern=severity
+# Lines starting with # are comments, blank lines are ignored.
+# Patterns are shell globs matched against the message field of findings.
+# Severity overrides: ignore (drop finding), warning, info
+# If severity is omitted, defaults to "ignore".
+#
+# The category field must match one of the analyzer categories:
+#   crash, deprecation, version, slow_startup, connection,
+#   security, memory, config, dependency
+
+# ZK non-TLS quorum communication is expected in CI environments
+security:*insecure*quorum*=ignore
+security:*non-tls*quorum*=ignore
+
+# JVM startup flags like -XX:+CrashOnOutOfMemoryError are not actual OOM errors
+memory:*CrashOnOutOfMemoryError*=ignore
+
+# Read-only volume permission errors are expected for :ro mounts
+security:*PermissionError*=warning
+security:*permission denied*read-only*=warning
+
+# Solr deprecation warnings for internal APIs
+deprecation:*Deprecated*=info
+deprecation:*deprecated*=info
+
+# Connection retries during startup are normal for Docker Compose orchestration
+connection:*retrying*=ignore
+connection:*connection refused*=ignore

--- a/e2e/pre-release-check.sh
+++ b/e2e/pre-release-check.sh
@@ -17,6 +17,8 @@ Options:
   --startup-threshold N  Seconds to flag slow startups (default: 30)
   --ignore-startup-window N  Seconds after first log line to ignore connection
                              retries (default: 60)
+  --allowlist PATH      Path to allowlist file for false positives
+  --max-errors N        Error threshold; exit 0 if errors <= N (default: 0)
   -h, --help            Show this help
 
 Categories:
@@ -35,12 +37,16 @@ EOF
 VERSION_FILE="./VERSION"
 STARTUP_THRESHOLD=30
 STARTUP_WINDOW=60
+ALLOWLIST_FILE=""
+MAX_ERRORS=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --version-file)  VERSION_FILE="$2"; shift 2 ;;
     --startup-threshold) STARTUP_THRESHOLD="$2"; shift 2 ;;
     --ignore-startup-window) STARTUP_WINDOW="$2"; shift 2 ;;
+    --allowlist) ALLOWLIST_FILE="$2"; shift 2 ;;
+    --max-errors) MAX_ERRORS="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     -*) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
     *)  break ;;
@@ -79,6 +85,96 @@ extract_service() {
   printf '%s' "$1" | sed -n 's/^\([a-zA-Z0-9_-]*\)[[:space:]]*|.*/\1/p'
 }
 
+# --- Allowlist loading ---
+# Parsed into parallel arrays: AL_CATEGORY[], AL_PATTERN[], AL_SEVERITY[]
+AL_COUNT=0
+AL_CATEGORIES=""
+AL_PATTERNS=""
+AL_SEVERITIES=""
+
+load_allowlist() {
+  _file="$1"
+  if [ ! -f "$_file" ]; then
+    echo "Warning: allowlist file not found: $_file" >&2
+    return
+  fi
+  while IFS= read -r _line; do
+    # Skip comments and blank lines
+    case "$_line" in
+      "#"*|"") continue ;;
+    esac
+    # Parse category:pattern=severity
+    _cat="${_line%%:*}"
+    _rest="${_line#*:}"
+    case "$_rest" in
+      *=*)
+        _pat="${_rest%%=*}"
+        _sev="${_rest##*=}"
+        ;;
+      *)
+        _pat="$_rest"
+        _sev="ignore"
+        ;;
+    esac
+    AL_COUNT=$((AL_COUNT + 1))
+    AL_CATEGORIES="${AL_CATEGORIES}${_cat}
+"
+    AL_PATTERNS="${AL_PATTERNS}${_pat}
+"
+    AL_SEVERITIES="${AL_SEVERITIES}${_sev}
+"
+  done < "$_file"
+  echo "Loaded $AL_COUNT allowlist rules from $_file" >&2
+}
+
+# Check if a finding matches an allowlist rule.
+# Returns the overridden severity via stdout, or empty string if no match.
+check_allowlist() {
+  _check_cat="$1"
+  _check_msg="$2"
+  _lc_msg="$(printf '%s' "$_check_msg" | tr '[:upper:]' '[:lower:]')"
+  if [ "$AL_COUNT" -eq 0 ]; then
+    return
+  fi
+  _idx=0
+  _remaining_cats="$AL_CATEGORIES"
+  _remaining_pats="$AL_PATTERNS"
+  _remaining_sevs="$AL_SEVERITIES"
+  while [ "$_idx" -lt "$AL_COUNT" ]; do
+    _al_cat="${_remaining_cats%%
+*}"
+    _remaining_cats="${_remaining_cats#*
+}"
+    _al_pat="${_remaining_pats%%
+*}"
+    _remaining_pats="${_remaining_pats#*
+}"
+    _al_sev="${_remaining_sevs%%
+*}"
+    _remaining_sevs="${_remaining_sevs#*
+}"
+    # Category must match (or be '*')
+    if [ "$_al_cat" != "*" ] && [ "$_al_cat" != "$_check_cat" ]; then
+      _idx=$((_idx + 1))
+      continue
+    fi
+    # Convert pattern to lowercase for case-insensitive glob matching
+    _lc_pat="$(printf '%s' "$_al_pat" | tr '[:upper:]' '[:lower:]')"
+    # shellcheck disable=SC2254
+    case "$_lc_msg" in
+      $_lc_pat)
+        printf '%s' "$_al_sev"
+        return
+        ;;
+    esac
+    _idx=$((_idx + 1))
+  done
+}
+
+if [ -n "$ALLOWLIST_FILE" ]; then
+  load_allowlist "$ALLOWLIST_FILE"
+fi
+
 # Finding accumulator
 FINDINGS=""
 FINDING_COUNT=0
@@ -89,14 +185,25 @@ add_finding() {
   _cat="$1"
   _sev="$2"
   _svc="$3"
-  _msg="$(json_escape "$4")"
+  _msg="$4"
   _line="$5"
+
+  # Check allowlist for severity override
+  _override="$(check_allowlist "$_cat" "$_msg")"
+  if [ -n "$_override" ]; then
+    if [ "$_override" = "ignore" ]; then
+      return
+    fi
+    _sev="$_override"
+  fi
+
+  _esc_msg="$(json_escape "$_msg")"
 
   if [ "$FINDING_COUNT" -gt 0 ]; then
     FINDINGS="${FINDINGS},"
   fi
 
-  FINDINGS="${FINDINGS}{\"category\":\"${_cat}\",\"severity\":\"${_sev}\",\"service\":\"${_svc}\",\"message\":\"${_msg}\",\"line\":${_line}}"
+  FINDINGS="${FINDINGS}{\"category\":\"${_cat}\",\"severity\":\"${_sev}\",\"service\":\"${_svc}\",\"message\":\"${_esc_msg}\",\"line\":${_line}}"
   FINDING_COUNT=$((FINDING_COUNT + 1))
 
   case "$_sev" in
@@ -314,9 +421,13 @@ printf '[%s]\n' "$FINDINGS"
 # Summary to stderr
 echo "--- Pre-release check summary ---" >&2
 echo "Total findings: $FINDING_COUNT (errors: $ERROR_COUNT, warnings: $WARNING_COUNT)" >&2
+if [ -n "$ALLOWLIST_FILE" ]; then
+  echo "Allowlist: $ALLOWLIST_FILE ($AL_COUNT rules loaded)" >&2
+fi
+echo "Error threshold: $MAX_ERRORS" >&2
 
 # Exit code
-if [ "$ERROR_COUNT" -gt 0 ]; then
+if [ "$ERROR_COUNT" -gt "$MAX_ERRORS" ]; then
   exit 1
 elif [ "$WARNING_COUNT" -gt 0 ]; then
   exit 2

--- a/tests/test-pre-release-check.sh
+++ b/tests/test-pre-release-check.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+# Unit tests for e2e/pre-release-check.sh
+# Run: sh tests/test-pre-release-check.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ANALYZER="$REPO_ROOT/e2e/pre-release-check.sh"
+ALLOWLIST="$REPO_ROOT/e2e/pre-release-allowlist.txt"
+PASS=0
+FAIL=0
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+assert_exit() {
+  _label="$1"
+  _expected="$2"
+  _actual="$3"
+  if [ "$_expected" = "$_actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✅ $_label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ❌ $_label (expected exit=$_expected, got $_actual)"
+  fi
+}
+
+assert_json_count() {
+  _label="$1"
+  _json_file="$2"
+  _expected="$3"
+  _actual="$(python3 -c "import json; print(len(json.load(open('$_json_file'))))")"
+  if [ "$_expected" = "$_actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✅ $_label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ❌ $_label (expected $_expected findings, got $_actual)"
+  fi
+}
+
+assert_json_field() {
+  _label="$1"
+  _json_file="$2"
+  _index="$3"
+  _field="$4"
+  _expected="$5"
+  _actual="$(python3 -c "import json; print(json.load(open('$_json_file'))[$_index]['$_field'])")"
+  if [ "$_expected" = "$_actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✅ $_label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ❌ $_label (expected $_field='$_expected', got '$_actual')"
+  fi
+}
+
+assert_no_category() {
+  _label="$1"
+  _json_file="$2"
+  _category="$3"
+  _count="$(python3 -c "import json; print(len([f for f in json.load(open('$_json_file')) if f['category'] == '$_category']))")"
+  if [ "$_count" = "0" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✅ $_label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ❌ $_label (found $_count findings with category '$_category')"
+  fi
+}
+
+# -------------------------------------------------------
+echo "Test 1: Clean logs produce zero findings (exit 0)"
+cat > "$tmpdir/clean.txt" <<'EOF'
+app1  | 2024-01-01 Server started successfully
+app2  | 2024-01-01 Listening on port 8080
+EOF
+sh "$ANALYZER" "$tmpdir/clean.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0" 0 "$rc"
+assert_json_count "0 findings" "$tmpdir/out.json" 0
+
+# -------------------------------------------------------
+echo "Test 2: FATAL error produces error finding (exit 1)"
+cat > "$tmpdir/fatal.txt" <<'EOF'
+db1  | 2024-01-01 FATAL: could not connect to database
+EOF
+sh "$ANALYZER" "$tmpdir/fatal.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 1" 1 "$rc"
+assert_json_count "1 finding" "$tmpdir/out.json" 1
+assert_json_field "category=crash" "$tmpdir/out.json" 0 "category" "crash"
+assert_json_field "severity=error" "$tmpdir/out.json" 0 "severity" "error"
+
+# -------------------------------------------------------
+echo "Test 3: Warnings-only produces exit 2"
+cat > "$tmpdir/warn.txt" <<'EOF'
+app1  | 2024-01-01 this feature is deprecated and will be removed
+EOF
+sh "$ANALYZER" "$tmpdir/warn.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 2" 2 "$rc"
+assert_json_field "category=deprecation" "$tmpdir/out.json" 0 "category" "deprecation"
+assert_json_field "severity=warning" "$tmpdir/out.json" 0 "severity" "warning"
+
+# -------------------------------------------------------
+echo "Test 4: Allowlist ignores ZK quorum findings"
+cat > "$tmpdir/zk.txt" <<'EOF'
+zoo1  | 2024-01-01 insecure quorum communication detected
+zoo2  | 2024-01-01 non-tls quorum peer established
+EOF
+sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/zk.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0" 0 "$rc"
+assert_json_count "0 findings (all ignored)" "$tmpdir/out.json" 0
+
+# -------------------------------------------------------
+echo "Test 5: Allowlist ignores CrashOnOutOfMemoryError"
+cat > "$tmpdir/jvm.txt" <<'EOF'
+solr1  | 2024-01-01 -XX:+CrashOnOutOfMemoryError set for JVM
+EOF
+sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/jvm.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0" 0 "$rc"
+assert_json_count "0 findings (ignored)" "$tmpdir/out.json" 0
+
+# -------------------------------------------------------
+echo "Test 6: Allowlist downgrades permission denied to warning"
+cat > "$tmpdir/perm.txt" <<'EOF'
+app1  | 2024-01-01 PermissionError: permission denied on read-only volume
+EOF
+sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/perm.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 2 (warning)" 2 "$rc"
+assert_json_field "severity=warning" "$tmpdir/out.json" 0 "severity" "warning"
+
+# -------------------------------------------------------
+echo "Test 7: Allowlist downgrades deprecation to info"
+cat > "$tmpdir/dep.txt" <<'EOF'
+solr1  | 2024-01-01 Deprecated handler class used in config
+EOF
+sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/dep.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0 (info only)" 0 "$rc"
+assert_json_field "severity=info" "$tmpdir/out.json" 0 "severity" "info"
+
+# -------------------------------------------------------
+echo "Test 8: --max-errors threshold allows some errors"
+cat > "$tmpdir/multi.txt" <<'EOF'
+app1  | 2024-01-01 FATAL: db connect failed
+app2  | 2024-01-01 out of memory error
+EOF
+sh "$ANALYZER" --max-errors 5 "$tmpdir/multi.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0 (errors <= threshold)" 0 "$rc"
+
+sh "$ANALYZER" --max-errors 1 "$tmpdir/multi.txt" > "$tmpdir/out2.json" 2>/dev/null; rc=$?
+assert_exit "exit code 1 (errors > threshold)" 1 "$rc"
+
+# -------------------------------------------------------
+echo "Test 9: --max-errors 0 is default (any error fails)"
+sh "$ANALYZER" "$tmpdir/multi.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 1 (default threshold)" 1 "$rc"
+
+# -------------------------------------------------------
+echo "Test 10: Missing allowlist file is tolerated"
+sh "$ANALYZER" --allowlist "/nonexistent/file.txt" "$tmpdir/clean.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0 (missing allowlist)" 0 "$rc"
+
+# -------------------------------------------------------
+echo "Test 11: Allowlist with real errors still catches them"
+cat > "$tmpdir/mixed.txt" <<'EOF'
+zoo1  | 2024-01-01 insecure quorum communication
+app1  | 2024-01-01 FATAL: unrecoverable error
+solr1 | 2024-01-01 -XX:+CrashOnOutOfMemoryError
+EOF
+sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/mixed.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 1 (real error)" 1 "$rc"
+assert_json_count "1 real finding (others filtered)" "$tmpdir/out.json" 1
+assert_json_field "category=crash" "$tmpdir/out.json" 0 "category" "crash"
+
+# -------------------------------------------------------
+echo ""
+echo "========================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "========================================"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #1006

## Summary

Working as Brett (Infrastructure Architect)

Adds two features to the pre-release log analyzer:

### 1. Allowlist file for false positives (`e2e/pre-release-allowlist.txt`)
- Format: `category:pattern=severity` (shell globs, case-insensitive)
- Severity overrides: `ignore` (drop), `warning`, `info`
- Pre-configured rules for known CI false positives:
  - ZK non-TLS quorum → ignore
  - JVM `CrashOnOutOfMemoryError` flag → ignore
  - `PermissionError` on read-only volumes → warning
  - Solr deprecation warnings → info

### 2. Configurable error threshold (`--max-errors N`)
- Only fail (exit 1) when error count exceeds the threshold
- Default remains 0 (any error fails), preserving existing behavior

### 3. Unit tests (24 test cases)
- Tests cover: clean logs, crash detection, warning-only, allowlist ignore/downgrade, threshold behavior, missing allowlist tolerance, mixed findings

### Changes
- `e2e/pre-release-check.sh` — allowlist parsing + threshold logic
- `.github/actions/log-analyzer/action.yml` — new `allowlist-path` and `max-errors` inputs
- `.github/workflows/integration-test.yml` — passes allowlist path
- `tests/test-pre-release-check.sh` — unit test suite