### PR TITLE
fix(ci): add environment to workflows using secrets

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -33,6 +33,7 @@ jobs:
   build-and-push:
     name: Build and push ${{ matrix.service.image }}${{ matrix.service.tag_suffix || '' }}
     runs-on: ubuntu-latest
+    environment: production
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Add `environment: production` to the `build-and-push` job in `build-containers.yml` so that secrets (`HF_TOKEN`) are gated behind a dedicated GitHub Actions environment with protection rules.

This resolves the zizmor `secrets-outside-env` finding (code scanning alert #230).

## Changes

- **`.github/workflows/build-containers.yml`**: Added `environment: production` to the `build-and-push` job

## Why

Using secrets outside a dedicated GitHub environment means any workflow trigger (including `pull_request` from forks) could potentially access them. Gating behind a named environment with protection rules is best practice per zizmor security analysis.

## Notes

- The `production` environment should be created in the repository settings if it does not already exist (GitHub will auto-create it on first workflow run, but adding protection rules is recommended)
- Only `build-containers.yml` was flagged by zizmor alert #230; other workflows using `secrets.GITHUB_TOKEN` alone are not flagged

Working as Dallas (Frontend Dev / CI assist)

Closes #1237