### PR TITLE
feat(admin): add sidebar navigation and organized admin menu

### DIFF
--- a/src/admin/src/main.py
+++ b/src/admin/src/main.py
@@ -1,24 +1,11 @@
-import json
 import logging
 import os
 
-import requests
 import streamlit as st
 
-import redis
 from auth import AuthSettings, logout, require_auth
 from logging_config import setup_logging
-from pages.shared.config import (
-    AUTH_ENABLED,
-    QUEUE_NAME,
-    RABBITMQ_HOST,
-    RABBITMQ_MGMT_PATH_PREFIX,
-    RABBITMQ_MGMT_PORT,
-    RABBITMQ_PASS,
-    RABBITMQ_USER,
-    REDIS_HOST,
-    REDIS_PORT,
-)
+from pages.shared.config import AUTH_ENABLED
 
 auth_user = None
 if AUTH_ENABLED:
@@ -32,15 +19,11 @@ if AUTH_ENABLED:
 setup_logging(service_name="admin")
 logger = logging.getLogger(__name__)
 
-rabbitmq_management_url = f"http://{RABBITMQ_HOST}:{RABBITMQ_MGMT_PORT}{RABBITMQ_MGMT_PATH_PREFIX}"
 admin_version = os.getenv("VERSION", "dev")
 
 st.set_page_config(page_title="Aithena Admin", page_icon="🏛️", layout="wide")
-st.title("🏛️ Aithena Admin Dashboard")
-st.caption(
-    f"Redis: `{REDIS_HOST}:{REDIS_PORT}` · Queue: `{QUEUE_NAME}` · RabbitMQ management: `{rabbitmq_management_url}`"
-)
 
+# ── Sidebar: version + auth ─────────────────────────────────────────────────
 st.sidebar.caption(f"Admin v{admin_version}")
 if auth_user is not None:
     st.sidebar.markdown(f"Signed in as **{auth_user.username}**")
@@ -48,62 +31,22 @@ if auth_user is not None:
         logout()
         st.rerun()
 
-# ── Redis metrics ────────────────────────────────────────────────────────────
-try:
-    redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
-    keys = redis_client.keys(f"/{QUEUE_NAME}/*")
+# ── Navigation ───────────────────────────────────────────────────────────────
+pages = {
+    "Overview": [
+        st.Page("pages/dashboard.py", title="Dashboard", icon="📊", default=True),
+    ],
+    "Documents": [
+        st.Page("pages/document_lister.py", title="Document Manager", icon="📄"),
+    ],
+    "Indexing": [
+        st.Page("pages/reindex.py", title="Reindex Library", icon="🔄"),
+    ],
+    "System": [
+        st.Page("pages/system_status.py", title="System Status", icon="🔧"),
+        st.Page("pages/infrastructure.py", title="Infrastructure", icon="🏗️"),
+    ],
+}
 
-    total = len(keys)
-    queued = processed = failed = 0
-    for key in keys:
-        raw = redis_client.get(key)
-        if not raw:
-            continue
-        try:
-            state = json.loads(raw)
-            if state.get("failed"):
-                failed += 1
-            elif state.get("processed"):
-                processed += 1
-            else:
-                queued += 1
-        except json.JSONDecodeError:
-            pass
-
-    col1, col2, col3, col4 = st.columns(4)
-    col1.metric("📚 Total Documents", total)
-    col2.metric("⏳ Queued", queued)
-    col3.metric("✅ Processed", processed)
-    col4.metric("❌ Failed", failed)
-
-except redis.exceptions.ConnectionError:
-    logger.error("Cannot connect to Redis", extra={"redis_host": REDIS_HOST, "redis_port": REDIS_PORT})
-    st.error(f"Cannot connect to Redis at {REDIS_HOST}:{REDIS_PORT}")
-
-# ── RabbitMQ management API ──────────────────────────────────────────────────
-st.subheader("📨 RabbitMQ Queue")
-try:
-    resp = requests.get(
-        f"{rabbitmq_management_url}/api/queues/%2F/{QUEUE_NAME}",
-        auth=(RABBITMQ_USER, RABBITMQ_PASS),
-        timeout=5,
-    )
-    if resp.status_code == 200:
-        queue_info = resp.json()
-        c1, c2, c3 = st.columns(3)
-        c1.metric("Messages Ready", queue_info.get("messages_ready", "N/A"))
-        c2.metric("Messages Unacked", queue_info.get("messages_unacknowledged", "N/A"))
-        c3.metric("Total Messages", queue_info.get("messages", "N/A"))
-    elif resp.status_code == 404:
-        st.info(f"Queue `{QUEUE_NAME}` not found — it will be created when the first document is listed.")
-    else:
-        st.warning(f"RabbitMQ management API returned HTTP {resp.status_code}.")
-except requests.exceptions.RequestException:
-    st.info(
-        "RabbitMQ management API not reachable. Verify `RABBITMQ_HOST`, "
-        "`RABBITMQ_MGMT_PORT`, and `RABBITMQ_MGMT_PATH_PREFIX`."
-    )
-
-st.divider()
-st.info("Use **Document Manager** in the sidebar to inspect documents and trigger requeue or clear actions.")
-st.info("Use **Reindex Library** to re-embed the entire library after changing the embedding model.")
+nav = st.navigation(pages)
+nav.run()

