### PR TITLE
fix(ci): restore Dependabot PR routing in heartbeat workflow

### DIFF
--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -23,7 +23,7 @@ on:
 permissions:
   issues: write
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   heartbeat:

--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -464,3 +464,17 @@ Extracted `aithena-common/` as shared Python package containing passwords and au
 **Architecture:** Dependency inversion applied — all services depend inward on `aithena-common`. No cross-service coupling except via HTTP APIs.
 
 **Key pattern:** When extracting shared code, keep domain-specific logic (migrations, seeding, JWT) in the service; only move pure utilities (hashing, schema DDL). Use re-exports with `# noqa: F401` if needed.
+
+### Dependabot PR Routing in Heartbeat (2026-03-30)
+
+**Root cause:** When `ralph-triage.js` was extracted from inline workflow JS, the Dependabot PR routing logic was lost. The `isUntriagedIssue()` function filters out PRs (`if (issue.pull_request) return false`), so Dependabot PRs were never triaged.
+
+**Fix:** Added parallel Dependabot PR triage pipeline in `ralph-triage.js`:
+- `fetchDependabotPRs()` fetches open PRs from `dependabot[bot]` via Issues API
+- `classifyDependabotPR()` classifies by dependency domain (file patterns + title patterns)
+- Domain classification maps to squad members via routing rules and role-based fallback
+- Updated workflow permissions from `pull-requests: read` to `pull-requests: write`
+
+**Key lesson:** When refactoring inline workflow code into standalone scripts, audit all code paths — not just the primary one. The Dependabot PR path was a secondary code path that got silently dropped. Use the git history of the inline code as a checklist.
+
+**Pattern:** Domain-to-member mapping uses a two-tier strategy: (1) try routing rules from routing.md, (2) fall back to role-based matching from roster in team.md. This makes classification resilient to routing table format changes.

