### PR TITLE
fix: address PR review comments (docs, prod config, PRD)

### DIFF
--- a/.squad/decisions/inbox/newt-admin-react-migration.md
+++ b/.squad/decisions/inbox/newt-admin-react-migration.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-The admin portal (`src/admin/`) is a standalone Streamlit (Python) app with 7 pages. The React UI (`src/aithena-ui/`) already has 3 admin pages (`/admin`, `/admin/users`, `/admin/backups`). For v2.0, we need to decide how to unify these.
+The admin portal (`src/admin/`) was originally a standalone Streamlit (Python) app with 7 pages. The `streamlit-admin` Compose service has since been removed and nginx redirects `/admin/streamlit` → `/admin`, but the `src/admin/` source tree is retained as reference. The React UI (`src/aithena-ui/`) already has 3 admin pages (`/admin`, `/admin/users`, `/admin/backups`). For v2.0, we need to complete the migration of all remaining Streamlit admin features into React.
 
 ## Decision
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -348,8 +348,8 @@ services:
       solr:
         condition: service_healthy
     environment:
-      SOLR_ADMIN_USER: ${SOLR_ADMIN_USER:-solr_admin}
-      SOLR_ADMIN_PASS: ${SOLR_ADMIN_PASS:-SolrAdmin_dev2024!}
+      SOLR_ADMIN_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
+      SOLR_ADMIN_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
       NGINX_ENVSUBST_FILTER: SOLR_BASIC_AUTH
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://127.0.0.1:80/health"]

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -3293,7 +3293,7 @@ Credentials are injected from `.env` at runtime. To view current Solr users:
 
 ```bash
 docker compose exec solr-search curl \
-  -u solr-admin:$SOLR_ADMIN_PASSWORD \
+  -u solr-admin:$SOLR_ADMIN_PASS \
   http://localhost:8983/api/users
 ```
 
@@ -3447,7 +3447,7 @@ git checkout v1.13.0
 
 # 3. Update .env with new per-service credentials (if upgrading from < v1.13.0)
 # Review and merge .env.example into your current .env
-# Add new variables: RABBITMQ_INDEXER_USER, RABBITMQ_LISTER_USER, SOLR_ADMIN_PASSWORD, etc.
+# Add new variables: RABBITMQ_INDEXER_USER, RABBITMQ_LISTER_USER, SOLR_ADMIN_PASS, etc.
 
 # 4. Pull new images
 docker compose pull
@@ -3470,7 +3470,7 @@ docker compose logs | grep -i error
 **Solution:**
 ```bash
 # 1. Check if credentials are in .env
-grep SOLR_ADMIN_PASSWORD .env
+grep SOLR_ADMIN_PASS .env
 grep RABBITMQ_INDEXER_USER .env
 grep REDIS_PASSWORD .env
 
@@ -3524,7 +3524,7 @@ The passthrough is configured in the nginx proxy and uses credentials from `.env
 ```bash
 # Ensure these are set in .env (created by the installer)
 SOLR_ADMIN_USER=admin
-SOLR_ADMIN_PASSWORD=<your-solr-password>
+SOLR_ADMIN_PASS=<your-solr-password>
 ```
 
 ### Document Indexer OOM Fix (#1074, #1075)

--- a/docs/prd/admin-react-migration.md
+++ b/docs/prd/admin-react-migration.md
@@ -12,7 +12,7 @@
 
 ## 1. Executive Summary
 
-The Aithena admin portal (`src/admin/`) is currently a standalone Streamlit (Python) application running as a separate service. The main user-facing search UI (`src/aithena-ui/`) was migrated to React + Vite in earlier releases and now includes a growing set of admin-oriented pages (document manager, backup dashboard, user management). This creates a **split-brain admin experience**: operators must context-switch between two completely different UIs with different auth flows, different tech stacks, and different deployment models.
+The Aithena admin portal (`src/admin/`) is a Streamlit (Python) application whose features are being progressively migrated into the React UI. The `streamlit-admin` Docker Compose service has been removed and nginx redirects `/admin/streamlit` → `/admin`, but the `src/admin/` source tree is retained as reference for migration. The main user-facing search UI (`src/aithena-ui/`) was migrated to React + Vite in earlier releases and now includes a growing set of admin-oriented pages (document manager, backup dashboard, user management). This creates a **split-brain admin experience**: some admin features exist only in the legacy Streamlit code while others are already in React.
 
 This PRD proposes a **full migration of all Streamlit admin features into the existing React application** for v2.0, unifying the tech stack, eliminating the standalone Streamlit service, and enabling shared components, consistent UX, and a single auth system.
 
