### PR TITLE
fix: remove render group from Intel GPU override

### DIFF
--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -130,8 +130,20 @@ Use overlay files (not profiles) when making a sidecar optional affects the main
 - Used override files (`docker-compose.nvidia.override.yml`, `docker-compose.intel.override.yml`) rather than profiles — consistent with existing ssl/e2e overlay pattern
 - `DEVICE` and `BACKEND` env vars in base compose default to `cpu`/`torch` for backward compatibility
 - NVIDIA: `deploy.resources.reservations.devices` with `driver: nvidia` and `capabilities: [gpu]`
-- Intel: `/dev/dri` device passthrough + `video`/`render` group_add + `INSTALL_OPENVINO` build arg
+- Intel: `/dev/dri` device passthrough + `video` group_add + `BASE_TAG` build arg (selects openvino base image)
 - Key files: `docker-compose.nvidia.override.yml`, `docker-compose.intel.override.yml`
+
+### HF Hub Offline Cache for Base Images
+- `SentenceTransformer()` alone does NOT cache HF Hub API metadata (tree listings, model card endpoints)
+- `optimum-intel` loading path calls `huggingface.co/api/models/.../tree/main` to discover openvino files — fails offline
+- Fix: call `huggingface_hub.snapshot_download(model_name)` BEFORE `SentenceTransformer()` to cache full repo metadata
+- Always add an offline verification `RUN` step: `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python -c "..."` to fail-fast during build
+- Applies to both torch and openvino variants in `embeddings-server-base` repo
+
+### Container Group Gotcha
+- `group_add: [render]` in Docker Compose fails if the `render` group doesn't exist inside the container image
+- The `render` group is a host-level Linux concept for GPU DRM access; slim Python images don't have it
+- For WSL2 Intel GPU (`/dev/dxg`), only `video` group is needed
 
 ## Reskill Notes (2026-07-25)
 

--- a/.squad/decisions/inbox/brett-openvino-cache-fix.md
+++ b/.squad/decisions/inbox/brett-openvino-cache-fix.md
@@ -1,0 +1,28 @@
+# Decision: HF Hub snapshot_download Required for Offline Base Images
+
+**Author:** Brett (Infrastructure Architect)
+**Date:** 2026-07-26
+**Status:** Implemented
+**Context:** OpenVINO base image fails at runtime with `HF_HUB_OFFLINE=1`
+
+## Problem
+
+The `embeddings-server-base` Dockerfile only called `SentenceTransformer()` to cache the model. This downloads model weights but does NOT cache HF Hub API metadata (tree listings, model info endpoints). At runtime with `HF_HUB_OFFLINE=1`, the `optimum-intel` loading path tries to call `huggingface.co/api/models/.../tree/main` to discover openvino files, which fails.
+
+## Decision
+
+1. **Always call `huggingface_hub.snapshot_download(model_name)` before `SentenceTransformer()`** in base image Dockerfiles. This caches the full HF Hub repo including metadata needed for offline loading.
+2. **Always add an offline verification step** in the Dockerfile: `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python -c "..."`. This fails the build if the cache is incomplete.
+3. **Removed `render` from `group_add`** in `docker-compose.intel.override.yml` — the group doesn't exist in slim Python images, causing container startup failures.
+
+## Rationale
+
+- `snapshot_download()` is the only HF Hub function that caches API tree metadata; `SentenceTransformer()` uses a different code path that skips this
+- The offline verification RUN step provides a build-time safety net — catches cache issues before the image ships
+- The `render` group is a host-level concept for native Linux DRM access; not needed for WSL2 `/dev/dxg` passthrough
+
+## Impact
+
+- Base image repo (`embeddings-server-base`): Dockerfile updated, pushed to main, CI rebuilds both variants
+- Aithena repo: `docker-compose.intel.override.yml` fixed, PR #1258 against dev
+- Pattern applies to any future base image that pre-caches HF models for offline use

--- a/docker-compose.intel.override.yml
+++ b/docker-compose.intel.override.yml
@@ -31,4 +31,3 @@ services:
       - /dev/dxg:/dev/dxg
     group_add:
       - video
-      - render

--- a/docs/guides/gpu-troubleshooting.md
+++ b/docs/guides/gpu-troubleshooting.md
@@ -67,7 +67,7 @@ ls -la /dev/dxg/
 # 2. Check Intel GPU is recognized
 clinfo | head -20
 
-# 3. Check user has video/render group access
+# 3. Check user has video group access
 groups
 ```
 
@@ -77,7 +77,7 @@ groups
 |-------|-----|
 | `/dev/dxg` missing | Install Intel compute-runtime drivers |
 | `clinfo` shows no devices | Install `intel-opencl-icd` and `intel-level-zero-gpu` |
-| Permission denied on `/dev/dxg` | Add user to `video` and `render` groups |
+| Permission denied on `/dev/dxg` | Add user to `video` group |
 | WSL2: `/dev/dxg` missing | Install Intel GPU drivers on **Windows** host, restart WSL |
 
 ### WSL2-Specific Issues


### PR DESCRIPTION
## Problem

The `docker-compose.intel.override.yml` has `group_add: [video, render]` but the `render` group doesn't exist inside the container image, causing:

```
Unable to find group render: no matching entries in group file
```

## Fix

- Removed `render` from `group_add` in `docker-compose.intel.override.yml` — only `video` is needed for `/dev/dxg` access in WSL2
- Updated `docs/guides/gpu-troubleshooting.md` to match

Working as Brett (Infrastructure Architect).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>