### PR TITLE
ci: increase admin smoke test timeout to 60s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
           - image: admin
             type: http
             port: "8501"
-            health_endpoint: /_stcore/health
+            health_endpoint: /admin/streamlit/_stcore/health
             startup_timeout: 60
           - image: aithena-ui
             type: http


### PR DESCRIPTION
Fixes #1132

Streamlit admin container takes >30s to boot in CI. Increase smoke test timeout from 30s to 60s to match embeddings-server.