### PR TITLE
ci: disable GHA cache for embeddings-server builds

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -52,10 +52,12 @@ jobs:
           - image: embeddings-server
             context: ./src/embeddings-server
             dockerfile: ./src/embeddings-server/Dockerfile
+            no_cache: true
           - image: embeddings-server
             context: ./src/embeddings-server
             dockerfile: ./src/embeddings-server/Dockerfile
             tag_suffix: "-openvino"
+            no_cache: true
             extra_build_args: |
               INSTALL_OPENVINO=true
               BASE_TAG=3.12-slim-multilingual-e5-base-openvino
@@ -102,5 +104,5 @@ jobs:
             ${{ matrix.service.extra_build_args || '' }}
           secrets: |
             HF_TOKEN=${{ secrets.HF_TOKEN }}
-          cache-from: type=gha,scope=${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
+          cache-from: ${{ !matrix.service.no_cache && format('type=gha,scope={0}{1}', matrix.service.image, matrix.service.tag_suffix || '') || '' }}
+          cache-to: ${{ !matrix.service.no_cache && format('type=gha,mode=max,scope={0}{1}', matrix.service.image, matrix.service.tag_suffix || '') || '' }}


### PR DESCRIPTION
## Problem

The embeddings-server base images contain ~1-5GB of model files that were being redundantly cached in the 10GB GHA cache (`type=gha,mode=max`). This was:
- **Crowding out** useful caches for smaller services (10.1GB / 10GB quota used)
- **Adding 3-8 min overhead** per build for cache upload, while only saving ~2 min on dependency install
- **Producing stale cache errors** (`blob sha256:...: not found`) whenever the base image changed

The base image layers are already served efficiently by GHCR — Docker pulls them from the registry regardless of GHA cache state.

## Fix

- Add `no_cache: true` to both embeddings-server matrix entries (torch + openvino)
- Conditionally skip `cache-from`/`cache-to` when `no_cache` is set
- Deleted 10.7GB of stale buildkit blob caches from the GHA cache store

Other services (admin, aithena-ui, solr-search, document-*) continue using GHA cache — they benefit from it.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>