### PR TITLE
fix: suppress Solr 9.7 credential deprecation warning (#1240)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -676,7 +676,7 @@ services:
             sleep 2
 
             solr auth enable --type basicAuth \
-              --credentials "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
+              -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
               --block-unknown false \
               --solr-include-file /dev/null \
               -z "$$ZK_HOST"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -731,7 +731,7 @@ services:
 
             # Create admin user with hashed password (also creates default RBAC rules)
             solr auth enable --type basicAuth \
-              --credentials "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
+              -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
               --block-unknown false \
               --solr-include-file /dev/null \
               -z "$$ZK_HOST"

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -55,7 +55,7 @@ def test_init_script_assigns_admin_role():
     # The admin role should be assigned via "solr auth enable" which creates
     # the admin user with admin role by default. Verify the solr auth enable command.
     assert "solr auth enable" in script, "solr-init script missing 'solr auth enable' command for admin bootstrap"
-    assert "--credentials" in script, "solr-init script missing --credentials flag in solr auth enable"
+    assert "-u" in script, "solr-init script missing -u flag in solr auth enable"
     assert "SOLR_ADMIN_USER" in script, "solr-init script must reference SOLR_ADMIN_USER"
 
 


### PR DESCRIPTION
## Summary

Replaces `--credentials` with `-u` in `solr auth enable` commands to suppress Solr 9.7 deprecation warnings.

### Warning suppressed
```
Option '-credentials': Deprecated for removal since 9.7: Use -u or --credentials instead
```

### Files changed
- `docker-compose.yml` — dev compose
- `docker-compose.prod.yml` — production compose

### Note on remaining warnings (#1240)
The other deprecation in `--type` is a Solr 9.7 CLI parser issue — it warns about the new-style flag too. This will likely be fixed in a future Solr release.

Refs #1240