--- a/src/admin/src/pages/dashboard.py
+++ b/src/admin/src/pages/dashboard.py
@@ -1,0 +1,93 @@
+"""Dashboard page — overview metrics for documents and queues."""
+
+import json
+import logging
+
+import requests
+import streamlit as st
+
+import redis
+from pages.shared.config import (
+    QUEUE_NAME,
+    RABBITMQ_HOST,
+    RABBITMQ_MGMT_PATH_PREFIX,
+    RABBITMQ_MGMT_PORT,
+    RABBITMQ_PASS,
+    RABBITMQ_USER,
+    REDIS_HOST,
+    REDIS_PORT,
+)
+
+logger = logging.getLogger(__name__)
+
+rabbitmq_management_url = (
+    f"http://{RABBITMQ_HOST}:{RABBITMQ_MGMT_PORT}{RABBITMQ_MGMT_PATH_PREFIX}"
+)
+
+st.title("📊 Dashboard")
+st.caption(
+    f"Redis: `{REDIS_HOST}:{REDIS_PORT}` · Queue: `{QUEUE_NAME}` · "
+    f"RabbitMQ management: `{rabbitmq_management_url}`"
+)
+
+# ── Redis metrics ────────────────────────────────────────────────────────────
+try:
+    redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+    keys = redis_client.keys(f"/{QUEUE_NAME}/*")
+
+    total = len(keys)
+    queued = processed = failed = 0
+    for key in keys:
+        raw = redis_client.get(key)
+        if not raw:
+            continue
+        try:
+            state = json.loads(raw)
+            if state.get("failed"):
+                failed += 1
+            elif state.get("processed"):
+                processed += 1
+            else:
+                queued += 1
+        except json.JSONDecodeError:
+            pass
+
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("📚 Total Documents", total)
+    col2.metric("⏳ Queued", queued)
+    col3.metric("✅ Processed", processed)
+    col4.metric("❌ Failed", failed)
+
+except redis.exceptions.ConnectionError:
+    logger.error(
+        "Cannot connect to Redis",
+        extra={"redis_host": REDIS_HOST, "redis_port": REDIS_PORT},
+    )
+    st.error(f"Cannot connect to Redis at {REDIS_HOST}:{REDIS_PORT}")
+
+# ── RabbitMQ management API ──────────────────────────────────────────────────
+st.subheader("📨 RabbitMQ Queue")
+try:
+    resp = requests.get(
+        f"{rabbitmq_management_url}/api/queues/%2F/{QUEUE_NAME}",
+        auth=(RABBITMQ_USER, RABBITMQ_PASS),
+        timeout=5,
+    )
+    if resp.status_code == 200:
+        queue_info = resp.json()
+        c1, c2, c3 = st.columns(3)
+        c1.metric("Messages Ready", queue_info.get("messages_ready", "N/A"))
+        c2.metric("Messages Unacked", queue_info.get("messages_unacknowledged", "N/A"))
+        c3.metric("Total Messages", queue_info.get("messages", "N/A"))
+    elif resp.status_code == 404:
+        st.info(
+            f"Queue `{QUEUE_NAME}` not found — it will be created "
+            "when the first document is listed."
+        )
+    else:
+        st.warning(f"RabbitMQ management API returned HTTP {resp.status_code}.")
+except requests.exceptions.RequestException:
+    st.info(
+        "RabbitMQ management API not reachable. Verify `RABBITMQ_HOST`, "
+        "`RABBITMQ_MGMT_PORT`, and `RABBITMQ_MGMT_PATH_PREFIX`."
+    )

--- a/src/admin/src/pages/document_lister.py
+++ b/src/admin/src/pages/document_lister.py
@@ -4,20 +4,8 @@ import pandas as pd
 import streamlit as st
 
 import redis
-from pages.shared.config import AUTH_ENABLED, QUEUE_NAME, REDIS_HOST, REDIS_PORT
+from pages.shared.config import QUEUE_NAME, REDIS_HOST, REDIS_PORT
 
-if AUTH_ENABLED:
-    from auth import AuthSettings, require_auth
-
-    try:
-        _settings = AuthSettings.from_env()
-    except ValueError as _exc:
-        st.error(f"Authentication configuration error: {_exc}")
-        st.stop()
-    require_auth(_settings)
-
-
-st.set_page_config(page_title="Document Manager", page_icon="📄", layout="wide")
 st.title("📄 Document Manager")
 
 redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)

