### PR TITLE
fix(indexer): install all dependencies at build time

### DIFF
--- a/src/document-indexer/Dockerfile
+++ b/src/document-indexer/Dockerfile
@@ -37,13 +37,12 @@ RUN apk add --no-cache procps libstdc++ libgomp libgcc
 
 RUN addgroup -S -g 1000 app && adduser -S -u 1000 -G app app
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/document_indexer /app/document_indexer
-COPY --from=builder /app/pyproject.toml /app/pyproject.toml
-COPY --from=builder /app/uv.lock /app/uv.lock
 
 RUN chown -R app:app /app
+
+ENV PATH="/app/.venv/bin:${PATH}"
 
 ENV RABBITMQ_HOST="localhost"
 ENV RABBITMQ_PORT=5672
@@ -58,4 +57,4 @@ ENV SOLR_COLLECTION="books"
 
 USER app
 
-CMD ["uv", "run", "python", "-m", "document_indexer"]
+CMD ["python", "-m", "document_indexer"]

--- a/src/document-lister/Dockerfile
+++ b/src/document-lister/Dockerfile
@@ -37,16 +37,15 @@ RUN apk add --no-cache procps su-exec
 
 RUN addgroup -S -g 1000 app && adduser -S -u 1000 -G app app
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/document_lister /app/document_lister
-COPY --from=builder /app/pyproject.toml /app/pyproject.toml
-COPY --from=builder /app/uv.lock /app/uv.lock
 
 RUN mkdir -p /data/documents && chown -R app:app /app /data/documents
 
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+ENV PATH="/app/.venv/bin:${PATH}"
 
 ENV RABBITMQ_HOST="localhost"
 ENV RABBITMQ_PORT=5672
@@ -57,4 +56,4 @@ ENV QUEUE_NAME="new_documents"
 ENV EXCHANGE_NAME="documents"
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["uv", "run", "python", "-m", "document_lister"]
+CMD ["python", "-m", "document_lister"]


### PR DESCRIPTION
## Summary

The **document-indexer** and **document-lister** containers used `uv run` as their CMD, which performs dependency resolution at startup. This caused uv to download dev dependencies (pygments and 6 other packages via pytest) every time the container started — violating the air-gap requirement.

## Changes

**Both `document-indexer` and `document-lister` Dockerfiles:**
- Replace `CMD ["uv", "run", "python", "-m", ...]` with `CMD ["python", "-m", ...]`
- Add `ENV PATH="/app/.venv/bin:${PATH}"` so the venv Python is used directly
- Remove `uv`, `pyproject.toml`, and `uv.lock` from the runtime stage (no longer needed)

## Other containers reviewed

| Container | Status |
|---|---|
| solr-search | ✅ Already uses venv PATH |
| admin | ✅ Already uses venv PATH |
| embeddings-server | ✅ Already uses venv PATH |
| aithena-ui | ✅ Node.js / nginx — N/A |
| solr | ✅ No Python deps |

## Root cause

`uv run` syncs the project environment before executing. Since the build used `--no-install-project`, the project package itself wasn't installed in the venv. At runtime, `uv run` detected this and tried to install it — pulling in dev transitive dependencies (pygments via pytest) from PyPI.

Closes #1078

Working as Brett (Docker specialist)
