### PR TITLE
refactor: restore dual-image OpenVINO build with model pre-download

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,9 +79,6 @@ BUILD_DATE=1970-01-01T00:00:00Z
 # ── GPU Platform ──────────────────────────────────────────────────────────────
 # Default: CPU-only (no changes needed)
 #
-# The single embeddings-server image supports both NVIDIA (CUDA) and
-# Intel (OpenVINO) — no separate image tags are needed.
-#
 # For NVIDIA GPU:
 #   docker compose -f docker-compose.yml -f docker-compose.nvidia.override.yml up -d
 #   (production: docker compose -f docker-compose.prod.yml -f docker-compose.nvidia.override.yml up -d)
@@ -90,10 +87,13 @@ BUILD_DATE=1970-01-01T00:00:00Z
 #   docker compose -f docker-compose.yml -f docker-compose.intel.override.yml up -d --build
 #   (production: docker compose -f docker-compose.prod.yml -f docker-compose.intel.override.yml up -d)
 #
-# The override compose files set DEVICE, BACKEND, and device passthrough
-# via their `environment:` sections — no GPU-related variables are needed
-# in .env.
+# The override compose files set DEVICE, BACKEND, image tags, and device
+# passthrough via their `environment:` sections — no GPU-related variables
+# are needed in .env.
 #
 # Reference (set automatically by override files, not by .env):
 #   DEVICE   — cpu | cuda | xpu    (compute device for the embeddings server)
 #   BACKEND  — torch | openvino    (inference backend)
