### PR TITLE
fix: align System Status Redis key pattern with indexer namespace

### DIFF
--- a/src/solr-search/config.py
+++ b/src/solr-search/config.py
@@ -157,8 +157,11 @@ settings = Settings(
     book_embedding_field=os.environ.get("BOOK_EMBEDDING_FIELD", "embedding_v"),
     redis_host=os.environ.get("REDIS_HOST", "redis"),
     redis_port=int(os.environ.get("REDIS_PORT", "6379")),
-    redis_key_pattern=os.environ.get("REDIS_KEY_PATTERN", "doc:*"),
     redis_queue_name=os.environ.get("REDIS_QUEUE_NAME", os.environ.get("QUEUE_NAME", "shortembeddings")),
+    redis_key_pattern=os.environ.get(
+        "REDIS_KEY_PATTERN",
+        f"/{os.environ.get('REDIS_QUEUE_NAME', os.environ.get('QUEUE_NAME', 'shortembeddings'))}/*",
+    ),
     rabbitmq_host=os.environ.get("RABBITMQ_HOST", "rabbitmq"),
     rabbitmq_port=int(os.environ.get("RABBITMQ_PORT", "5672")),
     rabbitmq_user=os.environ.get("RABBITMQ_USER", ""),

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -1757,13 +1757,35 @@ def _raw_indexing_status(key_pattern: str) -> tuple[dict[str, int], set[str]]:
     for key, val in zip(keys, values, strict=False):
         if val is None:
             pending += 1
-        elif val == "text_indexed":
-            indexed += 1
-        elif val == "failed":
-            failed += 1
-            failed_keys.add(str(key))
-        else:
-            pending += 1
+            continue
+        try:
+            state = json.loads(val)
+            if isinstance(state, dict):
+                if state.get("failed"):
+                    failed += 1
+                    failed_keys.add(str(key))
+                elif state.get("processed") or state.get("text_indexed"):
+                    indexed += 1
+                else:
+                    pending += 1
+            else:
+                # Legacy string format fallback
+                if val == "text_indexed":
+                    indexed += 1
+                elif val == "failed":
+                    failed += 1
+                    failed_keys.add(str(key))
+                else:
+                    pending += 1
+        except (json.JSONDecodeError, ValueError):
+            # Treat unparseable values as legacy format
+            if val == "text_indexed":
+                indexed += 1
+            elif val == "failed":
+                failed += 1
+                failed_keys.add(str(key))
+            else:
+                pending += 1
 
     total = len(keys)
     return {


### PR DESCRIPTION
## Summary

The `/v1/status/` endpoint was scanning for Redis keys matching `doc:*` but document-lister/indexer write keys under `/{QUEUE_NAME}/*`. This caused System Status to show 0/0/0/0 for all indexing metrics.

## Changes

**`src/solr-search/config.py`**
- Changed default `REDIS_KEY_PATTERN` from `doc:*` to `/{QUEUE_NAME}/*` (derived from the same env vars as `redis_queue_name`, defaulting to `/shortembeddings/*`)

**`src/solr-search/main.py`**
- Updated `_raw_indexing_status()` to parse JSON state objects (`{"processed": true, "failed": true, ...}`) written by the indexer pipeline
- Maintained backward compatibility with legacy string-format values (`"text_indexed"`, `"failed"`)

## Testing

All 993 existing tests pass (91% coverage).

⚠️ This task was flagged as "needs review" — Dallas is a frontend specialist but this is backend Python work. Please have a squad member review before merging.

Working as Dallas (Full-stack Specialist)

Closes #1065