### PR TITLE
fix(docker): remove editable path deps for Docker compatibility

### DIFF
--- a/installer/pyproject.toml
+++ b/installer/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-aithena-common = { path = "../src/aithena-common", editable = true }
+aithena-common = { path = "../src/aithena-common" }
 
 [dependency-groups]
 dev = [

--- a/installer/uv.lock
+++ b/installer/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 [[package]]
 name = "aithena-common"
 version = "0.1.0"
-source = { editable = "../src/aithena-common" }
+source = { directory = "../src/aithena-common" }
 dependencies = [
     { name = "argon2-cffi" },
 ]
@@ -34,7 +34,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "aithena-common", editable = "../src/aithena-common" }]
+requires-dist = [{ name = "aithena-common", directory = "../src/aithena-common" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.3" }]

--- a/src/solr-search/pyproject.toml
+++ b/src/solr-search/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-aithena-common = { path = "../aithena-common", editable = true }
+aithena-common = { path = "../aithena-common" }
 
 [dependency-groups]
 dev = [

--- a/src/solr-search/uv.lock
+++ b/src/solr-search/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [[package]]
 name = "aithena-common"
 version = "0.1.0"
-source = { editable = "../aithena-common" }
+source = { directory = "../aithena-common" }
 dependencies = [
     { name = "argon2-cffi" },
 ]
@@ -1129,7 +1129,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aithena-common", editable = "../aithena-common" },
+    { name = "aithena-common", directory = "../aithena-common" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "fastapi", extras = ["all"], specifier = ">=0.115.0,<1" },
     { name = "pika", specifier = ">=1.3.2" },


### PR DESCRIPTION
Editable path deps create .pth symlinks in the venv that point to the source directory. In Docker multi-stage builds, these break because the source dir only exists in the builder stage.

Removes `editable = true` from aithena-common path references in both solr-search and installer, regenerates lockfiles.

Fixes the solr-search smoke test failure: `ModuleNotFoundError: No module named 'aithena_common'`