### PR TITLE
fix(e2e): handle flaky Playwright E2E tests with readiness gate and retries

### DIFF
--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -118,10 +118,70 @@ async function writeAuthStorageState(resolvedBaseURL: string): Promise<void> {
   }
 }
 
+const SEARCH_READY_TIMEOUT_MS = Number(process.env.SEARCH_READY_TIMEOUT_MS || '120000');
+const SEARCH_READY_POLL_MS = 3_000;
+
+async function waitForSearchReadiness(resolvedBaseURL: string, accessToken: string): Promise<void> {
+  const apiBaseURL = getApiBaseUrl(resolvedBaseURL) || DEFAULT_SEARCH_API_URL;
+  const searchUrl = new URL('/v1/search/', `${apiBaseURL}/`).toString();
+  const api = await playwrightRequest.newContext({ ignoreHTTPSErrors: true });
+  const startedAt = Date.now();
+  let lastError = '';
+
+  try {
+    while (Date.now() - startedAt < SEARCH_READY_TIMEOUT_MS) {
+      try {
+        const response = await api.get(searchUrl, {
+          params: { q: '*', page: '1', limit: '1' },
+          headers: { Authorization: `Bearer ${accessToken}` },
+          timeout: 10_000,
+        });
+
+        if (response.ok()) {
+          const payload = await response.json() as { total?: number };
+          if (typeof payload.total === 'number' && payload.total > 0) {
+            console.log(`[playwright] search readiness confirmed: ${payload.total} document(s) indexed`);
+            return;
+          }
+          lastError = `Search returned 0 results (total: ${payload.total ?? 'undefined'})`;
+        } else {
+          lastError = `Search API responded with ${response.status()}`;
+        }
+      } catch (error) {
+        lastError = `Search API unreachable: ${error instanceof Error ? error.message : String(error)}`;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, SEARCH_READY_POLL_MS));
+    }
+  } finally {
+    await api.dispose();
+  }
+
+  console.warn(
+    `[playwright] search readiness gate timed out after ${SEARCH_READY_TIMEOUT_MS}ms. ` +
+    `Last error: ${lastError}. Proceeding anyway — tests that need indexed data will skip.`
+  );
+}
+
 export default async function globalSetup(_config: FullConfig): Promise<void> {
   const resolvedBaseURL = await findAvailableAppUrl();
   process.env.PLAYWRIGHT_APP_BASE_URL = resolvedBaseURL;
   await writeAuthStorageState(resolvedBaseURL);
+
+  const authState = JSON.parse(
+    await (await import('node:fs/promises')).readFile(AUTH_STATE_PATH, 'utf-8')
+  );
+  const accessToken =
+    authState?.origins?.[0]?.localStorage?.find(
+      (item: { name: string; value: string }) => item.name === AUTH_TOKEN_STORAGE_KEY
+    )?.value || '';
+
+  if (accessToken) {
+    await waitForSearchReadiness(resolvedBaseURL, accessToken);
+  } else {
+    console.warn('[playwright] no auth token available — skipping search readiness gate');
+  }
+
   console.log(`[playwright] using app base URL: ${resolvedBaseURL}`);
   console.log(`[playwright] using search API URL: ${getApiBaseUrl(resolvedBaseURL) || DEFAULT_SEARCH_API_URL}`);
   console.log(`[playwright] wrote auth storage state: ${AUTH_STATE_PATH}`);

--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "test": "npm run test:e2e",
     "test:e2e": "npx playwright test",
+    "test:e2e:gate": "npx playwright test --project=chromium",
+    "test:e2e:screenshots": "npx playwright test --project=screenshots",
     "test:e2e:ui": "npx playwright test --ui"
   },
   "devDependencies": {

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  retries: process.env.CI ? 2 : 0,
   reporter: [['list'], ['html', { open: 'never' }]],
   globalSetup: require.resolve('./global-setup'),
   outputDir: 'test-results',
@@ -28,6 +28,15 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testIgnore: /screenshots\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    {
+      name: 'screenshots',
+      testMatch: /screenshots\.spec\.ts/,
+      retries: 1,
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/e2e/playwright/tests/screenshots.spec.ts
+++ b/e2e/playwright/tests/screenshots.spec.ts
@@ -31,6 +31,9 @@ async function captureUnauthenticatedLoginPage(browser: Browser, appBaseURL: str
 
 test('captures curated screenshots for release documentation', async ({ browser, page, request }, testInfo) => {
   test.slow();
+  // Screenshot tests are non-blocking: failures here must not gate releases.
+  // They run in the separate "screenshots" Playwright project (see playwright.config.ts).
+  test.info().annotations.push({ type: 'non-blocking', description: 'Screenshot capture — does not gate releases.' });
 
   const appBaseURL = getAppBaseURL();
   const catalog = await discoverCatalogScenario(request, appBaseURL);


### PR DESCRIPTION
## Summary

Working as **Lambert** (Tester).

Addresses three root causes of intermittent Playwright E2E failures on CI:

### 1. Pre-test readiness gate
Global setup now polls `/v1/search/?q=*` until at least one indexed document is returned before any test runs. Configurable via `SEARCH_READY_TIMEOUT_MS` (default 120s). On timeout it logs a warning and proceeds — tests that require indexed data already skip gracefully.

### 2. Increased retry count
CI retries increased from 1 → 2 to absorb transient flakiness from auth redirect races, animation timing, and network jitter. Local runs remain at 0 retries.

### 3. Screenshot test separation
`screenshots.spec.ts` is now in its own Playwright project (`screenshots`) with `retries: 1`. The gate project (`chromium`) excludes it via `testIgnore`. New npm scripts:
- `test:e2e:gate` — runs only release-blocking tests
- `test:e2e:screenshots` — runs only screenshot capture

### Files changed
- `e2e/playwright/global-setup.ts` — search readiness polling
- `e2e/playwright/playwright.config.ts` — retries, project split
- `e2e/playwright/tests/screenshots.spec.ts` — non-blocking annotation
- `e2e/playwright/package.json` — new npm scripts

Closes #1022