@@ -22,7 +22,7 @@ This PRD proposes a **full migration of all Streamlit admin features into the ex
 - **Shared component library**: Reuse existing React components (tables, metrics cards, error states, loading spinners, modals) across user and admin pages
 - **Single auth system**: JWT-based auth with role-based access control already in aithena-ui — no separate basic auth or cookie SSO passthrough needed
 - **Eliminated Docker socket dependency**: The Streamlit log viewer mounts `/var/run/docker.sock` — a security concern flagged in review. The React version will use a proper API-based log streaming endpoint
-- **Reduced deployment footprint**: Remove the `streamlit-admin` container from the Docker Compose stack
+- **Reduced deployment footprint**: Complete removal of the `streamlit-admin` container and `src/admin/` source tree from the Docker Compose stack
 - **Better accessibility**: The React UI already has `eslint-plugin-jsx-a11y`, keyboard navigation patterns, and ARIA roles; Streamlit's accessibility story is limited
 
 ---
@@ -50,7 +50,7 @@ The Streamlit admin communicates **directly** with Redis, RabbitMQ Management AP
 
 3. **Direct infrastructure access**: The admin talks directly to Redis (`redis-py`), RabbitMQ (HTTP management API), and Docker (`docker-py` with socket mount). This creates tight coupling, security surface, and makes the admin impossible to run outside the Docker network.
 
-4. **Security concern — Docker socket**: The log viewer requires mounting `/var/run/docker.sock:ro` into the admin container. Even read-only, this grants significant host Docker daemon access. This was flagged during PR review and gated behind `ENABLE_LOG_VIEWER=false` by default.
+4. **Security concern — Docker socket**: The log viewer requires mounting `/var/run/docker.sock:ro` into the admin container. Even read-only, this grants significant host Docker daemon access. This was flagged during PR review; a configuration gate (e.g., an `ENABLE_LOG_VIEWER` flag defaulting to `false`) is a desired mitigation but is not currently enforced in the Streamlit `src/admin/src/pages/log_viewer.py`.
 
 5. **Partial React migration already in progress**: `aithena-ui` already has an `/admin` page (document manager with queued/processed/failed tabs), `/admin/users` (user management), and `/admin/backups` (backup dashboard). The Streamlit pages duplicate some of this functionality with inconsistent UX.
 
@@ -141,7 +141,7 @@ The Streamlit admin communicates **directly** with Redis, RabbitMQ Management AP
 
 | Feature | Current Implementation | Data Source |
 |---|---|---|
-| Security gate | `ENABLE_LOG_VIEWER` env var (default: false) | Config |
+| Security gate | None in Streamlit; planned `ENABLE_LOG_VIEWER` env var gate for React (default: false) | Config (planned) |
 | Docker dependency check | `docker` Python package import check | Runtime |
 | Docker connection test | `docker.from_env().ping()` | Docker socket (`/var/run/docker.sock:ro`) |
 | Service selector | `st.selectbox` with running aithena containers | Docker SDK: `client.containers.list()` |
@@ -484,7 +484,7 @@ Returns recent log lines for a container, without requiring Docker socket access
 
 **Implementation options** (in order of preference):
 
-1. **Docker SDK in backend**: Move Docker socket mount to `solr-search` container instead of admin. The backend is a trusted service with API authentication — this is more defensible than exposing the socket to a Streamlit app with basic auth.
+1. **Docker SDK in backend**: Move Docker socket mount to `solr-search` container instead of admin. The backend is a trusted service with API authentication — this is more defensible than exposing the socket directly to the Streamlit admin UI, even though it is protected by JWT/cookie-based auth.
 
 2. **Docker API over HTTP**: Configure Docker daemon to expose the API over a Unix socket or TCP to `solr-search` only, with network-level isolation.
 
