### PR TITLE
fix: pass ov_config CACHE_DIR to fix OpenVINO model load on read-only /models/

### DIFF
--- a/src/embeddings-server/main.py
+++ b/src/embeddings-server/main.py
@@ -32,6 +32,14 @@ if BACKEND == "openvino":
     ov_device = _ov_device_map.get(device, "CPU") if device else "CPU"
     if ov_device != "CPU":
         model_kwargs["model_kwargs"] = {"device": ov_device}
+    # optimum-intel sets CACHE_DIR to {model_dir}/model_cache when device is GPU,
+    # which fails if /models/ is read-only. Override via ov_config so the compiled
+    # model cache goes to a writable location instead.
+    _ov_cache = os.environ.get("OPENVINO_CACHE_DIR", "").strip() or "/tmp/ov_cache"  # noqa: S108
+    model_kwargs["model_kwargs"] = {
+        **model_kwargs.get("model_kwargs", {}),
+        "ov_config": {"CACHE_DIR": _ov_cache},
+    }
 elif BACKEND != "torch":
     model_kwargs["backend"] = BACKEND
     if device and device != "cpu":

--- a/src/embeddings-server/tests/test_gpu_config.py
+++ b/src/embeddings-server/tests/test_gpu_config.py
@@ -169,7 +169,9 @@ class TestGpuModelInit:
         # OpenVINO backend: device goes through model_kwargs, not top-level device
         assert "device" not in call_kwargs[1]
         assert call_kwargs[1].get("backend") == "openvino"
-        assert call_kwargs[1].get("model_kwargs") == {"device": "GPU"}
+        mk = call_kwargs[1].get("model_kwargs", {})
+        assert mk.get("device") == "GPU"
+        assert "CACHE_DIR" in mk.get("ov_config", {})
 
     def test_xpu_with_openvino(self):
         """With DEVICE=xpu + BACKEND=openvino, device is mapped to OV 'GPU' via model_kwargs."""
@@ -177,14 +179,45 @@ class TestGpuModelInit:
         call_kwargs = mock_st_class.call_args
         assert "device" not in call_kwargs[1]
         assert call_kwargs[1].get("backend") == "openvino"
-        assert call_kwargs[1].get("model_kwargs") == {"device": "GPU"}
+        mk = call_kwargs[1].get("model_kwargs", {})
+        assert mk.get("device") == "GPU"
+        assert "CACHE_DIR" in mk.get("ov_config", {})
 
     def test_cpu_with_openvino(self):
-        """With DEVICE=cpu + BACKEND=openvino, no model_kwargs device (defaults to CPU)."""
+        """With DEVICE=cpu + BACKEND=openvino, no model_kwargs device but ov_config CACHE_DIR is set."""
         _, _, _, mock_st_class = _fresh_import(device="cpu", backend="openvino")
         call_kwargs = mock_st_class.call_args
         assert call_kwargs[1].get("backend") == "openvino"
-        assert "model_kwargs" not in call_kwargs[1] or "device" not in call_kwargs[1].get("model_kwargs", {})
+        mk = call_kwargs[1].get("model_kwargs", {})
+        assert "device" not in mk
+        assert "CACHE_DIR" in mk.get("ov_config", {})
+
+    def test_openvino_cache_dir_default(self):
+        """Without OPENVINO_CACHE_DIR env var, CACHE_DIR defaults to /tmp/ov_cache."""
+        os.environ.pop("OPENVINO_CACHE_DIR", None)
+        _, _, _, mock_st_class = _fresh_import(backend="openvino")
+        mk = mock_st_class.call_args[1].get("model_kwargs", {})
+        assert mk.get("ov_config", {}).get("CACHE_DIR") == "/tmp/ov_cache"  # noqa: S108
+
+    def test_openvino_cache_dir_from_env(self):
+        """OPENVINO_CACHE_DIR env var overrides the default cache path."""
+        os.environ["OPENVINO_CACHE_DIR"] = "/custom/cache"
+        try:
+            _, _, _, mock_st_class = _fresh_import(backend="openvino")
+            mk = mock_st_class.call_args[1].get("model_kwargs", {})
+            assert mk.get("ov_config", {}).get("CACHE_DIR") == "/custom/cache"
+        finally:
+            os.environ.pop("OPENVINO_CACHE_DIR", None)
+
+    def test_openvino_cache_dir_empty_env_uses_default(self):
+        """Empty OPENVINO_CACHE_DIR env var falls back to /tmp/ov_cache."""
+        os.environ["OPENVINO_CACHE_DIR"] = ""
+        try:
+            _, _, _, mock_st_class = _fresh_import(backend="openvino")
+            mk = mock_st_class.call_args[1].get("model_kwargs", {})
+            assert mk.get("ov_config", {}).get("CACHE_DIR") == "/tmp/ov_cache"  # noqa: S108
+        finally:
+            os.environ.pop("OPENVINO_CACHE_DIR", None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

rc.31 still fails to load the OpenVINO model with:
```
Couldn't create directory ["/models/.../openvino/model_cache"], err=Permission denied
```

The `OPENVINO_CACHE_DIR` env var added in PR #1324 does **not** work because **optimum-intel ignores it entirely**. In `optimum/intel/openvino/modeling_base.py:408-415`, `_compile_model()` hardcodes:
```python
cache_dir = Path(model_save_dir).joinpath("model_cache")
ov_config["CACHE_DIR"] = str(cache_dir)
```
when the device contains "gpu". It never reads the env var.

## Fix

Pass `ov_config={"CACHE_DIR": "/tmp/ov_cache"}` through the `model_kwargs` chain so it reaches `OVModel.from_pretrained()` → `_compile_model()`. When `CACHE_DIR` is already present in `ov_config`, optimum-intel skips the hardcoded fallback.

The env var `OPENVINO_CACHE_DIR` from PR #1324 is now used as the source for this value, so the Dockerfile's `mkdir + ENV` remain useful.

## Call chain
```
main.py model_kwargs["model_kwargs"]["ov_config"]
→ SentenceTransformer(model_kwargs=...)
→ Transformer._load_model(**model_args)
→ load_openvino_model(**model_kwargs)
→ OVModel.from_pretrained(ov_config=...)
→ _compile_model(ov_config=...) — skips hardcoded CACHE_DIR ✓
```

## Testing
- Updated tests for cuda+openvino, xpu+openvino, cpu+openvino to verify `ov_config.CACHE_DIR` is present
- All 58 tests pass

Closes #1326