### PR TITLE
ci: trigger RC container publish on push to dev

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,6 +15,9 @@ on:
   pull_request:
     branches: [main]
 
+  push:
+    branches: [dev]
+
 permissions:
   contents: read
 
@@ -29,6 +32,7 @@ jobs:
     # Skip PR builds from forks (they lack push/package permissions)
     if: >-
       github.event_name == 'workflow_dispatch'
+      || github.event_name == 'push'
       || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     outputs:
       version: ${{ steps.resolve.outputs.version }}


### PR DESCRIPTION
## Changes

Adds automatic RC container publishing when code merges to the dev branch, eliminating the need for manual `workflow_dispatch` triggers.

### Pre-release Workflow Triggers

The `pre-release.yml` workflow now supports three trigger modes:

1. **`push: branches: [dev]`** — Automatic RC publish
   - Triggered on every merge to dev
   - Builds all containers with RC tag (auto-incremented)
   - **Pushes** containers to GHCR
   - Runs smoke tests to validate RC containers
   
2. **`pull_request: branches: [main]`** — Dry-run validation (existing)
   - Triggered on PRs targeting main (release candidates)
   - Builds containers but **does not push**
   - Validates that release code can build successfully
   
3. **`workflow_dispatch`** — Manual trigger (existing)
   - Allows manual RC publish with custom version/RC number
   - Useful for backports or off-schedule releases

### Implementation Details

- Updated `on:` section to include `push: branches: [dev]`
- Updated `prepare` job condition to allow `push` events
- `build-and-push` condition already handles this: `push: ${{ github.event_name != 'pull_request' }}`
- `smoke-test` condition already filters for non-PR events

### No Breaking Changes

- Existing PR-to-main flow remains unchanged (dry-run)
- Existing workflow_dispatch flow remains unchanged
- Smoke tests now run for push events (advisory, no blocking)