### PR TITLE
fix(document-lister): volume permission hardening with entrypoint wrapper

### DIFF
--- a/src/document-lister/Dockerfile
+++ b/src/document-lister/Dockerfile
@@ -33,7 +33,7 @@ ENV VERSION=${VERSION} \
 
 WORKDIR /app
 
-RUN apk add --no-cache procps
+RUN apk add --no-cache procps su-exec
 
 RUN addgroup -S -g 1000 app && adduser -S -u 1000 -G app app
 
@@ -45,6 +45,9 @@ COPY --from=builder /app/uv.lock /app/uv.lock
 
 RUN mkdir -p /data/documents && chown -R app:app /app /data/documents
 
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
 ENV RABBITMQ_HOST="localhost"
 ENV RABBITMQ_PORT=5672
 ENV REDIS_HOST="localhost"
@@ -53,6 +56,5 @@ ENV DOCUMENT_WILDCARD="*.pdf"
 ENV QUEUE_NAME="new_documents"
 ENV EXCHANGE_NAME="documents"
 
-USER app
-
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["uv", "run", "python", "-m", "document_lister"]

--- a/src/document-lister/entrypoint.sh
+++ b/src/document-lister/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Fix ownership of bind-mounted directories when container starts as root,
+# then drop to the unprivileged "app" user via su-exec (Alpine gosu equivalent).
+#
+# The document-data volume is a host bind mount (type: none, o: bind) so the
+# directory inherits host ownership (typically root:root).  The app user (1000)
+# needs write access to scan and manage documents.
+
+if [ "$(id -u)" = "0" ]; then
+    # Only fix the top-level directory; avoid recursive chown on a potentially
+    # large book library — subdirectory contents stay as-is (readable by all).
+    chown app:app /data/documents 2>/dev/null || true
+    exec su-exec app "$@"
+fi
+
+# Already running as non-root (e.g. --user flag) — just exec the command.
+exec "$@"


### PR DESCRIPTION
## Summary

Working as **Brett** (Infrastructure Architect).

Adds an entrypoint wrapper to **document-lister** that fixes bind-mount directory ownership before dropping to the unprivileged `app` user — resolving the #1 recurring bug where containers fail because host directories are owned by `root:root`.

Closes #1007

## What changed

| File | Change |
|------|--------|
| `src/document-lister/entrypoint.sh` | **New** — chowns `/data/documents` then drops to `app` (UID 1000) via `su-exec` |
| `src/document-lister/Dockerfile` | Install `su-exec`, copy entrypoint, set `ENTRYPOINT`, remove `USER app` |

## Full service audit

| Service | Volume type | Writable? | Permission fix | Status |
|---------|------------|-----------|----------------|--------|
| solr/solr2/solr3 | bind mount (host `/source/volumes/solr-data*`) | ✅ | `entrypoint.sh` + `gosu` | ✅ Already fixed |
| solr-search | bind mount (`AUTH_DB_DIR`) + named vols | ✅ | `entrypoint.sh` + `gosu` | ✅ Already fixed |
| **document-lister** | bind mount (`BOOKS_PATH`) | ✅ | **`entrypoint.sh` + `su-exec`** | **🆕 Fixed in this PR** |
| document-indexer | bind mount (`BOOKS_PATH`) | ❌ read-only | N/A | ✅ No fix needed |
| embeddings-server | none | — | N/A | ✅ No volumes |
| rabbitmq | bind mount (`/source/volumes/rabbitmq-data`) | ✅ | Official `docker-entrypoint.sh` handles it | ✅ Already fixed |
| zoo1/2/3 | bind mount (`/source/volumes/zoo-data*`) | ✅ | Official ZK image handles it | ✅ Already fixed |
| redis | bind mount (`/source/volumes/redis`) | ✅ | Official Redis image handles it | ✅ Already fixed |

### Key finding
All "named" volumes in `docker-compose.yml` are actually host bind mounts (`driver: local, type: none, o: bind`). The `document-data` volume binds to `${BOOKS_PATH:-/data/booklibrary}` — making document-lister the only unprotected service with writable access to a bind mount.

### Design choice: `su-exec` vs `gosu`
document-lister uses Alpine; `su-exec` is the native Alpine equivalent of `gosu` (available in main repos, same behaviour). solr-search uses Debian-slim where `gosu` is standard.

## Testing
- Docker build verified: image builds cleanly
- Container starts as root, entrypoint drops to `app` (UID 1000)
- Write test to `/data/documents` succeeds after ownership fix