--- a/src/admin/src/pages/infrastructure.py
+++ b/src/admin/src/pages/infrastructure.py
@@ -1,0 +1,53 @@
+"""Infrastructure page — quick links to infrastructure management UIs."""
+
+import os
+
+import streamlit as st
+
+from pages.shared.config import (
+    RABBITMQ_HOST,
+    RABBITMQ_MGMT_PATH_PREFIX,
+    RABBITMQ_MGMT_PORT,
+    REDIS_HOST,
+    REDIS_PORT,
+)
+
+SOLR_ADMIN_URL = os.environ.get("SOLR_ADMIN_URL", "/admin/solr/")
+RABBITMQ_ADMIN_URL = os.environ.get("RABBITMQ_ADMIN_URL", "/admin/rabbitmq/")
+
+st.title("🏗️ Infrastructure")
+st.caption("Quick links to infrastructure management dashboards.")
+
+st.subheader("Management UIs")
+
+col1, col2 = st.columns(2)
+
+with col1, st.container(border=True):
+    st.markdown("#### 🗄️ Apache Solr")
+    st.markdown("Full-text search engine admin console.")
+    st.markdown(
+        f"[Open Solr Admin ↗]({SOLR_ADMIN_URL})",
+    )
+
+with col2, st.container(border=True):
+    st.markdown("#### 🐰 RabbitMQ")
+    st.markdown("Message queue management console.")
+    st.markdown(
+        f"[Open RabbitMQ Management ↗]({RABBITMQ_ADMIN_URL})",
+    )
+
+st.divider()
+st.subheader("Connection Details")
+
+rabbitmq_management_url = (
+    f"http://{RABBITMQ_HOST}:{RABBITMQ_MGMT_PORT}{RABBITMQ_MGMT_PATH_PREFIX}"
+)
+
+st.markdown(
+    f"""
+| Service | Endpoint |
+|---------|----------|
+| **Redis** | `{REDIS_HOST}:{REDIS_PORT}` |
+| **RabbitMQ Management** | `{rabbitmq_management_url}` |
+"""
+)

--- a/src/admin/src/pages/reindex.py
+++ b/src/admin/src/pages/reindex.py
@@ -10,20 +10,8 @@ from __future__ import annotations
 import requests
 import streamlit as st
 
-from pages.shared.config import ADMIN_API_KEY, AUTH_ENABLED, SOLR_SEARCH_URL
+from pages.shared.config import ADMIN_API_KEY, SOLR_SEARCH_URL
 
-if AUTH_ENABLED:
-    from auth import AuthSettings, require_auth
-
-    try:
-        _settings = AuthSettings.from_env()
-    except ValueError as _exc:
-        st.error(f"Authentication configuration error: {_exc}")
-        st.stop()
-    require_auth(_settings)
-
-
-st.set_page_config(page_title="Reindex Library", page_icon="🔄", layout="wide")
 st.title("🔄 Reindex Library")
 
 st.markdown(

--- a/src/admin/src/pages/system_status.py
+++ b/src/admin/src/pages/system_status.py
@@ -6,18 +6,7 @@ from typing import Any
 import requests
 import streamlit as st
 
-from pages.shared.config import AUTH_ENABLED, SOLR_SEARCH_URL
-
-if AUTH_ENABLED:
-    from auth import AuthSettings, require_auth
-
-    try:
-        _settings = AuthSettings.from_env()
-    except ValueError as _exc:
-        st.error(f"Authentication configuration error: {_exc}")
-        st.stop()
-    require_auth(_settings)
-
+from pages.shared.config import SOLR_SEARCH_URL
 
 APP_SERVICE_ORDER = [
     "solr-search",
@@ -37,7 +26,6 @@ STATUS_STYLE = {
     "down": ("❌", "red"),
 }
 
-st.set_page_config(page_title="System Status", page_icon="🔧", layout="wide")
 st.title("🔧 System Status")
 
 


### PR DESCRIPTION
## Summary

Restructures the Streamlit admin portal with a proper sidebar navigation using `st.navigation()`. Admin features are now directly accessible through organized menu sections instead of relying on Streamlit's flat auto-discovered pages.

### Changes

**Navigation structure (sidebar sections):**
- **Overview** → Dashboard (Redis metrics, RabbitMQ queue stats)
- **Documents** → Document Manager (queued/processed/failed)
- **Indexing** → Reindex Library
- **System** → System Status, Infrastructure (Solr/RabbitMQ admin links)

**Key changes:**
- `main.py`: Converted from a dashboard page into a navigation controller
- New `pages/dashboard.py`: Extracted dashboard metrics from main.py
- New `pages/infrastructure.py`: Quick links to Solr Admin and RabbitMQ Management UIs
- Removed per-page `st.set_page_config()` and auth guards — both are now centralized in `main.py`
- Auth is enforced once before any page renders

### Testing
- All 95 existing tests pass
- Ruff linting passes

Working as Dallas (Frontend Dev)

Closes #1069