### PR TITLE
ci: pass BACKEND=openvino to openvino smoke tests

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -171,6 +171,7 @@ jobs:
             health_endpoint: /health
             startup_timeout: 60
             tag_suffix: "-openvino"
+            docker_env: "-e BACKEND=openvino -e DEVICE=cpu"
           - image: admin
             type: http
             port: "8501"
@@ -207,13 +208,14 @@ jobs:
           SERVICE_PORT: ${{ matrix.service.port }}
           HEALTH_ENDPOINT: ${{ matrix.service.health_endpoint }}
           STARTUP_TIMEOUT: ${{ matrix.service.startup_timeout }}
+          DOCKER_ENV: ${{ matrix.service.docker_env || '' }}
         run: |
           image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${RC_TAG}"
           port="${SERVICE_PORT}"
           endpoint="${HEALTH_ENDPOINT}"
           timeout="${STARTUP_TIMEOUT}"
 
-          docker run -d --name smoke-container -p "${port}:${port}" "${image}"
+          docker run -d --name smoke-container -p "${port}:${port}" ${DOCKER_ENV} "${image}"
 
           elapsed=0
           echo "Waiting up to ${timeout}s for ${SERVICE_IMAGE} at :${port}${endpoint}..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,7 @@ jobs:
             health_endpoint: /health
             startup_timeout: 60
             tag_suffix: "-openvino"
+            docker_env: "-e BACKEND=openvino -e DEVICE=cpu"
           - image: admin
             type: http
             port: "8501"
@@ -177,13 +178,14 @@ jobs:
           SERVICE_PORT: ${{ matrix.service.port }}
           HEALTH_ENDPOINT: ${{ matrix.service.health_endpoint }}
           STARTUP_TIMEOUT: ${{ matrix.service.startup_timeout }}
+          DOCKER_ENV: ${{ matrix.service.docker_env || '' }}
         run: |
           image="ghcr.io/jmservera/aithena-${SERVICE_IMAGE}:${VERSION}"
           port="${SERVICE_PORT}"
           endpoint="${HEALTH_ENDPOINT}"
           timeout="${STARTUP_TIMEOUT}"
 
-          docker run -d --name smoke-container -p "${port}:${port}" "${image}"
+          docker run -d --name smoke-container -p "${port}:${port}" ${DOCKER_ENV} "${image}"
 
           elapsed=0
           echo "Waiting up to ${timeout}s for ${SERVICE_IMAGE} at :${port}${endpoint}..."


### PR DESCRIPTION
## Problem

The openvino smoke test was failing because the container ran with default settings (`backend=torch`), but the openvino base image only contains OpenVINO model files (`openvino_model.bin`), not pytorch weights (`pytorch_model.bin`/`model.safetensors`).

Error from rc.10:
```
Failed to load embedding model: Error no file named pytorch_model.bin, model.safetensors, tf_model.h5, model.ckpt.index or flax_model.msgpack found in directory /models/sentence_transformers/intfloat_multilingual-e5-base
```

## Fix

- Add `docker_env: "-e BACKEND=openvino -e DEVICE=cpu"` to the openvino smoke test matrix entries
- Pass `DOCKER_ENV` flags to `docker run` in both pre-release and release workflows  
- Use `DEVICE=cpu` since CI runners have no GPU

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>