### PR TITLE
ci: extract reusable container build workflow

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,0 +1,96 @@
+name: Build Containers
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Semantic version without v prefix (e.g. 1.2.3 or 1.2.3-rc.1)'
+        required: true
+        type: string
+      push:
+        description: 'Push images to registry'
+        required: false
+        type: boolean
+        default: true
+      tags:
+        description: 'Docker metadata tag patterns (multi-line, passed to docker/metadata-action)'
+        required: true
+        type: string
+      build-date:
+        description: 'Build timestamp in ISO 8601 format'
+        required: true
+        type: string
+    secrets:
+      HF_TOKEN:
+        description: 'HuggingFace token for embeddings-server model download'
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and push ${{ matrix.service.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - image: admin
+            context: .
+            dockerfile: ./src/admin/Dockerfile
+          - image: aithena-ui
+            context: ./src/aithena-ui
+            dockerfile: ./src/aithena-ui/Dockerfile
+          - image: document-indexer
+            context: ./src/document-indexer
+            dockerfile: ./src/document-indexer/Dockerfile
+          - image: document-lister
+            context: ./src/document-lister
+            dockerfile: ./src/document-lister/Dockerfile
+          - image: embeddings-server
+            context: ./src/embeddings-server
+            dockerfile: ./src/embeddings-server/Dockerfile
+          - image: solr-search
+            context: .
+            dockerfile: ./src/solr-search/Dockerfile
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ghcr.io/jmservera/aithena-${{ matrix.service.image }}
+          tags: ${{ inputs.tags }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+        with:
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile }}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ inputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ inputs.build-date }}
+          secrets: |
+            HF_TOKEN=${{ secrets.HF_TOKEN }}
+          cache-from: type=gha,scope=${{ matrix.service.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,77 +94,23 @@ jobs:
         run: echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
   build-and-push:
-    name: Build and push ${{ matrix.service.image }}
-    runs-on: ubuntu-latest
+    name: Build and push containers
     needs: validate-tag
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        service:
-          - image: admin
-            context: .
-            dockerfile: ./src/admin/Dockerfile
-          - image: aithena-ui
-            context: ./src/aithena-ui
-            dockerfile: ./src/aithena-ui/Dockerfile
-          - image: document-indexer
-            context: ./src/document-indexer
-            dockerfile: ./src/document-indexer/Dockerfile
-          - image: document-lister
-            context: ./src/document-lister
-            dockerfile: ./src/document-lister/Dockerfile
-          - image: embeddings-server
-            context: ./src/embeddings-server
-            dockerfile: ./src/embeddings-server/Dockerfile
-          - image: solr-search
-            context: .
-            dockerfile: ./src/solr-search/Dockerfile
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate Docker metadata
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
-        with:
-          images: ghcr.io/jmservera/aithena-${{ matrix.service.image }}
-          tags: |
-            type=semver,pattern={{version}},value=v${{ needs.validate-tag.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=v${{ needs.validate-tag.outputs.version }}
-            type=semver,pattern={{major}},value=v${{ needs.validate-tag.outputs.version }}
-            type=raw,value=latest
-
-      - name: Build and push image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
-        with:
-          context: ${{ matrix.service.context }}
-          file: ${{ matrix.service.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ needs.validate-tag.outputs.version }}
-            GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ needs.validate-tag.outputs.build_date }}
-          secrets: |
-            HF_TOKEN=${{ secrets.HF_TOKEN }}
-          cache-from: type=gha,scope=${{ matrix.service.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}
+    uses: ./.github/workflows/build-containers.yml
+    with:
+      version: ${{ needs.validate-tag.outputs.version }}
+      push: true
+      tags: |
+        type=semver,pattern={{version}},value=v${{ needs.validate-tag.outputs.version }}
+        type=semver,pattern={{major}}.{{minor}},value=v${{ needs.validate-tag.outputs.version }}
+        type=semver,pattern={{major}},value=v${{ needs.validate-tag.outputs.version }}
+        type=raw,value=latest
+      build-date: ${{ needs.validate-tag.outputs.build_date }}
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   smoke-test:
     name: Smoke test ${{ matrix.service.image }}

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -117,6 +117,7 @@ Use overlay files (not profiles) when making a sidecar optional affects the main
 | 2026-07-25 | — | setupdev.sh expansion (all dev tools) |
 | 2026-03-16 | — | Cleaned 44 stale branches; enabled auto-delete |
 | 2026-03-22 | #826/PR#847 | nginx static thumbnail serving (volume mount + /thumbnails/ location) |
+| — | #1120 | Extract reusable container build workflow (build-containers.yml) |
 
 ---
 


### PR DESCRIPTION
## Summary

Extract the common Docker build matrix from `release.yml` into a reusable workflow `build-containers.yml` that both release and pre-release workflows can call via `workflow_call`.

## Changes

- **New file:** `.github/workflows/build-containers.yml` — reusable workflow with the 6-service build matrix (admin, aithena-ui, document-indexer, document-lister, embeddings-server, solr-search)
- **Refactored:** `.github/workflows/release.yml` — `build-and-push` job now calls the reusable workflow instead of inlining the matrix
- **Updated:** Brett's history with this work entry

## Design

The reusable workflow accepts:
| Input | Type | Description |
|-------|------|-------------|
| `version` | string | Semantic version without `v` prefix |
| `push` | boolean | Whether to push images (default: true) |
| `tags` | string | Docker metadata tag patterns (multi-line) |
| `build-date` | string | ISO 8601 build timestamp |
| `HF_TOKEN` | secret | HuggingFace token for embeddings-server |

This allows a future pre-release workflow to call the same build matrix with different tag patterns (e.g. `type=raw,value=1.2.3-rc.1`) — zero drift between RC and release builds.

## What didn't change
- `validate-tag`, `smoke-test`, `package-release`, and `github-release` jobs are untouched
- `needs:` dependency graph preserved (`build-and-push` job ID unchanged)
- GHA build cache scopes identical (`scope=${{ matrix.service.image }}`) — shared between RC and release
- All action SHAs pinned, same versions as before

## Validation
- YAML syntax validated (Python yaml.safe_load)
- actionlint passes with zero errors on both workflow files

Working as Brett (Infrastructure Architect)

Closes #1120