### PR TITLE
ci: add RC smoke tests to pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -135,3 +135,153 @@ jobs:
       build-date: ${{ needs.prepare.outputs.build_date }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  smoke-test:
+    name: Smoke test ${{ matrix.service.image }}
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - build-and-push
+    # Only run when images were actually pushed (skip PR dry-runs)
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - image: solr-search
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 30
+          - image: embeddings-server
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 60
+          - image: admin
+            type: http
+            port: "8501"
+            health_endpoint: /admin/streamlit/_stcore/health
+            startup_timeout: 60
+          - image: aithena-ui
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 15
+          - image: document-lister
+            type: process
+          - image: document-indexer
+            type: process
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        env:
+          SERVICE_IMAGE: ${{ matrix.service.image }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+        run: docker pull "ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
+
+      - name: Start container and check health endpoint
+        if: matrix.service.type == 'http'
+        env:
+          SERVICE_IMAGE: ${{ matrix.service.image }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+          SERVICE_PORT: ${{ matrix.service.port }}
+          HEALTH_ENDPOINT: ${{ matrix.service.health_endpoint }}
+          STARTUP_TIMEOUT: ${{ matrix.service.startup_timeout }}
+        run: |
+          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
+          port="${SERVICE_PORT}"
+          endpoint="${HEALTH_ENDPOINT}"
+          timeout="${STARTUP_TIMEOUT}"
+
+          docker run -d --name smoke-container -p "${port}:${port}" "${image}"
+
+          elapsed=0
+          echo "Waiting up to ${timeout}s for ${SERVICE_IMAGE} at :${port}${endpoint}..."
+          while [ "$elapsed" -lt "$timeout" ]; do
+            if curl -sf "http://localhost:${port}${endpoint}" > /dev/null 2>&1; then
+              echo "✅ ${SERVICE_IMAGE} is healthy after ${elapsed}s"
+              exit 0
+            fi
+            # Fail fast if the container exited
+            if ! docker inspect --format='{{.State.Running}}' smoke-container 2>/dev/null | grep -q true; then
+              echo "❌ Container exited before becoming healthy"
+              exit 1
+            fi
+            sleep 2
+            elapsed=$((elapsed + 2))
+          done
+          echo "❌ ${SERVICE_IMAGE} failed to respond within ${timeout}s"
+          exit 1
+
+      - name: Verify container starts (process check)
+        if: matrix.service.type == 'process'
+        env:
+          SERVICE_IMAGE: ${{ matrix.service.image }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+        run: |
+          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
+
+          docker run -d --name smoke-container "${image}"
+
+          echo "Waiting 10s to verify ${SERVICE_IMAGE} starts without crashing..."
+          sleep 10
+
+          if docker inspect --format='{{.State.Running}}' smoke-container 2>/dev/null | grep -q true; then
+            echo "✅ ${SERVICE_IMAGE} is still running after 10s"
+          else
+            exit_code=$(docker inspect --format='{{.State.ExitCode}}' smoke-container)
+            echo "⚠️ ${SERVICE_IMAGE} exited with code ${exit_code}"
+            # Queue consumers exit quickly without RabbitMQ/Redis — verify it at
+            # least survived initial module loading (ran for >3s).
+            started=$(docker inspect --format='{{.State.StartedAt}}' smoke-container)
+            finished=$(docker inspect --format='{{.State.FinishedAt}}' smoke-container)
+            runtime=$(python3 -c "
+          from datetime import datetime, timezone
+          fmt = '%Y-%m-%dT%H:%M:%S'
+          s = '${started}'[:19]
+          f = '${finished}'[:19]
+          d = (datetime.strptime(f, fmt) - datetime.strptime(s, fmt)).total_seconds()
+          print(d)
+          ")
+            echo "Container ran for ${runtime}s"
+            if python3 -c "exit(0 if float('${runtime}') >= 3 else 1)"; then
+              echo "✅ ${SERVICE_IMAGE} passed module-loading phase (ran ${runtime}s before exit)"
+            else
+              echo "❌ ${SERVICE_IMAGE} crashed immediately (${runtime}s) — likely a broken image"
+              exit 1
+            fi
+          fi
+
+      - name: Report result to summary
+        if: always()
+        env:
+          SERVICE_IMAGE: ${{ matrix.service.image }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+          STEP_STATUS: ${{ job.status }}
+        run: |
+          if [ "$STEP_STATUS" = "success" ]; then
+            echo "| ✅ | \`${SERVICE_IMAGE}\` | \`${RC_TAG}\` | Passed |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| ❌ | \`${SERVICE_IMAGE}\` | \`${RC_TAG}\` | Failed |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "::group::Container logs for ${{ matrix.service.image }}"
+          docker logs smoke-container 2>&1 || true
+          echo "::endgroup::"
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f smoke-container 2>/dev/null || true

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -119,6 +119,7 @@ Use overlay files (not profiles) when making a sidecar optional affects the main
 | 2026-03-22 | #826/PR#847 | nginx static thumbnail serving (volume mount + /thumbnails/ location) |
 | — | #1120 | Extract reusable container build workflow (build-containers.yml) |
 | — | #1123 | Pre-release container workflow (RC tags via build-containers.yml, auto-increment) |
+| — | #1118/PR#TBD | RC smoke tests in pre-release workflow (same matrix as release.yml, advisory) |
 
 ---
 


### PR DESCRIPTION
## Summary

Add a `smoke-test` matrix job to the pre-release workflow that validates all 6 container images after RC builds are pushed to ghcr.io.

## What changed

Added a `smoke-test` job to `.github/workflows/pre-release.yml` that mirrors the existing smoke tests in `release.yml`:

- **Same 6-service matrix:** solr-search, embeddings-server, admin, aithena-ui, document-lister, document-indexer
- **Same health endpoints:** HTTP health checks for web services, process-alive checks for queue consumers
- **RC-tagged images:** Tests pull `{version}-rc.{n}` tags (e.g. `1.16.0-rc.1`), never `latest`
- **Advisory only:** Failures are reported in workflow summary but don't block the workflow
- **Gated on push:** Only runs on `workflow_dispatch` (when images are actually pushed), skipped on PR dry-runs

## Acceptance criteria

- [x] Same health check endpoints tested as in release.yml
- [x] Smoke tests run after RC images are pushed
- [x] Per-container validation: startup, health checks, readiness probes
- [x] Tests run against RC-tagged images (not latest)
- [x] All 6 services validated
- [x] Failures reported in workflow summary (advisory)
- [x] Test results reported in workflow summary

Working as Brett (Infrastructure Architect)

Closes #1118