### PR TITLE
refactor: single embeddings-server image with OpenVINO included

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,9 @@ BUILD_DATE=1970-01-01T00:00:00Z
 # ── GPU Platform ──────────────────────────────────────────────────────────────
 # Default: CPU-only (no changes needed)
 #
+# The single embeddings-server image supports both NVIDIA (CUDA) and
+# Intel (OpenVINO) — no separate image tags are needed.
+#
 # For NVIDIA GPU:
 #   docker compose -f docker-compose.yml -f docker-compose.nvidia.override.yml up -d
 #   (production: docker compose -f docker-compose.prod.yml -f docker-compose.nvidia.override.yml up -d)
@@ -87,13 +90,10 @@ BUILD_DATE=1970-01-01T00:00:00Z
 #   docker compose -f docker-compose.yml -f docker-compose.intel.override.yml up -d --build
 #   (production: docker compose -f docker-compose.prod.yml -f docker-compose.intel.override.yml up -d)
 #
-# The override compose files set DEVICE, BACKEND, image tags, and device
-# passthrough via their `environment:` sections — no GPU-related variables
-# are needed in .env.
+# The override compose files set DEVICE, BACKEND, and device passthrough
+# via their `environment:` sections — no GPU-related variables are needed
+# in .env.
 #
 # Reference (set automatically by override files, not by .env):
 #   DEVICE   — cpu | cuda | xpu    (compute device for the embeddings server)
 #   BACKEND  — torch | openvino    (inference backend)
-#
-# Optional: override the embeddings-server image tag independently
-# EMBEDDINGS_VERSION=1.17.0-openvino

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build-and-push:
-    name: Build and push ${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
+    name: Build and push ${{ matrix.service.image }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,11 +52,6 @@ jobs:
           - image: embeddings-server
             context: ./src/embeddings-server
             dockerfile: ./src/embeddings-server/Dockerfile
-          - image: embeddings-server
-            context: ./src/embeddings-server
-            dockerfile: ./src/embeddings-server/Dockerfile
-            tag_suffix: "-openvino"
-            extra_build_args: "INSTALL_OPENVINO=true"
           - image: solr-search
             context: .
             dockerfile: ./src/solr-search/Dockerfile
@@ -82,8 +77,6 @@ jobs:
         with:
           images: ghcr.io/jmservera/aithena-${{ matrix.service.image }}
           tags: ${{ inputs.tags }}
-          flavor: |
-            suffix=${{ matrix.service.tag_suffix || '' }}
 
       - name: Build and push image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
@@ -97,8 +90,7 @@ jobs:
             VERSION=${{ inputs.version }}
             GIT_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ inputs.build-date }}
-            ${{ matrix.service.extra_build_args || '' }}
           secrets: |
             HF_TOKEN=${{ secrets.HF_TOKEN }}
