### PR TITLE
perf(ci): bump openvino smoke test timeout to 120s

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -169,7 +169,7 @@ jobs:
             type: http
             port: "8080"
             health_endpoint: /health
-            startup_timeout: 60
+            startup_timeout: 120
             tag_suffix: "-openvino"
             docker_env: "-e BACKEND=openvino -e DEVICE=cpu"
           - image: admin


### PR DESCRIPTION
The openvino embeddings-server image is larger and takes longer to start on CI runners. Increasing the timeout from 60s to 120s to prevent false negatives in smoke tests.