### PR TITLE
fix: use /dev/dxg for Intel GPU passthrough in WSL2

### DIFF
--- a/docker-compose.intel.override.yml
+++ b/docker-compose.intel.override.yml
@@ -10,10 +10,10 @@
 #
 # Prerequisites:
 #   - Intel GPU with compute-runtime drivers
-#   - /dev/dri device must be accessible
+#   - /dev/dxg device must be accessible (WSL2)
 #
 # Verify GPU access:
-#   ls -la /dev/dri/
+#   ls -la /dev/dxg
 
 services:
   embeddings-server:
@@ -28,7 +28,7 @@ services:
       - DEVICE=xpu
       - BACKEND=openvino
     devices:
-      - /dev/dri:/dev/dri
+      - /dev/dxg:/dev/dxg
     group_add:
       - video
       - render

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -181,7 +181,7 @@ docker compose -f docker-compose.yml -f docker-compose.nvidia.override.yml up -d
 #### Prerequisites
 - Intel GPU with OpenCL/Level Zero support (Arc A-series, Iris Xe, or integrated GPU with Gen12+)
 - Intel compute-runtime drivers
-- `/dev/dri` device accessible
+- `/dev/dxg` device accessible
 
 #### Install Intel compute-runtime
 
@@ -200,8 +200,8 @@ sudo apt-get install -y intel-opencl-icd intel-level-zero-gpu
 
 #### Verify Intel setup
 ```bash
-# Check /dev/dri exists
-ls -la /dev/dri/
+# Check /dev/dxg exists
+ls -la /dev/dxg/
 
 # Check Intel GPU is recognized
 sudo apt-get install -y clinfo
@@ -225,9 +225,9 @@ Many users run Aithena on Windows via WSL2. GPU passthrough works for both NVIDI
 
 #### Intel on WSL2
 1. Install latest Intel GPU drivers on **Windows**
-2. WSL2 exposes `/dev/dri/renderD128` for GPU compute
-3. Verify: `ls -la /dev/dri/` inside WSL — you should see `renderD128`
-4. The Intel override file maps `/dev/dri` into the container
+2. WSL2 exposes `/dev/dxg` for GPU compute
+3. Verify: `ls -la /dev/dxg/` inside WSL — you should see `renderD128`
+4. The Intel override file maps `/dev/dxg` into the container
 
 ### Verification
 
@@ -256,7 +256,7 @@ Expected output with GPU:
 | `xpu device not found` | Intel compute-runtime missing | Install intel-opencl-icd |
 | Health shows `device: cpu` despite override | Override file not loaded | Check `docker compose config` output |
 | Container crash on startup | GPU memory insufficient | Try `DEVICE=cpu` to verify, then check GPU memory |
-| `/dev/dri` not found in WSL2 | GPU drivers not installed on Windows host | Install Windows GPU drivers, restart WSL |
+| `/dev/dxg` not found in WSL2 | GPU drivers not installed on Windows host | Install Windows GPU drivers, restart WSL |
 
 ## Backup dashboard and restore workflow (v1.14.x)
 

--- a/docs/guides/gpu-troubleshooting.md
+++ b/docs/guides/gpu-troubleshooting.md
@@ -61,8 +61,8 @@ docker compose -f docker-compose.yml -f docker-compose.nvidia.override.yml confi
 
 **Diagnosis:**
 ```bash
-# 1. Check /dev/dri exists
-ls -la /dev/dri/
+# 1. Check /dev/dxg exists
+ls -la /dev/dxg/
 
 # 2. Check Intel GPU is recognized
 clinfo | head -20
@@ -75,14 +75,14 @@ groups
 
 | Check | Fix |
 |-------|-----|
-| `/dev/dri` missing | Install Intel compute-runtime drivers |
+| `/dev/dxg` missing | Install Intel compute-runtime drivers |
 | `clinfo` shows no devices | Install `intel-opencl-icd` and `intel-level-zero-gpu` |
-| Permission denied on `/dev/dri` | Add user to `video` and `render` groups |
-| WSL2: `/dev/dri` missing | Install Intel GPU drivers on **Windows** host, restart WSL |
+| Permission denied on `/dev/dxg` | Add user to `video` and `render` groups |
+| WSL2: `/dev/dxg` missing | Install Intel GPU drivers on **Windows** host, restart WSL |
 
 ### WSL2-Specific Issues
 
-**`/dev/dri` not available in WSL2:**
+**`/dev/dxg` not available in WSL2:**
 1. Ensure GPU drivers are installed on the **Windows host** (not inside WSL)
 2. Run `wsl --update` to get the latest WSL2 kernel
 3. Restart WSL: `wsl --shutdown` then reopen
@@ -92,7 +92,7 @@ groups
 2. Configure Docker runtime: `sudo nvidia-ctk runtime configure --runtime=docker`
 3. Restart Docker: `sudo systemctl restart docker`
 
-**Intel: `/dev/dri/renderD128` missing:**
+**Intel: `/dev/dxg` missing:**
 1. This requires recent Intel GPU drivers on Windows
 2. Check Windows Device Manager → Display adapters for Intel GPU
 3. Update Intel driver from [Intel Download Center](https://www.intel.com/content/www/us/en/download-center/home.html)
@@ -162,6 +162,6 @@ CPU mode is always stable. GPU acceleration is purely opt-in.
 2. Review container logs: `docker compose logs embeddings-server`
 3. File an issue at the project repository with:
    - Output of `docker compose logs embeddings-server --tail 100`
-   - Output of `nvidia-smi` or `ls -la /dev/dri/`
+   - Output of `nvidia-smi` or `ls -la /dev/dxg/`
    - Your Docker Compose command
    - Host OS and GPU model

--- a/docs/prd/gpu-acceleration.md
+++ b/docs/prd/gpu-acceleration.md
@@ -236,7 +236,7 @@ services:
 services:
   embeddings-server:
     devices:
-      - /dev/dri  # Intel GPU device passthrough
+      - /dev/dxg  # Intel GPU device passthrough (WSL2)
     environment:
       DEVICE: "${DEVICE:-auto}"
       BACKEND: "${BACKEND:-openvino}"

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -772,7 +772,7 @@ docker compose -f docker-compose.yml -f docker-compose.intel.override.yml up -d
 ### Prerequisites
 
 - **NVIDIA:** NVIDIA drivers + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
-- **Intel:** Intel GPU drivers + `/dev/dri` device accessible (see [Admin Manual](admin-manual.md) for WSL2 setup)
+- **Intel:** Intel GPU drivers + `/dev/dxg` device accessible (see [Admin Manual](admin-manual.md) for WSL2 setup)
 
 > **Note:** GPU acceleration only affects indexing speed. Search performance is unchanged — Solr handles search queries independently of the embedding hardware.
 


### PR DESCRIPTION
OpenVINO on WSL2 requires `/dev/dxg` (DirectX GPU device) instead of `/dev/dri`.

### Changes
- **docker-compose.intel.override.yml** — device `/dev/dri:/dev/dri` → `/dev/dxg:/dev/dxg`
- **docs/** — updated admin-manual, user-manual, gpu-troubleshooting, and PRD to reference `/dev/dxg`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>