### PR TITLE
refactor: use openvino base image tag instead of build-time model download

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -56,7 +56,9 @@ jobs:
             context: ./src/embeddings-server
             dockerfile: ./src/embeddings-server/Dockerfile
             tag_suffix: "-openvino"
-            extra_build_args: "INSTALL_OPENVINO=true"
+            extra_build_args: |
+              INSTALL_OPENVINO=true
+              BASE_TAG=3.12-slim-multilingual-e5-base-openvino
           - image: solr-search
             context: .
             dockerfile: ./src/solr-search/Dockerfile

--- a/docker-compose.intel.override.yml
+++ b/docker-compose.intel.override.yml
@@ -23,6 +23,7 @@ services:
     build:
       args:
         INSTALL_OPENVINO: "true"
+        BASE_TAG: "3.12-slim-multilingual-e5-base-openvino"
     environment:
       - DEVICE=xpu
       - BACKEND=openvino

--- a/src/embeddings-server/Dockerfile
+++ b/src/embeddings-server/Dockerfile
@@ -62,18 +62,6 @@ ENV PATH="/app/.venv/bin:${PATH}"
 COPY main.py model_utils.py /app/
 COPY config /app/config
 
-# Pre-download OpenVINO model files at build time.
-# The base image caches torch-format model files; OpenVINO needs its own
-# IR format files (openvino_model.xml + .bin) from the HF repo's openvino/ folder.
-# SentenceTransformer(backend="openvino") fetches them automatically.
-ARG INSTALL_OPENVINO=false
-RUN --mount=type=secret,id=HF_TOKEN \
-    if [ "$INSTALL_OPENVINO" = "true" ]; then \
-      HF_TOKEN="$(cat /run/secrets/HF_TOKEN 2>/dev/null || true)" \
-      HF_HUB_OFFLINE=0 TRANSFORMERS_OFFLINE=0 \
-      python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('intfloat/multilingual-e5-base', backend='openvino')" ; \
-    fi
-
 RUN chown -R app:app /app /models
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary

Follow-up to PR #1253. Instead of downloading the OpenVINO model at build time in the aithena Dockerfile, delegate model caching to the base image repo.

### Base image changes (separate PR)

[embeddings-server-base PR #2](https://github.com/jmservera/embeddings-server-base/pull/2) adds a `BACKEND` build arg:

| Base tag | Model format |
|----------|-------------|
| `3.12-slim-multilingual-e5-base` | PyTorch safetensors (default) |
| `3.12-slim-multilingual-e5-base-openvino` | OpenVINO IR (xml + bin) |

### Changes in this PR

- **Dockerfile**: Remove the build-time model download step — the base image now handles it
- **build-containers.yml**: Pass `BASE_TAG=3.12-slim-multilingual-e5-base-openvino` for the `-openvino` matrix entry
- **docker-compose.intel.override.yml**: Pass `BASE_TAG` for local dev builds

### Build flow

```
Base image repo builds:
  embeddings-server-base:3.12-slim-multilingual-e5-base          (torch model cached)
  embeddings-server-base:3.12-slim-multilingual-e5-base-openvino (openvino IR model cached)

Aithena CI builds:
  aithena-embeddings-server:1.17.0-rc.X           → FROM base:3.12-slim-multilingual-e5-base
  aithena-embeddings-server:1.17.0-rc.X-openvino  → FROM base:3.12-slim-multilingual-e5-base-openvino
```

⚠️ **Dependency**: The openvino base image must be built first (via base repo PR #2) before the `-openvino` aithena image can build successfully.