-          cache-from: type=gha,scope=${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
+          cache-from: type=gha,scope=${{ matrix.service.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -141,7 +141,7 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   smoke-test:
-    name: Smoke test ${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
+    name: Smoke test ${{ matrix.service.image }}
     runs-on: ubuntu-latest
     needs:
       - prepare
@@ -165,13 +165,6 @@ jobs:
             port: "8080"
             health_endpoint: /health
             startup_timeout: 60
-          - image: embeddings-server
-            type: http
-            port: "8080"
-            health_endpoint: /health
-            startup_timeout: 60
-            tag_suffix: "-openvino"
-            docker_env: "-e BACKEND=openvino -e DEVICE=cpu"
           - image: admin
             type: http
             port: "8501"
@@ -198,26 +191,23 @@ jobs:
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
           RC_TAG: ${{ needs.prepare.outputs.full_tag }}
-          TAG_SUFFIX: ${{ matrix.service.tag_suffix || '' }}
-        run: docker pull "ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}${TAG_SUFFIX}"
+        run: docker pull "ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
 
       - name: Start container and check health endpoint
         if: matrix.service.type == 'http'
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
           RC_TAG: ${{ needs.prepare.outputs.full_tag }}
-          TAG_SUFFIX: ${{ matrix.service.tag_suffix || '' }}
           SERVICE_PORT: ${{ matrix.service.port }}
           HEALTH_ENDPOINT: ${{ matrix.service.health_endpoint }}
           STARTUP_TIMEOUT: ${{ matrix.service.startup_timeout }}
-          DOCKER_ENV: ${{ matrix.service.docker_env || '' }}
         run: |
-          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}${TAG_SUFFIX}"
+          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
           port="${SERVICE_PORT}"
           endpoint="${HEALTH_ENDPOINT}"
           timeout="${STARTUP_TIMEOUT}"
 
-          docker run -d --name smoke-container -p "${port}:${port}" ${DOCKER_ENV} "${image}"
+          docker run -d --name smoke-container -p "${port}:${port}" "${image}"
 
           elapsed=0
           echo "Waiting up to ${timeout}s for ${SERVICE_IMAGE} at :${port}${endpoint}..."
@@ -242,9 +232,8 @@ jobs:
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
           RC_TAG: ${{ needs.prepare.outputs.full_tag }}
-          TAG_SUFFIX: ${{ matrix.service.tag_suffix || '' }}
         run: |
-          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}${TAG_SUFFIX}"
+          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
 
           docker run -d --name smoke-container "${image}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   smoke-test:
-    name: Smoke test ${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
+    name: Smoke test ${{ matrix.service.image }}
     runs-on: ubuntu-latest
     needs:
       - validate-tag
@@ -135,13 +135,6 @@ jobs:
             port: "8080"
             health_endpoint: /health
             startup_timeout: 60
-          - image: embeddings-server
-            type: http
-            port: "8080"
-            health_endpoint: /health
-            startup_timeout: 60
-            tag_suffix: "-openvino"
-            docker_env: "-e BACKEND=openvino -e DEVICE=cpu"
           - image: admin
             type: http
             port: "8501"
@@ -168,26 +161,23 @@ jobs:
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
           VERSION: ${{ needs.validate-tag.outputs.version }}
-          TAG_SUFFIX: ${{ matrix.service.tag_suffix || '' }}
-        run: docker pull "ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}${TAG_SUFFIX}"
+        run: docker pull "ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}"
 
       - name: Start container and check health endpoint
         if: matrix.service.type == 'http'
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
           VERSION: ${{ needs.validate-tag.outputs.version }}
-          TAG_SUFFIX: ${{ matrix.service.tag_suffix || '' }}
           SERVICE_PORT: ${{ matrix.service.port }}
           HEALTH_ENDPOINT: ${{ matrix.service.health_endpoint }}
           STARTUP_TIMEOUT: ${{ matrix.service.startup_timeout }}
-          DOCKER_ENV: ${{ matrix.service.docker_env || '' }}
         run: |
-          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}${TAG_SUFFIX}"
+          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}"
           port="${SERVICE_PORT}"
           endpoint="${HEALTH_ENDPOINT}"
           timeout="${STARTUP_TIMEOUT}"
 
-          docker run -d --name smoke-container -p "${port}:${port}" ${DOCKER_ENV} "${image}"
+          docker run -d --name smoke-container -p "${port}:${port}" "${image}"
 
           elapsed=0
           echo "Waiting up to ${timeout}s for ${SERVICE_IMAGE} at :${port}${endpoint}..."
@@ -212,9 +202,8 @@ jobs:
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
           VERSION: ${{ needs.validate-tag.outputs.version }}
-          TAG_SUFFIX: ${{ matrix.service.tag_suffix || '' }}
         run: |
-          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}${TAG_SUFFIX}"
+          image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}"
 
           docker run -d --name smoke-container "${image}"
 

--- a/docker-compose.intel.override.yml
+++ b/docker-compose.intel.override.yml
@@ -1,11 +1,13 @@
 # docker-compose.intel.override.yml
 #
 # GPU acceleration override for Intel GPUs (Arc, iGPU via WSL2).
+# OpenVINO is included in the single embeddings-server image — this
+# override only sets runtime env vars and device passthrough.
 #
-# Usage (dev — builds from source with OpenVINO):
+# Usage (dev):
 #   docker compose -f docker-compose.yml -f docker-compose.intel.override.yml up -d --build
 #
-# Production (pulls pre-built OpenVINO image):
+# Production:
 #   docker compose -f docker-compose.prod.yml -f docker-compose.intel.override.yml up -d
 #
 # Prerequisites:
@@ -17,12 +19,6 @@
 
 services:
   embeddings-server:
-    # Override image tag to the pre-built OpenVINO variant (used by docker compose pull / up)
-    image: ghcr.io/jmservera/aithena-embeddings-server:${EMBEDDINGS_VERSION:-${VERSION:-latest}-openvino}
-    # Build args for local dev builds (only used with --build flag; ignored for pre-built images)
-    build:
-      args:
-        INSTALL_OPENVINO: "true"
     environment:
       - DEVICE=xpu
       - BACKEND=openvino

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
         VERSION: ${VERSION:-dev}
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
         BUILD_DATE: ${BUILD_DATE:-unknown}
-        BASE_TAG: ${EMBEDDINGS_BASE_TAG:-3.12-slim-multilingual-e5-base}
+        BASE_TAG: 3.12-slim-multilingual-e5-base
       secrets:
         - HF_TOKEN
     environment:

