### PR TITLE
fix: auto-create volume directories and add WSL2 installation guide

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -154,11 +154,16 @@ Docker Compose automatically orchestrates startup based on `depends_on` health c
 
 2. **Create volume directories**:
    ```bash
-   sudo mkdir -p /source/volumes/{rabbitmq-data,redis,solr-data,solr-data2,solr-data3,zoo-backup}
-   sudo mkdir -p /source/volumes/{zoo-data1,zoo-data2,zoo-data3}/{data,logs,datalog}
-   sudo chown -R 8983:8983 /source/volumes/solr-data*  # Solr UID
-   sudo chown -R 1000:1000 /source/volumes/zoo-data*   # ZooKeeper UID
+   sudo ./scripts/init-volumes.sh
    ```
+
+   This creates all required directories under `/source/volumes` with correct ownership. To use a custom path (e.g., secondary disk), set `VOLUMES_ROOT`:
+
+   ```bash
+   sudo VOLUMES_ROOT=/mnt/data/aithena/volumes ./scripts/init-volumes.sh
+   ```
+
+   For WSL2-specific setup (secondary disks, Docker Desktop vs Docker CE), see the [WSL2 Installation Guide](../guides/wsl2-installation.md).
 
 3. **Start infrastructure tier**:
    ```bash

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -157,10 +157,11 @@ Docker Compose automatically orchestrates startup based on `depends_on` health c
    sudo ./scripts/init-volumes.sh
    ```
 
-   This creates all required directories under `/source/volumes` with correct ownership. To use a custom path (e.g., secondary disk), set `VOLUMES_ROOT`:
+   This creates all required directories under `/source/volumes` with correct ownership. To use a custom path (e.g., secondary disk), set `VOLUMES_ROOT` and symlink:
 
    ```bash
-   sudo VOLUMES_ROOT=/mnt/data/aithena/volumes ./scripts/init-volumes.sh
+   sudo VOLUMES_ROOT=/mnt/data/volumes ./scripts/init-volumes.sh
+   sudo ln -s /mnt/data/volumes /source/volumes
    ```
 
    For WSL2-specific setup (secondary disks, Docker Desktop vs Docker CE), see the [WSL2 Installation Guide](../guides/wsl2-installation.md).

