### PR TITLE
feat: add per-container smoke tests to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,129 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}
 
+  smoke-test:
+    name: Smoke test ${{ matrix.service.image }}
+    runs-on: ubuntu-latest
+    needs:
+      - validate-tag
+      - build-and-push
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - image: solr-search
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 30
+          - image: embeddings-server
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 60
+          - image: admin
+            type: http
+            port: "8501"
+            health_endpoint: /_stcore/health
+            startup_timeout: 30
+          - image: aithena-ui
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 15
+          - image: document-lister
+            type: process
+          - image: document-indexer
+            type: process
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        run: docker pull ghcr.io/jmservera/aithena-${{ matrix.service.image }}:${{ needs.validate-tag.outputs.version }}
+
+      - name: Start container and check health endpoint
+        if: matrix.service.type == 'http'
+        run: |
+          image="ghcr.io/jmservera/aithena-${{ matrix.service.image }}:${{ needs.validate-tag.outputs.version }}"
+          port="${{ matrix.service.port }}"
+          endpoint="${{ matrix.service.health_endpoint }}"
+          timeout="${{ matrix.service.startup_timeout }}"
+
+          docker run -d --name smoke-container -p "${port}:${port}" "${image}"
+
+          elapsed=0
+          echo "Waiting up to ${timeout}s for ${{ matrix.service.image }} at :${port}${endpoint}..."
+          while [ "$elapsed" -lt "$timeout" ]; do
+            if curl -sf "http://localhost:${port}${endpoint}" > /dev/null 2>&1; then
+              echo "✅ ${{ matrix.service.image }} is healthy after ${elapsed}s"
+              exit 0
+            fi
+            # Fail fast if the container exited
+            if ! docker inspect --format='{{.State.Running}}' smoke-container 2>/dev/null | grep -q true; then
+              echo "❌ Container exited before becoming healthy"
+              exit 1
+            fi
+            sleep 2
+            elapsed=$((elapsed + 2))
+          done
+          echo "❌ ${{ matrix.service.image }} failed to respond within ${timeout}s"
+          exit 1
+
+      - name: Verify container starts (process check)
+        if: matrix.service.type == 'process'
+        run: |
+          image="ghcr.io/jmservera/aithena-${{ matrix.service.image }}:${{ needs.validate-tag.outputs.version }}"
+
+          docker run -d --name smoke-container "${image}"
+
+          echo "Waiting 10s to verify ${{ matrix.service.image }} starts without crashing..."
+          sleep 10
+
+          if docker inspect --format='{{.State.Running}}' smoke-container 2>/dev/null | grep -q true; then
+            echo "✅ ${{ matrix.service.image }} is still running after 10s"
+          else
+            exit_code=$(docker inspect --format='{{.State.ExitCode}}' smoke-container)
+            echo "⚠️ ${{ matrix.service.image }} exited with code ${exit_code}"
+            # Queue consumers exit quickly without RabbitMQ/Redis — verify it at
+            # least survived initial module loading (ran for >3s).
+            started=$(docker inspect --format='{{.State.StartedAt}}' smoke-container)
+            finished=$(docker inspect --format='{{.State.FinishedAt}}' smoke-container)
+            runtime=$(python3 -c "
+          from datetime import datetime, timezone
+          fmt = '%Y-%m-%dT%H:%M:%S'
+          s = '${started}'[:19]
+          f = '${finished}'[:19]
+          d = (datetime.strptime(f, fmt) - datetime.strptime(s, fmt)).total_seconds()
+          print(d)
+          ")
+            echo "Container ran for ${runtime}s"
+            if python3 -c "exit(0 if float('${runtime}') >= 3 else 1)"; then
+              echo "✅ ${{ matrix.service.image }} passed module-loading phase (ran ${runtime}s before exit)"
+            else
+              echo "❌ ${{ matrix.service.image }} crashed immediately (${runtime}s) — likely a broken image"
+              exit 1
+            fi
+          fi
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "::group::Container logs for ${{ matrix.service.image }}"
+          docker logs smoke-container 2>&1 || true
+          echo "::endgroup::"
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f smoke-container 2>/dev/null || true
+
   package-release:
     name: Package release artifacts
     runs-on: ubuntu-latest
@@ -232,6 +355,7 @@ jobs:
       - validate-tag
       - build-and-push
       - package-release
+      - smoke-test
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Closes #1004
Partially addresses #1005 (smoke tests + parallel packaging)

Working as Brett (Infrastructure Architect)

## Changes

Adds a `smoke-test` job to the release workflow that runs after `build-and-push` and verifies each Docker image starts correctly before a GitHub release is published.

### HTTP services tested (health endpoint polling)
| Service | Port | Health Endpoint | Timeout |
|---------|------|----------------|---------|
| solr-search | 8080 | `/health` | 30s |
| embeddings-server | 8080 | `/health` | 60s |
| admin (Streamlit) | 8501 | `/_stcore/health` | 30s |
| aithena-ui (nginx) | 8080 | `/health` | 15s |

### Queue consumers tested (process check)
| Service | Check |
|---------|-------|
| document-lister | Survives module loading (>3s) |
| document-indexer | Survives module loading (>3s) |

### Workflow dependency graph
```
validate-tag → build-and-push → ┬─ smoke-test    ─┬→ github-release
                                 └─ package-release ┘
```

- `smoke-test` and `package-release` run **in parallel** after `build-and-push`
- `github-release` gates on **both** completing successfully
- Matrix uses `fail-fast: false` so all containers are tested even if one fails
- Container logs are captured on failure via `docker logs`
- GHA cache for builds (including embeddings-server model weights) was already present