### PR TITLE
ci: remove non-existent 'environment: release' from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,6 @@ jobs:
     name: Build and push ${{ matrix.service.image }}
     runs-on: ubuntu-latest
     needs: validate-tag
-    environment: release
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Removes `environment: release` from `.github/workflows/release.yml` — the environment doesn't exist in this repo and triggers a code scanning alert.

Unblocks #1088.