@@ -620,15 +620,15 @@ Returns infrastructure connection details and management UI URLs.
 | Metric | Target | Measurement |
 |---|---|---|
 | Streamlit pages migrated | 7/7 | Feature checklist (Section 4 inventory) |
-| Streamlit service removed | Yes | `docker compose ps` shows no `streamlit-admin` |
-| Docker socket removed | Yes | No `/var/run/docker.sock` mount in any compose file |
+| Legacy Streamlit artifacts removed | Yes | `src/admin/` directory deleted; Streamlit admin CI job removed; docs contain no references to the Streamlit admin UI |
+| Docker socket removed from browser-facing services | Yes | No `/var/run/docker.sock` mount in any browser-facing compose service (backend-only mount is acceptable) |
 | Separate auth system removed | Yes | No `AUTH_JWT_SECRET` / `AUTH_ADMIN_USERNAME` / `AUTH_ADMIN_PASSWORD` env vars |
 
 ### 11.2 Quality Gates
 
 | Metric | Target | Measurement |
 |---|---|---|
-| Admin test count | ≥ 81 (current Streamlit baseline) | `vitest run` count for admin-related test files |
+| Admin test count | ≥ 116 (v1.15.0 baseline) | `vitest run` count for admin-related test files (React) must equal or exceed the current combined Streamlit+React admin test count |
 | Admin test coverage | ≥ 80% | `vitest --coverage` for `pages/admin/` and `hooks/admin*` |
 | Accessibility violations | 0 (critical/serious) | `axe-core` automated audit |
 | Admin page load time | < 2s on local Docker stack | Manual measurement + Lighthouse |

--- a/docs/test-reports/v1.15.0.md
+++ b/docs/test-reports/v1.15.0.md
@@ -11,7 +11,7 @@
 
 ## Summary
 
-All **1,939 tests** executed across 6 services (1,934 passed, 5 pre-existing failures, 0 skipped). This represents a **3× increase** from the v1.7.0 baseline (628 tests), reflecting the extensive test additions in the v1.15.0 "Release Quality & CI Hardening" milestone. All coverage thresholds met. No regressions introduced by v1.15.0 changes.
+All **1,944 tests** executed across 6 services (1,939 passed, 5 pre-existing failures, 0 skipped). This represents a **3× increase** from the v1.7.0 baseline (628 tests), reflecting the extensive test additions in the v1.15.0 "Release Quality & CI Hardening" milestone. All coverage thresholds met. No regressions introduced by v1.15.0 changes.
 
 ---
 


### PR DESCRIPTION
## Summary
Addresses all active (non-outdated) review comments from PR #1088 and PR #1095.

### PR #1088 comments addressed:
1. **`docker-compose.prod.yml:352`** — Removed insecure default Solr credentials in nginx service. Now uses `:?` syntax requiring explicit env vars.
2. **`docs/admin-manual.md:3527`** — Fixed `SOLR_ADMIN_PASSWORD` → `SOLR_ADMIN_PASS` (4 occurrences) to match actual env var names.
3. **`docs/test-reports/v1.15.0.md:14,36`** — Fixed test count: summary said 1,939 total but per-service adds up to 1,944. Now consistent.
4. **`release.yml:166`** — Already addressed: `environment: release` was added in PR #1091, making this alert stale.
5. **`test_indexing_status.py:17`** — Already addressed: `indexing_status.py` was refactored for import-safety in PR #1091, helpers are now side-effect free.

### PR #1095 comments addressed:
1. Updated executive summary to reflect streamlit-admin service already removed
2. Fixed ENABLE_LOG_VIEWER gate description (planned, not currently enforced)
3. Fixed log viewer security gate table entry
4. Corrected auth description (JWT/cookie-based, not basic auth)
5. Reconciled Docker socket metric with recommended Option 1 approach
6. Updated 'Streamlit service removed' metric to track remaining artifacts
7. Updated admin test baseline from 81 to 116 (v1.15.0 count)
8. Updated decision doc context to reflect current state