### PR TITLE
fix(installer): add inline script metadata for CWD-independent execution

### DIFF
--- a/installer/setup.py
+++ b/installer/setup.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "aithena-common",
+# ]
+#
+# [tool.uv.sources]
+# aithena-common = { path = "../src/aithena-common" }
+# ///
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary

Fixes `ModuleNotFoundError: No module named 'aithena_common'` when running the installer from the repo root.

## Problem

Running `uv run installer/setup.py` from the repo root failed because `uv` resolves dependencies from the CWD's `pyproject.toml`. The repo root has no `pyproject.toml`, so `aithena-common` was never installed.

## Fix

Added [PEP 723](https://peps.python.org/pep-0723/) inline script metadata to `setup.py`. This tells `uv run` about the `aithena-common` dependency regardless of CWD.

- From `installer/`: project `pyproject.toml` takes precedence (existing behavior)
- From repo root: inline metadata kicks in, resolving the path relative to the script

## Testing

- `cd /repo && uv run installer/setup.py --help` ✅ (was failing)
- `cd /repo/installer && uv run setup.py --help` ✅
- `cd /repo/installer && uv run pytest` — 6/6 tests pass ✅

Closes #1330