+#
+# Optional: override the embeddings-server image tag independently
+# EMBEDDINGS_VERSION=1.17.0-openvino

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build-and-push:
-    name: Build and push ${{ matrix.service.image }}
+    name: Build and push ${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,6 +52,11 @@ jobs:
           - image: embeddings-server
             context: ./src/embeddings-server
             dockerfile: ./src/embeddings-server/Dockerfile
+          - image: embeddings-server
+            context: ./src/embeddings-server
+            dockerfile: ./src/embeddings-server/Dockerfile
+            tag_suffix: "-openvino"
+            extra_build_args: "INSTALL_OPENVINO=true"
           - image: solr-search
             context: .
             dockerfile: ./src/solr-search/Dockerfile
@@ -77,6 +82,8 @@ jobs:
         with:
           images: ghcr.io/jmservera/aithena-${{ matrix.service.image }}
           tags: ${{ inputs.tags }}
+          flavor: |
+            suffix=${{ matrix.service.tag_suffix || '' }}
 
       - name: Build and push image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
@@ -90,7 +97,8 @@ jobs:
             VERSION=${{ inputs.version }}
             GIT_COMMIT=${{ github.sha }}
             BUILD_DATE=${{ inputs.build-date }}
+            ${{ matrix.service.extra_build_args || '' }}
           secrets: |
             HF_TOKEN=${{ secrets.HF_TOKEN }}
-          cache-from: type=gha,scope=${{ matrix.service.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}
+          cache-from: type=gha,scope=${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -141,7 +141,7 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   smoke-test:
-    name: Smoke test ${{ matrix.service.image }}
+    name: Smoke test ${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
     runs-on: ubuntu-latest
     needs:
       - prepare
@@ -165,6 +165,12 @@ jobs:
             port: "8080"
             health_endpoint: /health
             startup_timeout: 60
+          - image: embeddings-server
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 60
+            tag_suffix: "-openvino"
           - image: admin
             type: http
             port: "8501"
@@ -190,14 +196,14 @@ jobs:
       - name: Pull image
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
-          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}${{ matrix.service.tag_suffix || '' }}
         run: docker pull "ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
 
       - name: Start container and check health endpoint
         if: matrix.service.type == 'http'
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
-          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}${{ matrix.service.tag_suffix || '' }}
           SERVICE_PORT: ${{ matrix.service.port }}
           HEALTH_ENDPOINT: ${{ matrix.service.health_endpoint }}
           STARTUP_TIMEOUT: ${{ matrix.service.startup_timeout }}
@@ -231,7 +237,7 @@ jobs:
         if: matrix.service.type == 'process'
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
-          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}${{ matrix.service.tag_suffix || '' }}
         run: |
           image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
 
@@ -270,7 +276,7 @@ jobs:
         if: always()
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
-          RC_TAG: ${{ needs.prepare.outputs.full_tag }}
+          RC_TAG: ${{ needs.prepare.outputs.full_tag }}${{ matrix.service.tag_suffix || '' }}
           STEP_STATUS: ${{ job.status }}
         run: |
           if [ "$STEP_STATUS" = "success" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   smoke-test:
-    name: Smoke test ${{ matrix.service.image }}
+    name: Smoke test ${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
     runs-on: ubuntu-latest
     needs:
       - validate-tag
@@ -135,6 +135,12 @@ jobs:
             port: "8080"
             health_endpoint: /health
             startup_timeout: 60
+          - image: embeddings-server
+            type: http
+            port: "8080"
+            health_endpoint: /health
+            startup_timeout: 60
+            tag_suffix: "-openvino"
           - image: admin
             type: http
             port: "8501"
@@ -160,14 +166,14 @@ jobs:
       - name: Pull image
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
-          VERSION: ${{ needs.validate-tag.outputs.version }}
+          VERSION: ${{ needs.validate-tag.outputs.version }}${{ matrix.service.tag_suffix || '' }}
         run: docker pull "ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}"
 
       - name: Start container and check health endpoint
         if: matrix.service.type == 'http'
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
-          VERSION: ${{ needs.validate-tag.outputs.version }}
+          VERSION: ${{ needs.validate-tag.outputs.version }}${{ matrix.service.tag_suffix || '' }}
           SERVICE_PORT: ${{ matrix.service.port }}
           HEALTH_ENDPOINT: ${{ matrix.service.health_endpoint }}
           STARTUP_TIMEOUT: ${{ matrix.service.startup_timeout }}
@@ -201,7 +207,7 @@ jobs:
         if: matrix.service.type == 'process'
         env:
           SERVICE_IMAGE: ${{ matrix.service.image }}
-          VERSION: ${{ needs.validate-tag.outputs.version }}
+          VERSION: ${{ needs.validate-tag.outputs.version }}${{ matrix.service.tag_suffix || '' }}
         run: |
           image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}"
 

--- a/docker-compose.intel.override.yml
+++ b/docker-compose.intel.override.yml
@@ -1,13 +1,11 @@
 # docker-compose.intel.override.yml
 #
 # GPU acceleration override for Intel GPUs (Arc, iGPU via WSL2).
-# OpenVINO is included in the single embeddings-server image — this
-# override only sets runtime env vars and device passthrough.
 #
-# Usage (dev):
+# Usage (dev — builds from source with OpenVINO):
 #   docker compose -f docker-compose.yml -f docker-compose.intel.override.yml up -d --build
 #
-# Production:
+# Production (pulls pre-built OpenVINO image):
 #   docker compose -f docker-compose.prod.yml -f docker-compose.intel.override.yml up -d
 #
 # Prerequisites:
@@ -19,6 +17,12 @@
 
 services:
   embeddings-server:
+    # Override image tag to the pre-built OpenVINO variant (used by docker compose pull / up)
+    image: ghcr.io/jmservera/aithena-embeddings-server:${EMBEDDINGS_VERSION:-${VERSION:-latest}-openvino}
+    # Build args for local dev builds (only used with --build flag; ignored for pre-built images)
+    build:
+      args:
+        INSTALL_OPENVINO: "true"
     environment:
       - DEVICE=xpu
       - BACKEND=openvino

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
         VERSION: ${VERSION:-dev}
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
         BUILD_DATE: ${BUILD_DATE:-unknown}
-        BASE_TAG: 3.12-slim-multilingual-e5-base
+        BASE_TAG: ${EMBEDDINGS_BASE_TAG:-3.12-slim-multilingual-e5-base}
       secrets:
         - HF_TOKEN
     environment:

--- a/docs/guides/gpu-troubleshooting.md
+++ b/docs/guides/gpu-troubleshooting.md
@@ -112,7 +112,7 @@ docker compose logs embeddings-server --tail 100 | grep -i "error\|fail\|cuda\|x
 |-------|-------|-----|
 | `CUDA out of memory` | GPU VRAM insufficient | Model needs ~1.5GB VRAM. Close other GPU apps. |
 | `RuntimeError: No CUDA GPUs are available` | Docker can't see GPU | Reinstall NVIDIA Container Toolkit |
-| `ImportError: openvino` | OpenVINO runtime broken | Rebuild the image or check Python environment |
+| `ImportError: openvino` | OpenVINO not installed in image | Use the `-openvino` image variant or rebuild with `INSTALL_OPENVINO=true` build arg |
 | `xpu` device errors | Intel compute-runtime version mismatch | Update to latest compute-runtime |
 
 ### Performance Not Improved
@@ -144,6 +144,7 @@ CPU mode is always stable. GPU acceleration is purely opt-in.
 |----------|--------|---------|-------------|
 | `DEVICE` | `auto`, `cpu`, `cuda`, `xpu` | `cpu` | Compute device for embeddings |
 | `BACKEND` | `torch`, `openvino` | `torch` | Inference backend |
+| `INSTALL_OPENVINO` | `true`, `false` | `false` | Build arg: include OpenVINO + pre-download IR model |
 
 ## Log Messages Reference
 

--- a/src/embeddings-server/Dockerfile
+++ b/src/embeddings-server/Dockerfile
@@ -2,6 +2,7 @@ ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 ARG BASE_TAG=3.12-slim-multilingual-e5-base
+ARG INSTALL_OPENVINO=false
 
 # ── Stage 1: dependencies (changes when pyproject.toml / uv.lock change) ──
 FROM python:3.12-slim AS dependencies
@@ -15,6 +16,12 @@ WORKDIR /app
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project --native-tls
+
+# Optionally install OpenVINO for Intel GPU support
+ARG INSTALL_OPENVINO=false
+RUN if [ "$INSTALL_OPENVINO" = "true" ]; then \
+      uv sync --frozen --no-dev --no-install-project --extra openvino --native-tls; \
+    fi
 
 # ── Stage 2: runtime (base image already contains the cached model) ──
 FROM ghcr.io/jmservera/embeddings-server-base:${BASE_TAG} AS runtime
@@ -50,12 +57,24 @@ RUN groupadd --system --gid 1000 app && useradd --system --uid 1000 --gid app --
 
 COPY --from=dependencies /app/.venv /app/.venv
 
+ENV PATH="/app/.venv/bin:${PATH}"
+
 COPY main.py model_utils.py /app/
 COPY config /app/config
 
-RUN chown -R app:app /app /models
+# Pre-download OpenVINO model files at build time.
+# The base image caches torch-format model files; OpenVINO needs its own
+# IR format files (openvino_model.xml + .bin) from the HF repo's openvino/ folder.
+# SentenceTransformer(backend="openvino") fetches them automatically.
+ARG INSTALL_OPENVINO=false
+RUN --mount=type=secret,id=HF_TOKEN \
+    if [ "$INSTALL_OPENVINO" = "true" ]; then \
+      HF_TOKEN="$(cat /run/secrets/HF_TOKEN 2>/dev/null || true)" \
+      HF_HUB_OFFLINE=0 TRANSFORMERS_OFFLINE=0 \
+      python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('intfloat/multilingual-e5-base', backend='openvino')" ; \
+    fi
 
-ENV PATH="/app/.venv/bin:${PATH}"
+RUN chown -R app:app /app /models
 
 EXPOSE 8080
 

--- a/src/embeddings-server/pyproject.toml
+++ b/src/embeddings-server/pyproject.toml
@@ -7,6 +7,10 @@ dependencies = [
     "sentence-transformers>=3.4,<6",
     "fastapi>=0.135,<1",
     "uvicorn[standard]>=0.42,<1",
+]
+
+[project.optional-dependencies]
+openvino = [
     "optimum-intel",
     "openvino",
 ]

--- a/src/embeddings-server/uv.lock
+++ b/src/embeddings-server/uv.lock
@@ -253,10 +253,14 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi" },
-    { name = "openvino" },
-    { name = "optimum-intel" },
     { name = "sentence-transformers" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+openvino = [
+    { name = "openvino" },
+    { name = "optimum-intel" },
 ]
 
 [package.dev-dependencies]
@@ -270,11 +274,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.135,<1" },
-    { name = "openvino" },
-    { name = "optimum-intel" },
+    { name = "openvino", marker = "extra == 'openvino'" },
+    { name = "optimum-intel", marker = "extra == 'openvino'" },
     { name = "sentence-transformers", specifier = ">=3.4,<6" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.42,<1" },
 ]
+provides-extras = ["openvino"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Reverts the single-image consolidation from PR #1251. OpenVINO requires IR-format model files (`openvino_model.xml` + `.bin`) which are different from the torch/ONNX files cached in the base image. A single image cannot serve both backends.

### Key addition: build-time model pre-download

When `INSTALL_OPENVINO=true`, the Dockerfile now:
1. Installs openvino + optimum-intel pip packages (via `uv sync --extra openvino`)
2. **Pre-downloads the OpenVINO IR model** by running `SentenceTransformer('intfloat/multilingual-e5-base', backend='openvino')` at build time — this fetches the files from the [HF repo's `openvino/` folder](https://huggingface.co/intfloat/multilingual-e5-base/tree/main/openvino)

This ensures the `-openvino` image ships with cached IR model files so it can run with `HF_HUB_OFFLINE=1` at runtime, just like the standard image does for torch.

### Files changed (10)
- `Dockerfile`: restore `INSTALL_OPENVINO` conditional + model pre-download step
- `pyproject.toml`: move openvino deps back to `[project.optional-dependencies]`
- `build-containers.yml`: restore `-openvino` matrix entry with `tag_suffix`
- `pre-release.yml` / `release.yml`: restore `-openvino` smoke test entries
- `docker-compose.intel.override.yml`: restore image override for `-openvino` tag
- `docker-compose.yml`: restore `EMBEDDINGS_BASE_TAG` variable
- `.env.example`: restore dual-image GPU documentation
- `gpu-troubleshooting.md`: restore `INSTALL_OPENVINO` reference

### Image tags produced
| Image | Use case |
|-------|----------|
| `aithena-embeddings-server:1.17.0-rc.X` | CPU / NVIDIA (torch backend) |
| `aithena-embeddings-server:1.17.0-rc.X-openvino` | Intel GPU (OpenVINO backend) |
