### PR TITLE
test: update collection detail test for unified card class names

### DIFF
--- a/e2e/playwright/tests/collections.spec.ts
+++ b/e2e/playwright/tests/collections.spec.ts
@@ -481,7 +481,7 @@ test.describe('collection detail view', () => {
     expect(await itemCards.count()).toBeGreaterThan(0);
 
     const firstCard = itemCards.first();
-    await expect(firstCard.locator('.collection-item-title')).toBeVisible();
+    await expect(firstCard.locator('.book-title')).toBeVisible();
   });
 
   test('empty collection shows empty state message', async ({ page, request }) => {


### PR DESCRIPTION
Fixes E2E test failure.

The CollectionItemCard was refactored to use BookCard layout with 'book-title' class instead of 'collection-item-title' in #1278. This test update was missed.