--- a/.squad/decisions/inbox/parker-heartbeat-fix.md
+++ b/.squad/decisions/inbox/parker-heartbeat-fix.md
@@ -1,0 +1,28 @@
+# Decision: Dependabot PR Routing in ralph-triage.js
+
+**Author:** Parker  
+**Date:** 2026-03-30  
+**Status:** Implemented
+
+## Context
+
+The heartbeat workflow lost Dependabot PR auto-assignment when inline JS was refactored to `ralph-triage.js`. PRs were silently filtered out by `isUntriagedIssue()`.
+
+## Decision
+
+Added a separate Dependabot PR triage pipeline alongside the existing issue triage. The classification uses a two-tier member lookup:
+
+1. **Routing rules** (from `routing.md`) — matches dependency domain keywords against work type columns
+2. **Role-based fallback** (from `team.md` roster) — matches against member role text
+
+This makes it resilient to routing table format changes while still respecting routing.md as the source of truth when available.
+
+## Dependency domain patterns
+
+File and title patterns map PRs to six domains: python-backend, frontend-js, github-actions, docker-infra, security, testing. Each domain carries both `workTypeKeywords` (for routing rules) and `roleKeywords` (for roster fallback).
+
+## Impact
+
+- `pull-requests: write` permission added to heartbeat workflow
+- New triage results include PRs alongside issues (same JSON format, uses `issueNumber` field since GitHub's label API works for both)
+- No changes to existing issue triage logic

--- a/.squad/templates/ralph-triage.js
+++ b/.squad/templates/ralph-triage.js
@@ -487,6 +487,179 @@ function isUntriagedIssue(issue, memberLabels) {
   return !memberLabels.some((label) => issueHasLabel(issue, label));
 }
 
+// --- Dependabot PR triage ---
+
+const DEPENDENCY_DOMAINS = [
+  {
+    name: 'python-backend',
+    filePatterns: [/pyproject\.toml$/, /requirements.*\.txt$/, /uv\.lock$/],
+    titlePatterns: [/\bpip\b/i, /\bpypi\b/i, /\bpython\b/i],
+    workTypeKeywords: ['python'],
+    roleKeywords: ['backend'],
+  },
+  {
+    name: 'frontend-js',
+    filePatterns: [/package\.json$/, /package-lock\.json$/, /yarn\.lock$/],
+    titlePatterns: [/\bnpm\b/i, /\bnode\b/i, /\btypescript\b/i],
+    workTypeKeywords: ['react', 'typescript'],
+    roleKeywords: ['frontend'],
+  },
+  {
+    name: 'github-actions',
+    filePatterns: [/\.github\/workflows\//, /\.github\/actions\//],
+    titlePatterns: [/\bgithub.actions?\b/i, /\bactions\//i],
+    workTypeKeywords: ['ci/cd'],
+    roleKeywords: ['infra'],
+  },
+  {
+    name: 'docker-infra',
+    filePatterns: [/Dockerfile/, /docker-compose/],
+    titlePatterns: [/\bdocker\b/i, /\bcontainer\b/i],
+    workTypeKeywords: ['docker', 'compose', 'container'],
+    roleKeywords: ['infra'],
+  },
+  {
+    name: 'security',
+    filePatterns: [],
+    titlePatterns: [/\bsecurity\b/i, /\bcrypto/i, /\bauth\b/i, /\bjwt\b/i, /\bcve-/i, /\bvulnerab/i],
+    workTypeKeywords: ['security'],
+    roleKeywords: ['security'],
+  },
+  {
+    name: 'testing',
+    filePatterns: [],
+    titlePatterns: [/\bpytest\b/i, /\bvitest\b/i, /\bjest\b/i, /\btesting[-\s]lib/i],
+    workTypeKeywords: ['testing', 'test'],
+    roleKeywords: ['test'],
+  },
+];
+
+async function fetchDependabotPRs(owner, repo, token) {
+  const all = [];
+  let page = 1;
+  const perPage = 100;
+
+  console.log('Fetching open Dependabot PRs…');
+  for (;;) {
+    const query = new URLSearchParams({
+      state: 'open',
+      creator: 'dependabot[bot]',
+      per_page: String(perPage),
+      page: String(page),
+    });
+    const items = await githubRequestJson(
+      `/repos/${owner}/${repo}/issues?${query.toString()}`,
+      token,
+    );
+    if (!Array.isArray(items) || items.length === 0) break;
+    all.push(...items.filter((item) => item.pull_request));
+    if (items.length < perPage) break;
+    page += 1;
+  }
+
+  console.log(`Found ${all.length} open Dependabot PR(s)`);
+  return all;
+}
+
+async function fetchPRFiles(owner, repo, prNumber, token) {
+  try {
+    const files = await githubRequestJson(
+      `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100`,
+      token,
+    );
+    return Array.isArray(files) ? files : [];
+  } catch (error) {
+    console.log(`Warning: could not fetch files for PR #${prNumber}: ${error.message}`);
+    return [];
+  }
+}
+
+function findMemberForDependencyDomain(domain, rules, roster) {
+  for (const keyword of domain.workTypeKeywords) {
+    const kw = keyword.toLowerCase();
+    for (const rule of rules) {
+      if (rule.workType.toLowerCase().includes(kw)) {
+        const agentName = rule.agentName.split(/\s*\+\s*/)[0].trim();
+        const agent = findMember(agentName, roster);
+        if (agent) return { agent, workType: rule.workType };
+      }
+    }
+  }
+
+  for (const keyword of domain.roleKeywords) {
+    const kw = keyword.toLowerCase();
+    for (const member of roster) {
+      if (member.role.toLowerCase().includes(kw)) {
+        return { agent: member, workType: member.role };
+      }
+    }
+  }
+
+  return null;
+}
+
+function classifyDependabotPR(prTitle, changedFiles, rules, modules, roster) {
+  const fileNames = changedFiles.map((f) => (typeof f === 'string' ? f : f.filename || ''));
+  const combinedText = `${prTitle}\n${fileNames.join('\n')}`.toLowerCase();
+  const normalizedText = normalizeTextForPathMatch(combinedText);
+
+  const bestModule = findBestModuleMatch(normalizedText, modules);
+  if (bestModule) {
+    const member = findMember(bestModule.primary, roster);
+    if (member) {
+      return {
+        agent: member,
+        reason: `Dependabot PR touches module "${bestModule.modulePath}"`,
+        source: 'module-ownership',
+        confidence: 'high',
+      };
+    }
+  }
+
+  for (const domain of DEPENDENCY_DOMAINS) {
+    const fileMatch =
+      domain.filePatterns.length > 0 &&
+      fileNames.some((f) => domain.filePatterns.some((p) => p.test(f)));
+    const titleMatch =
+      domain.titlePatterns.length > 0 && domain.titlePatterns.some((p) => p.test(prTitle));
+
+    if (fileMatch || titleMatch) {
+      const match = findMemberForDependencyDomain(domain, rules, roster);
+      if (match) {
+        const matchType = fileMatch ? 'file pattern' : 'title pattern';
+        return {
+          agent: match.agent,
+          reason: `Dependabot ${domain.name} dependency (${matchType}) → ${match.workType}`,
+          source: 'dependabot-domain',
+          confidence: fileMatch ? 'high' : 'medium',
+        };
+      }
+    }
+  }
+
+  const bestRule = findBestRuleMatch(combinedText, rules);
+  if (bestRule) {
+    const agent = findMember(bestRule.rule.agentName, roster);
+    if (agent) {
+      return {
+        agent,
+        reason: `Matched routing keyword(s): ${bestRule.matchedKeywords.join(', ')}`,
+        source: 'routing-rule',
+        confidence: 'medium',
+      };
+    }
+  }
+
+  const lead = findLeadFallback(roster);
+  if (!lead) return null;
+  return {
+    agent: lead,
+    reason: 'No dependency domain match — routed to Lead/Architect',
+    source: 'lead-fallback',
+    confidence: 'low',
+  };
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const token = process.env.GITHUB_TOKEN;
@@ -525,6 +698,35 @@ async function main() {
     if (!decision) continue;
     results.push({
       issueNumber: issue.number,
+      assignTo: decision.agent.name,
+      label: decision.agent.label,
+      reason: decision.reason,
+      source: decision.source,
+    });
+  }
+
+  // --- Dependabot PR triage ---
+  console.log('--- Dependabot PR triage ---');
+  const dependabotPRs = await fetchDependabotPRs(owner, repo, token);
+  const untriagedPRs = dependabotPRs.filter(
+    (pr) => !memberLabels.some((label) => issueHasLabel(pr, label)),
+  );
+  console.log(`${untriagedPRs.length} untriaged Dependabot PR(s) to classify`);
+
+  for (const pr of untriagedPRs) {
+    const files = await fetchPRFiles(owner, repo, pr.number, token);
+    const decision = classifyDependabotPR(pr.title || '', files, rules, modules, roster);
+
+    if (!decision) {
+      console.log(`PR #${pr.number}: no classification match, skipping`);
+      continue;
+    }
+
+    console.log(
+      `PR #${pr.number} "${pr.title}" → ${decision.agent.name} (${decision.source}, ${decision.confidence})`,
+    );
+    results.push({
+      issueNumber: pr.number,
       assignTo: decision.agent.name,
       label: decision.agent.label,
       reason: decision.reason,


### PR DESCRIPTION
Closes the Dependabot PR routing regression introduced when inline workflow JS was refactored to `ralph-triage.js`.

## What changed

**`.squad/templates/ralph-triage.js`**
- Added `fetchDependabotPRs()` — fetches open PRs from `dependabot[bot]` via the Issues API
- Added `fetchPRFiles()` — retrieves changed files for classification
- Added `classifyDependabotPR()` — classifies PRs by dependency domain using file patterns and title patterns
- Added `findMemberForDependencyDomain()` — two-tier member lookup: routing rules first, then role-based fallback from roster
- Six dependency domains: python-backend, frontend-js, github-actions, docker-infra, security, testing
- Existing issue triage logic is untouched

**`.github/workflows/squad-heartbeat.yml`**
- Changed `pull-requests: read` → `pull-requests: write` (needed to add labels to PRs)

## How it works

1. After issue triage, the script fetches open Dependabot PRs
2. Skips PRs that already have a `squad:{member}` label
3. For each untriaged PR, fetches changed files and classifies by domain
4. Domain patterns match file paths (e.g., `pyproject.toml` → python-backend) and PR titles
5. Maps domain to squad member via routing rules or role-based roster fallback
6. Falls back to Lead/Architect if no domain matches

Working as Parker (Backend Dev)

## Checklist
- [x] Verify script passes syntax check (`node -c`)
- [x] Script does not crash on execution (401 expected with test token)
- [x] Pre-commit hooks pass
- [x] `.squad/scripts/verify.sh` passes