### PR TITLE
fix(embeddings-server): relink venv python for openvino base image

### DIFF
--- a/src/embeddings-server/Dockerfile
+++ b/src/embeddings-server/Dockerfile
@@ -63,6 +63,11 @@ RUN if ! id -u app >/dev/null 2>&1; then \
 
 COPY --from=dependencies /app/.venv /app/.venv
 
+# Relink venv python to the runtime image's interpreter (the build stage
+# used python:3.12-slim at /usr/local/bin/python3 which doesn't exist here).
+RUN REAL_PYTHON="$(readlink -f "$(which python3)")"; \
+    ln -sf "$REAL_PYTHON" /app/.venv/bin/python
+
 ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY main.py model_utils.py /app/


### PR DESCRIPTION
## Root Cause

The uv venv built on the `python:3.12-slim` build stage creates a symlink to `/usr/local/bin/python3`, which doesn't exist on the openvino base image (`openvino/ubuntu24_runtime:2025.4.0` has python at `/usr/bin/python3.12`).

## Fix

Added a RUN step in the Dockerfile to relink the venv python to the runtime image's interpreter after copying the venv from the build stage. This ensures that when the container starts, the venv's python symlink points to a valid interpreter.

Also restores `openvino` to pyproject.toml pip extras (uv venvs isolate from system PYTHONPATH, so the base image's system openvino is not visible inside the venv).

## Testing

Tested locally with BACKEND=openvino DEVICE=cpu:
- OpenVINO imports OK
- Embedding dimension: 768
- Container healthy in 16s

## Fixes

Fixes the `sh: 1: exec: uvicorn: not found` error from RC build run 23691829456