--- a/docs/guides/gpu-troubleshooting.md
+++ b/docs/guides/gpu-troubleshooting.md
@@ -112,7 +112,7 @@ docker compose logs embeddings-server --tail 100 | grep -i "error\|fail\|cuda\|x
 |-------|-------|-----|
 | `CUDA out of memory` | GPU VRAM insufficient | Model needs ~1.5GB VRAM. Close other GPU apps. |
 | `RuntimeError: No CUDA GPUs are available` | Docker can't see GPU | Reinstall NVIDIA Container Toolkit |
-| `ImportError: openvino` | OpenVINO not installed in image | Rebuild with `INSTALL_OPENVINO=true` build arg |
+| `ImportError: openvino` | OpenVINO runtime broken | Rebuild the image or check Python environment |
 | `xpu` device errors | Intel compute-runtime version mismatch | Update to latest compute-runtime |
 
 ### Performance Not Improved
@@ -144,7 +144,6 @@ CPU mode is always stable. GPU acceleration is purely opt-in.
 |----------|--------|---------|-------------|
 | `DEVICE` | `auto`, `cpu`, `cuda`, `xpu` | `cpu` | Compute device for embeddings |
 | `BACKEND` | `torch`, `openvino` | `torch` | Inference backend |
-| `INSTALL_OPENVINO` | `true`, `false` | `false` | Build arg: include OpenVINO in image |
 
 ## Log Messages Reference
 

--- a/src/embeddings-server/Dockerfile
+++ b/src/embeddings-server/Dockerfile
@@ -2,7 +2,6 @@ ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 ARG BASE_TAG=3.12-slim-multilingual-e5-base
-ARG INSTALL_OPENVINO=false
 
 # ── Stage 1: dependencies (changes when pyproject.toml / uv.lock change) ──
 FROM python:3.12-slim AS dependencies
@@ -16,12 +15,6 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project --native-tls
-
-# Optionally install OpenVINO for Intel GPU support
-ARG INSTALL_OPENVINO=false
-RUN if [ "$INSTALL_OPENVINO" = "true" ]; then \
-      uv sync --frozen --no-dev --no-install-project --extra openvino --native-tls; \
-    fi
 
 # ── Stage 2: runtime (base image already contains the cached model) ──
 FROM ghcr.io/jmservera/embeddings-server-base:${BASE_TAG} AS runtime

--- a/src/embeddings-server/pyproject.toml
+++ b/src/embeddings-server/pyproject.toml
@@ -7,10 +7,6 @@ dependencies = [
     "sentence-transformers>=3.4,<6",
     "fastapi>=0.135,<1",
     "uvicorn[standard]>=0.42,<1",
-]
-
-[project.optional-dependencies]
-openvino = [
     "optimum-intel",
     "openvino",
 ]

--- a/src/embeddings-server/uv.lock
+++ b/src/embeddings-server/uv.lock
@@ -253,14 +253,10 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
-    { name = "sentence-transformers" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.optional-dependencies]
-openvino = [
     { name = "openvino" },
     { name = "optimum-intel" },
+    { name = "sentence-transformers" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -274,12 +270,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.135,<1" },
-    { name = "openvino", marker = "extra == 'openvino'" },
-    { name = "optimum-intel", marker = "extra == 'openvino'" },
+    { name = "openvino" },
+    { name = "optimum-intel" },
     { name = "sentence-transformers", specifier = ">=3.4,<6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.42,<1" },
 ]
-provides-extras = ["openvino"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Consolidate the embeddings-server into a single image that always includes OpenVINO. The ~150MB size increase on a 9GB image doesn't justify maintaining separate CPU and -openvino image variants.

## Changes

- **pyproject.toml**: Moved `optimum-intel` and `openvino` from optional to main dependencies
- **Dockerfile**: Removed `INSTALL_OPENVINO` build arg and conditional install block
- **build-containers.yml**: Removed duplicate `-openvino` matrix entry, `tag_suffix`, `extra_build_args`, and flavor suffix
- **pre-release.yml / release.yml**: Removed `-openvino` smoke test entry, cleaned up `tag_suffix` and `docker_env` plumbing
- **docker-compose.intel.override.yml**: Removed `image:` override and `build: args:` block — now purely runtime config (DEVICE/BACKEND + device passthrough)
- **docker-compose.yml**: Removed `EMBEDDINGS_BASE_TAG` variable indirection
- **.env.example**: Updated GPU docs to reflect single-image approach
- **gpu-troubleshooting.md**: Removed `INSTALL_OPENVINO` from env var reference table

## How it works now

The difference between NVIDIA and Intel deployments is purely runtime environment variables (`DEVICE`/`BACKEND`) set by the override compose files — no separate image build or tag needed.

Working as Brett (Infra Architect)