--- a/docs/guides/wsl2-installation.md
+++ b/docs/guides/wsl2-installation.md
@@ -94,17 +94,13 @@ sudo ./scripts/init-volumes.sh
 sudo VOLUMES_ROOT=/mnt/data/aithena/volumes ./scripts/init-volumes.sh
 ```
 
-If using a custom `VOLUMES_ROOT`, you have two choices to make Docker Compose use it:
-
-### Choice 1: Symlink (simple)
+If using a custom `VOLUMES_ROOT`, you **must** symlink the path so Docker Compose can find the volumes at the expected location:
 
 ```bash
 sudo ln -s /mnt/data/aithena/volumes /source/volumes
 ```
 
-### Choice 2: Override volume paths
-
-Create a `docker-compose.override.yml` that redefines the volume device paths. This is more explicit but requires maintaining the override file.
+Alternatively, you can override volume paths via a `docker-compose.override.yml`.
 
 ## Secondary disk options
 

--- a/docs/guides/wsl2-installation.md
+++ b/docs/guides/wsl2-installation.md
@@ -1,0 +1,249 @@
+# WSL2 Installation Guide
+
+This guide covers installing Aithena on Windows using WSL2 (Windows Subsystem for Linux). It documents both Docker Desktop and direct Docker CE approaches, along with options for storing data on a secondary disk.
+
+## Prerequisites
+
+- Windows 10 version 2004+ or Windows 11
+- WSL2 enabled with an Ubuntu 24.04 distribution
+- At least 16 GB RAM (32 GB recommended)
+- SSD storage for Docker volumes (100 GB+ recommended)
+
+## Option A: Docker Desktop (Recommended for most users)
+
+Docker Desktop manages the WSL2 integration automatically and provides a GUI for container management.
+
+### Installation
+
+1. Download and install [Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/).
+2. During setup, ensure **Use WSL 2 based engine** is checked.
+3. In Docker Desktop → Settings → Resources → WSL Integration, enable your Ubuntu distro.
+4. Open your Ubuntu terminal and verify:
+
+   ```bash
+   docker --version
+   docker compose version
+   ```
+
+### Volume storage location
+
+Docker Desktop stores all container data inside a managed WSL2 virtual disk at:
+
+```
+%LOCALAPPDATA%\Docker\wsl\data\ext4.vhdx
+```
+
+To move this to a secondary disk, see [Moving Docker Desktop data](#moving-docker-desktop-data-to-a-secondary-disk) below.
+
+## Option B: Docker CE directly in WSL2
+
+Install Docker Engine directly inside the WSL2 Ubuntu distribution, without Docker Desktop. This gives full control but requires manual setup.
+
+### Installation
+
+```bash
+# Remove any old packages
+sudo apt-get remove docker docker-engine docker.io containerd runc 2>/dev/null
+
+# Add Docker's official GPG key and repository
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Add your user to the docker group (log out and back in to take effect)
+sudo groupadd docker 2>/dev/null || true
+sudo usermod -aG docker "$USER"
+newgrp docker
+
+# Start Docker (WSL2 doesn't use systemd by default)
+sudo service docker start
+
+# Verify
+docker run --rm hello-world
+```
+
+> **Tip:** To start Docker automatically when WSL opens, add `sudo service docker start` to your `~/.bashrc`, or enable systemd in `/etc/wsl.conf`:
+>
+> ```ini
+> [boot]
+> systemd=true
+> ```
+
+### Volume storage location
+
+With Docker CE inside WSL2, container data lives in the WSL2 ext4 filesystem at `/var/lib/docker/`. To use a secondary disk, see [Secondary disk options](#secondary-disk-options) below.
+
+## Setting up Aithena volumes
+
+Aithena uses bind-mounted named volumes that require host directories to exist before starting. Run the provided init script:
+
+```bash
+# Default: creates directories under /source/volumes
+sudo ./scripts/init-volumes.sh
+
+# Custom path (e.g., secondary disk):
+sudo VOLUMES_ROOT=/mnt/data/aithena/volumes ./scripts/init-volumes.sh
+```
+
+If using a custom `VOLUMES_ROOT`, you have two choices to make Docker Compose use it:
+
+### Choice 1: Symlink (simple)
+
+```bash
+sudo ln -s /mnt/data/aithena/volumes /source/volumes
+```
+
+### Choice 2: Override volume paths
+
+Create a `docker-compose.override.yml` that redefines the volume device paths. This is more explicit but requires maintaining the override file.
+
+## Secondary disk options
+
+### Option 1: Virtual disk (VHDX) — Best performance
+
+Create a dedicated ext4 virtual disk and mount it inside WSL2. This avoids the 9P filesystem overhead of `/mnt/` paths.
+
+**From PowerShell (Administrator):**
+
+```powershell
+# Create a 200 GB virtual disk on D: drive
+wsl --shutdown
+New-VHD -Path "D:\wsl-aithena-data.vhdx" -SizeBytes 200GB -Dynamic
+```
+
+**Mount in WSL2:**
+
+```bash
+# Identify the disk (from PowerShell: wsl --mount --vhd D:\wsl-aithena-data.vhdx --bare)
+# Then inside WSL:
+DISK="/dev/sdX"  # Check with lsblk after mounting
+sudo mkfs.ext4 "$DISK"
+sudo mkdir -p /mnt/aithena-data
+sudo mount "$DISK" /mnt/aithena-data
+
+# Set up Aithena volumes
+sudo VOLUMES_ROOT=/mnt/aithena-data/volumes ./scripts/init-volumes.sh
+sudo ln -s /mnt/aithena-data/volumes /source/volumes
+```
+
+> **Note:** `wsl --mount --vhd` requires Windows 11 or a recent Windows 10 insider build. For older Windows 10, use the `Attach-VHD` + `wsl --mount` approach.
+
+**Auto-mount on WSL startup** — add to `/etc/fstab` or create a script in `/etc/wsl.conf`:
+
+```ini
+[boot]
+command = mount /dev/sdX /mnt/aithena-data
+```
+
+### Option 2: Move the entire WSL distro — Simplest
+
+Relocate the entire WSL2 Ubuntu distribution to a secondary disk. All data (including Docker) follows.
+
+**From PowerShell (Administrator):**
+
+```powershell
+wsl --shutdown
+wsl --export Ubuntu-24.04 D:\wsl-backup\ubuntu.tar
+wsl --unregister Ubuntu-24.04
+wsl --import Ubuntu-24.04 D:\wsl\Ubuntu-24.04 D:\wsl-backup\ubuntu.tar
+```
+
+After import, set your default user:
+
+```bash
+ubuntu2404.exe config --default-user your_username
+```
+
+### Option 3: Docker data-root — Docker CE only
+
+Redirect Docker's storage root to a secondary disk mount point. This works only with Docker CE (not Docker Desktop).
+
+```bash
+# Mount secondary disk (ext4 formatted)
+sudo mkdir -p /mnt/docker-data
+sudo mount /dev/sdX1 /mnt/docker-data
+
+# Configure Docker to use new root
+sudo tee /etc/docker/daemon.json <<EOF
+{
+  "data-root": "/mnt/docker-data"
+}
+EOF
+
+sudo service docker restart
+docker info | grep "Docker Root Dir"
+# Should show: /mnt/docker-data
+```
+
+### Option 4: Symlink `/mnt/d/` path — Easiest but slowest
+
+Mount a Windows drive folder directly. This uses the 9P protocol, which is slower than native ext4.
+
+```bash
+sudo VOLUMES_ROOT=/mnt/d/aithena/volumes ./scripts/init-volumes.sh
+sudo ln -s /mnt/d/aithena/volumes /source/volumes
+```
+
+> **⚠️ Performance warning:** 9P filesystem access through `/mnt/` is significantly slower than native ext4. This option is acceptable for development but **not recommended for production workloads**.
+
+## Performance comparison
+
+| Option | Filesystem | Performance | Complexity |
+|--------|-----------|-------------|------------|
+| VHDX virtual disk | ext4 (native) | ⭐⭐⭐ Best | Medium |
+| Move WSL distro | ext4 (native) | ⭐⭐⭐ Best | Low |
+| Docker data-root | ext4 (native) | ⭐⭐⭐ Best | Low |
+| `/mnt/d/` symlink | 9P (Windows) | ⭐ Slow | Low |
+
+## Moving Docker Desktop data to a secondary disk
+
+Docker Desktop stores its data in a managed VHDX. To move it:
+
+1. Open Docker Desktop → Settings → Resources → Advanced
+2. Change **Disk image location** to your secondary disk path (e.g., `D:\DockerDesktop\data`)
+3. Click **Apply & Restart**
+
+Docker Desktop will move the VHDX automatically.
+
+## Troubleshooting
+
+### "permission denied" on volume directories
+
+Ensure the volume directories have correct ownership:
+
+```bash
+sudo ./scripts/init-volumes.sh
+```
+
+### Docker daemon not starting in WSL2
+
+If `sudo service docker start` fails, enable systemd:
+
+```bash
+echo -e "[boot]\nsystemd=true" | sudo tee /etc/wsl.conf
+# Then restart WSL from PowerShell: wsl --shutdown
+```
+
+### Slow file I/O
+
+If you're using `/mnt/` paths (9P), switch to a native ext4 solution (VHDX, distro move, or data-root). See [Secondary disk options](#secondary-disk-options).
+
+### "No space left on device"
+
+The default WSL2 virtual disk is limited to 256 GB. Expand it:
+
+```powershell
+wsl --shutdown
+Resize-VHD -Path "$env:LOCALAPPDATA\...\ext4.vhdx" -SizeBytes 512GB
+wsl
+sudo resize2fs /dev/sda  # or appropriate device
+```

--- a/scripts/init-volumes.sh
+++ b/scripts/init-volumes.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
-# Create all required Docker volume directories for Aithena.
+# Create required Docker volume directories for Aithena.
+# Covers docker-compose.yml and docker-compose.prod.yml.
+# For SSL (docker-compose.ssl.yml), also create certbot dirs manually.
 #
 # Usage:
-#   ./scripts/init-volumes.sh              # Uses default /source/volumes
-#   VOLUMES_ROOT=/mnt/d/aithena ./scripts/init-volumes.sh  # Custom root
+#   sudo ./scripts/init-volumes.sh              # Uses default /source/volumes
+#   sudo VOLUMES_ROOT=/mnt/data/volumes ./scripts/init-volumes.sh  # Custom root
+#
+# When using a custom VOLUMES_ROOT, you must symlink it so Docker Compose
+# can find the volumes at the expected path:
+#   ln -s /mnt/data/volumes /source/volumes
 #
 # The script is idempotent — safe to run repeatedly.
 
 set -euo pipefail
 
 VOLUMES_ROOT="${VOLUMES_ROOT:-/source/volumes}"
+WARN=0
 
 echo "Creating Aithena volume directories under ${VOLUMES_ROOT} ..."
 
@@ -38,18 +45,32 @@ for d in "${dirs[@]}"; do
 done
 
 # Solr runs as UID 8983 inside the container.
-# Use -R only on the top-level directory; ignore errors on files already
-# owned by the target UID (common on re-runs).
 for d in "${VOLUMES_ROOT}/solr-data" "${VOLUMES_ROOT}/solr-data2" "${VOLUMES_ROOT}/solr-data3"; do
-    chown -R 8983:8983 "$d" 2>/dev/null || chown 8983:8983 "$d" 2>/dev/null || true
+    if ! chown -R 8983:8983 "$d" 2>/dev/null; then
+        echo "⚠  Could not chown $d to 8983:8983 — run with sudo" >&2
+        WARN=1
+    fi
 done
 
 # ZooKeeper runs as UID 1000 inside the container.
 for d in "${VOLUMES_ROOT}/zoo-data1" "${VOLUMES_ROOT}/zoo-data2" "${VOLUMES_ROOT}/zoo-data3" "${VOLUMES_ROOT}/zoo-backup"; do
-    chown -R 1000:1000 "$d" 2>/dev/null || chown 1000:1000 "$d" 2>/dev/null || true
+    if ! chown -R 1000:1000 "$d" 2>/dev/null; then
+        echo "⚠  Could not chown $d to 1000:1000 — run with sudo" >&2
+        WARN=1
+    fi
 done
 
-echo "Done. All volume directories created under ${VOLUMES_ROOT}."
 echo ""
-echo "If using a custom path, export VOLUMES_ROOT before running docker compose:"
-echo "  export VOLUMES_ROOT=${VOLUMES_ROOT}"
+if [ "$WARN" -eq 1 ]; then
+    echo "Done with warnings. Some directories may have incorrect ownership."
+    echo "Re-run with sudo to fix: sudo $0"
+else
+    echo "Done. All volume directories created under ${VOLUMES_ROOT}."
+fi
+
+if [ "${VOLUMES_ROOT}" != "/source/volumes" ]; then
+    echo ""
+    echo "Docker Compose expects volumes at /source/volumes."
+    echo "Create a symlink so Compose can find them:"
+    echo "  sudo ln -s ${VOLUMES_ROOT} /source/volumes"
+fi

--- a/scripts/init-volumes.sh
+++ b/scripts/init-volumes.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Create all required Docker volume directories for Aithena.
+#
+# Usage:
+#   ./scripts/init-volumes.sh              # Uses default /source/volumes
+#   VOLUMES_ROOT=/mnt/d/aithena ./scripts/init-volumes.sh  # Custom root
+#
+# The script is idempotent — safe to run repeatedly.
+
+set -euo pipefail
+
+VOLUMES_ROOT="${VOLUMES_ROOT:-/source/volumes}"
+
+echo "Creating Aithena volume directories under ${VOLUMES_ROOT} ..."
+
+# Service data directories
+dirs=(
+    "${VOLUMES_ROOT}/collections-db"
+    "${VOLUMES_ROOT}/rabbitmq-data"
+    "${VOLUMES_ROOT}/redis"
+    "${VOLUMES_ROOT}/solr-data"
+    "${VOLUMES_ROOT}/solr-data2"
+    "${VOLUMES_ROOT}/solr-data3"
+    "${VOLUMES_ROOT}/zoo-backup"
+    "${VOLUMES_ROOT}/zoo-data1/data"
+    "${VOLUMES_ROOT}/zoo-data1/datalog"
+    "${VOLUMES_ROOT}/zoo-data1/logs"
+    "${VOLUMES_ROOT}/zoo-data2/data"
+    "${VOLUMES_ROOT}/zoo-data2/datalog"
+    "${VOLUMES_ROOT}/zoo-data2/logs"
+    "${VOLUMES_ROOT}/zoo-data3/data"
+    "${VOLUMES_ROOT}/zoo-data3/datalog"
+    "${VOLUMES_ROOT}/zoo-data3/logs"
+)
+
+for d in "${dirs[@]}"; do
+    mkdir -p "$d"
+done
+
+# Solr runs as UID 8983 inside the container.
+# Use -R only on the top-level directory; ignore errors on files already
+# owned by the target UID (common on re-runs).
+for d in "${VOLUMES_ROOT}/solr-data" "${VOLUMES_ROOT}/solr-data2" "${VOLUMES_ROOT}/solr-data3"; do
+    chown -R 8983:8983 "$d" 2>/dev/null || chown 8983:8983 "$d" 2>/dev/null || true
+done
+
+# ZooKeeper runs as UID 1000 inside the container.
+for d in "${VOLUMES_ROOT}/zoo-data1" "${VOLUMES_ROOT}/zoo-data2" "${VOLUMES_ROOT}/zoo-data3" "${VOLUMES_ROOT}/zoo-backup"; do
+    chown -R 1000:1000 "$d" 2>/dev/null || chown 1000:1000 "$d" 2>/dev/null || true
+done
+
+echo "Done. All volume directories created under ${VOLUMES_ROOT}."
+echo ""
+echo "If using a custom path, export VOLUMES_ROOT before running docker compose:"
+echo "  export VOLUMES_ROOT=${VOLUMES_ROOT}"


### PR DESCRIPTION
## Summary

Closes #1310

### Changes

1. **`scripts/init-volumes.sh`** — New idempotent script that creates all 16 required Docker volume directories under `/source/volumes` (or custom `VOLUMES_ROOT`) with correct ownership:
   - Solr directories → UID 8983
   - ZooKeeper directories → UID 1000
   - Graceful handling of re-runs (existing files with correct ownership don't cause errors)

2. **`docs/guides/wsl2-installation.md`** — Comprehensive WSL2 installation guide covering:
   - Docker Desktop vs Docker CE setup
   - 4 secondary disk options with performance comparison
   - Volume initialization with custom paths
   - Troubleshooting section

3. **`docs/deployment/production.md`** — Updated Volume Initialization section to reference `init-volumes.sh` instead of manual mkdir commands

### Testing
- Script tested on existing volume structure (idempotent re-run)
- Script tested on clean directory (fresh creation)
- Pre-commit checks passed