### PR TITLE
fix: resolve review thread feedback

### DIFF
--- a/.squad/agents/newt/history.md
+++ b/.squad/agents/newt/history.md
@@ -437,7 +437,7 @@ Full plan available at .squad/decisions.md (v1.10.0 kickoff decision).
 
 **Output**: `docs/prd/admin-react-migration.md`
 
-### Documentation: Intel GPU WSL2 Setup Guide — 2025-03-26
+### Documentation: Intel GPU WSL2 Setup Guide — 2026-03-26
 
 **Task:** Create comprehensive guide for running Aithena with Intel GPU acceleration on WSL2.
 

--- a/docker-compose.intel.override.yml
+++ b/docker-compose.intel.override.yml
@@ -30,4 +30,4 @@ services:
     devices:
       - /dev/dxg:/dev/dxg
     volumes:
-      - /usr/lib/wsl:/usr/lib/wsl
+      - /usr/lib/wsl:/usr/lib/wsl:ro

--- a/docs/release-notes/v1.17.0.md
+++ b/docs/release-notes/v1.17.0.md
@@ -22,7 +22,7 @@ A complete GPU acceleration feature set for document embeddings indexing:
 
 #### WI-4: Embeddings-Server GPU Support (#1151)
 
-**What changed:** Updated embeddings-server image to optionally install the OpenVINO backend via `uv sync --extra openvino` (gated by the `INSTALL_OPENVINO` flag), using the OpenVINO version pinned in the lockfile (currently `openvino==2026.0.0` in v1.17.0+) for Intel GPU/CPU support alongside existing NVIDIA CUDA support.
+**What changed:** Updated embeddings-server image to optionally install the OpenVINO backend via `uv sync --extra openvino` (gated by the `INSTALL_OPENVINO` build arg), using the OpenVINO version pinned in the lockfile (currently `openvino==2026.0.0` in v1.17.0+) for Intel GPU/CPU support alongside existing NVIDIA CUDA support.
 
 **User impact:** GPU support now available; CPU mode unchanged by default.
 

--- a/docs/release-notes/v1.17.0.md
+++ b/docs/release-notes/v1.17.0.md
@@ -22,7 +22,7 @@ A complete GPU acceleration feature set for document embeddings indexing:
 
 #### WI-4: Embeddings-Server GPU Support (#1151)
 
-**What changed:** Updated embeddings-server Dockerfile to include OpenVINO library (`openvino==2024.1.0`) for Intel GPU/CPU support alongside existing NVIDIA CUDA support.
+**What changed:** Updated embeddings-server image to optionally install the OpenVINO backend via `uv sync --extra openvino` (gated by the `INSTALL_OPENVINO` flag), using the OpenVINO version pinned in the lockfile (currently `openvino==2026.0.0` in v1.17.0+) for Intel GPU/CPU support alongside existing NVIDIA CUDA support.
 
 **User impact:** GPU support now available; CPU mode unchanged by default.
 

--- a/docs/test-reports/v1.17.0.md
+++ b/docs/test-reports/v1.17.0.md
@@ -40,7 +40,7 @@ The following areas were identified from the closed issues as the primary change
 
 **Expected behavior after fix:**
 
-- OpenVINO is installed in the embeddings-server image via `uv sync --extra openvino` when `INSTALL_OPENVINO=1` is set
+- OpenVINO is installed in the embeddings-server image via `uv sync --extra openvino` when `INSTALL_OPENVINO=true` is set
 - The resolved OpenVINO version in `uv.lock` is pinned (currently `openvino==2026.0.0`) and used by the image
 - Image builds successfully on x86_64 (and ARM64 if supported)
 - No import conflicts between torch and openvino

--- a/docs/test-reports/v1.17.0.md
+++ b/docs/test-reports/v1.17.0.md
@@ -40,15 +40,16 @@ The following areas were identified from the closed issues as the primary change
 
 **Expected behavior after fix:**
 
-- OpenVINO (`openvino==2024.1.0`) is installed in embeddings-server image
+- OpenVINO is installed in the embeddings-server image via `uv sync --extra openvino` when `INSTALL_OPENVINO=1` is set
+- The resolved OpenVINO version in `uv.lock` is pinned (currently `openvino==2026.0.0`) and used by the image
 - Image builds successfully on x86_64 (and ARM64 if supported)
 - No import conflicts between torch and openvino
 - Image size remains within budget (<300 MB added total)
 
 **Where to verify in the repository:**
 
-- `src/embeddings-server/Dockerfile` — should include `RUN pip install openvino==2024.1.0`
-- `src/embeddings-server/requirements.txt` (if used) — should pin openvino version
+- `src/embeddings-server/Dockerfile` — should wire `INSTALL_OPENVINO` into the build and run `uv sync --extra openvino` when it is enabled
+- `src/embeddings-server/uv.lock` — should include a pinned `openvino` entry (currently `openvino==2026.0.0`)
 
 **Risk if unfixed:** Intel GPU support will not be available; only NVIDIA CUDA and CPU modes will work.
 


### PR DESCRIPTION
Addresses review comments on the v1.17.1 release PR:

- Add read-only flag to /usr/lib/wsl volume mount for security
- Update release notes and test report for OpenVINO install mechanism
- Correct OpenVINO version references to use lockfile version (2026.0.0)
- Fix date in Intel GPU WSL2 guide history entry (2025 → 2026)