### PR TITLE
fix: bridge system OpenVINO into venv via .pth file

### DIFF
--- a/src/embeddings-server/Dockerfile
+++ b/src/embeddings-server/Dockerfile
@@ -63,6 +63,17 @@ RUN if ! id -u app >/dev/null 2>&1; then \
 
 COPY --from=dependencies /app/.venv /app/.venv
 
+# Bridge system OpenVINO into the venv (openvino base image exposes packages
+# via PYTHONPATH, but uv venvs isolate from system paths; a .pth file is the
+# standard Python mechanism to add paths inside a venv).
+RUN OPENVINO_PYTHON="/opt/intel/openvino/python"; \
+    if [ -d "$OPENVINO_PYTHON" ]; then \
+      SITE_DIR="$(/app/.venv/bin/python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')"; \
+      echo "$OPENVINO_PYTHON" > "$SITE_DIR/openvino-system.pth"; \
+      /app/.venv/bin/python -c "import openvino; print(f'OpenVINO {openvino.__version__} bridged into venv')" \
+        || (echo "FATAL: OpenVINO not importable inside venv after .pth setup" && exit 1); \
+    fi
+
 ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY main.py model_utils.py /app/


### PR DESCRIPTION
## Problem

The openvino-based embeddings-server container fails at runtime:

```
CRITICAL: Failed to load embedding model: Using the OpenVINO backend requires
installing Optimum and OpenVINO.
```

**Root cause:** The venv (built on `python:3.12-slim` in Stage 1) is copied into the openvino base image (Stage 2). The base image provides OpenVINO at `/opt/intel/openvino/python` via `PYTHONPATH`, but `uv`-created venvs isolate from system paths — the venv Python never sees the system openvino package.

## Fix

- Add a `.pth` file in the venv's site-packages pointing to `/opt/intel/openvino/python`
- This is the standard Python mechanism for adding paths inside a venv
- The `.pth` file is only created when the openvino base image is detected (`/opt/intel/openvino/python` exists)
- Added build-time `import openvino` verification — Docker build fails fast if the bridge doesn't work

## CI safeguard

The build-time verification ensures the openvino image build fails at `docker build` time (not at runtime) if the import fails. This replaces relying solely on the smoke test (which previously didn't catch this because RC builds kept getting cancelled by `cancel-in-progress`).