### PR TITLE
fix(solr): align auth role assignment with Solr 9.7 defaults

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -684,12 +684,9 @@ services:
             echo "Waiting for Solr to load security config..."
             sleep 5
 
-            # Assign admin role to admin user
-            echo "Assigning admin role..."
-            curl -fsS -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
-              "$$SOLR_URL/solr/admin/authorization" \
-              -H 'Content-Type: application/json' \
-              -d '{"set-user-role": {"'"$$SOLR_ADMIN_USER"'": ["admin"]}}'
+            # NOTE: solr auth enable (Solr 9.7) already assigns the admin user
+            # all built-in roles: ["superadmin", "admin", "search", "index"].
+            # Do NOT overwrite with set-user-role — that strips superadmin/search.
 
             echo "Adding readonly user..."
             curl -fsS -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
@@ -697,11 +694,11 @@ services:
               -H 'Content-Type: application/json' \
               -d '{"set-user": {"'"$$SOLR_READONLY_USER"'": "'"$$SOLR_READONLY_PASS"'"}}'
 
-            # Assign readonly role
+            # Assign search role (Solr 9.7 built-in role for read + collection-admin-read)
             curl -fsS -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
               "$$SOLR_URL/solr/admin/authorization" \
               -H 'Content-Type: application/json' \
-              -d '{"set-user-role": {"'"$$SOLR_READONLY_USER"'": ["readonly"]}}'
+              -d '{"set-user-role": {"'"$$SOLR_READONLY_USER"'": ["search"]}}'
 
             echo "Security bootstrap complete."
           else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -739,12 +739,9 @@ services:
             echo "Waiting for Solr to load security config..."
             sleep 5
 
-            # Assign admin role to admin user
-            echo "Assigning admin role..."
-            curl -fsS -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
-              "$$SOLR_URL/solr/admin/authorization" \
-              -H 'Content-Type: application/json' \
-              -d '{"set-user-role": {"'"$$SOLR_ADMIN_USER"'": ["admin"]}}'
+            # NOTE: solr auth enable (Solr 9.7) already assigns the admin user
+            # all built-in roles: ["superadmin", "admin", "search", "index"].
+            # Do NOT overwrite with set-user-role — that strips superadmin/search.
 
             # Add readonly user
             echo "Adding readonly user..."
@@ -753,11 +750,11 @@ services:
               -H 'Content-Type: application/json' \
               -d '{"set-user": {"'"$$SOLR_READONLY_USER"'": "'"$$SOLR_READONLY_PASS"'"}}'
 
-            # Assign readonly role
+            # Assign search role (Solr 9.7 built-in role for read + collection-admin-read)
             curl -fsS -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
               "$$SOLR_URL/solr/admin/authorization" \
               -H 'Content-Type: application/json' \
-              -d '{"set-user-role": {"'"$$SOLR_READONLY_USER"'": ["readonly"]}}'
+              -d '{"set-user-role": {"'"$$SOLR_READONLY_USER"'": ["search"]}}'
 
             echo "Security bootstrap complete."
           else

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -1,11 +1,11 @@
-"""Tests for solr-init entrypoint script and security.json (issue #1287).
+"""Tests for solr-init entrypoint script and security.json (issue #1287, #1332).
 
 Parses docker-compose.yml to extract the solr-init inline entrypoint script
 and verifies that:
-- The admin user gets the "admin" role
-- The readonly user gets the "readonly" role (not "search")
+- The admin user roles are NOT overwritten (solr auth enable assigns all 4 roles)
+- The readonly user gets the "search" role (Solr 9.7 built-in role)
 - The readonly user is created via /admin/authentication
-- security.json references the "readonly" role for read operations
+- security.json matches Solr 9.7 built-in role hierarchy
 """
 
 from __future__ import annotations
@@ -45,42 +45,46 @@ def _load_security_json() -> dict:
 # ---------- 1. Admin role assignment ----------
 
 
-def test_init_script_assigns_admin_role():
-    """solr-init must assign the admin user-role via /admin/authorization."""
+def test_init_script_does_not_overwrite_admin_roles():
+    """solr-init must NOT overwrite admin roles set by solr auth enable (#1332).
+
+    Solr 9.7's `solr auth enable` assigns ["superadmin", "admin", "search", "index"]
+    to the created user. A set-user-role call for the admin user would overwrite these.
+    """
     script = _load_solr_init_script()
 
-    # Look for curl to /admin/authorization with set-user-role for admin
-    assert "/solr/admin/authorization" in script, "solr-init script missing /admin/authorization call"
-
-    # The admin role should be assigned via "solr auth enable" which creates
-    # the admin user with admin role by default. Verify the solr auth enable command.
-    assert "solr auth enable" in script, "solr-init script missing 'solr auth enable' command for admin bootstrap"
+    # Verify solr auth enable is used for admin bootstrap
+    assert "solr auth enable" in script, "solr-init script missing 'solr auth enable' command"
     assert "-u" in script, "solr-init script missing -u flag in solr auth enable"
     assert "SOLR_ADMIN_USER" in script, "solr-init script must reference SOLR_ADMIN_USER"
+
+    # Verify there is NO set-user-role call for the admin user
+    role_assignments = re.findall(r'"set-user-role":\s*\{[^}]*\}', script)
+    admin_assignments = [r for r in role_assignments if "SOLR_ADMIN_USER" in r]
+    assert not admin_assignments, (
+        f"solr-init must NOT call set-user-role for admin user — solr auth enable "
+        f"already assigns all needed roles. Found: {admin_assignments}"
+    )
 
 
 # ---------- 2. Readonly role assignment ----------
 
 
-def test_init_script_assigns_readonly_role():
-    """The readonly user must be assigned the 'readonly' role (not 'search')."""
+def test_init_script_assigns_readonly_search_role():
+    """The readonly user must be assigned the 'search' role (Solr 9.7 built-in)."""
     script = _load_solr_init_script()
 
     # Find all set-user-role JSON payloads for the readonly user
-    # Pattern: "set-user-role": {"$SOLR_READONLY_USER": ["readonly"]}
     role_assignments = re.findall(r'"set-user-role":\s*\{[^}]*\}', script)
     assert role_assignments, "No set-user-role calls found in solr-init script"
 
-    # Check that the readonly user gets "readonly" role, not "search"
     readonly_assignment = [r for r in role_assignments if "SOLR_READONLY_USER" in r]
     assert readonly_assignment, "No set-user-role for SOLR_READONLY_USER found"
 
     for assignment in readonly_assignment:
-        assert '"readonly"' in assignment, (
-            f"Readonly user should be assigned 'readonly' role, not 'search'. "
-            f"Found: {assignment} — #1287 fix may not be applied"
+        assert '"search"' in assignment, (
+            f"Readonly user should be assigned 'search' role (Solr 9.7 built-in). Found: {assignment}"
         )
-        assert '"search"' not in assignment, f"Readonly user should NOT use 'search' role. Found: {assignment}"
 
 
 # ---------- 3. Readonly user creation ----------
@@ -101,23 +105,23 @@ def test_init_script_creates_readonly_user():
     assert "SOLR_READONLY_PASS" in script, "Script must reference SOLR_READONLY_PASS"
 
 
-# ---------- 4. security.json has readonly role ----------
+# ---------- 4. security.json matches Solr 9.7 role hierarchy ----------
 
 
-def test_security_json_has_readonly_role():
-    """security.json must define permissions that reference the 'readonly' role."""
+def test_security_json_matches_solr97_roles():
+    """security.json must use Solr 9.7 built-in role hierarchy."""
     sec = _load_security_json()
 
     auth = sec.get("authorization", {})
     permissions = auth.get("permissions", [])
     assert permissions, "security.json has no permissions defined"
 
-    # Collect all roles referenced in read-type permissions
-    read_permissions = [p for p in permissions if p.get("name") == "read"]
-    assert read_permissions, "No 'read' permission found in security.json"
+    # Build permission-to-role map
+    perm_map = {p["name"]: p.get("role") for p in permissions}
 
-    for perm in read_permissions:
-        roles = perm.get("role", [])
-        if isinstance(roles, str):
-            roles = [roles]
-        assert "readonly" in roles, f"'read' permission should include 'readonly' role. Found roles: {roles}"
+    # Verify Solr 9.7 role hierarchy
+    assert perm_map.get("security-edit") == "superadmin", "security-edit must require superadmin role"
+    assert perm_map.get("collection-admin-read") == "search", "collection-admin-read must require search role"
+    assert perm_map.get("read") == "search", "read must require search role"
+    assert perm_map.get("collection-admin-edit") == "admin", "collection-admin-edit must require admin role"
+    assert perm_map.get("update") == "index", "update must require index role"

--- a/src/solr/security.json
+++ b/src/solr/security.json
@@ -9,7 +9,7 @@
     "permissions": [
       {
         "name": "security-edit",
-        "role": "admin"
+        "role": "superadmin"
       },
       {
         "name": "security-read",
@@ -25,10 +25,7 @@
       },
       {
         "name": "config-read",
-        "role": [
-          "admin",
-          "readonly"
-        ]
+        "role": "admin"
       },
       {
         "name": "core-admin-edit",
@@ -36,10 +33,7 @@
       },
       {
         "name": "core-admin-read",
-        "role": [
-          "admin",
-          "readonly"
-        ]
+        "role": "admin"
       },
       {
         "name": "collection-admin-edit",
@@ -47,21 +41,23 @@
       },
       {
         "name": "collection-admin-read",
-        "role": [
-          "admin",
-          "readonly"
-        ]
+        "role": "search"
       },
       {
         "name": "update",
-        "role": "admin"
+        "role": "index"
       },
       {
         "name": "read",
-        "role": [
-          "admin",
-          "readonly"
-        ]
+        "role": "search"
+      },
+      {
+        "name": "health",
+        "role": null
+      },
+      {
+        "name": "metrics-read",
+        "role": null
       },
       {
         "name": "all",


### PR DESCRIPTION
## Summary

Fixes #1332 — Solr auth bootstrap was overwriting admin roles, breaking security operations.

### Root Cause

Solr 9.7's `solr auth enable` automatically assigns all 4 built-in roles (`superadmin`, `admin`, `search`, `index`) to the created admin user. Our `solr-init` entrypoint was then calling `set-user-role` to overwrite these with just `["admin"]`, which stripped:
- **`superadmin`** — needed for `security-edit` operations
- **`search`** — needed for `collection-admin-read` and `read` operations
- **`index`** — needed for `update` operations

### Fix

1. **Removed** the `set-user-role` call for the admin user — `solr auth enable` already handles it correctly
2. **Changed** the readonly user role from `"readonly"` (custom, non-standard) to `"search"` (Solr 9.7 built-in role with read + collection-admin-read)
3. **Updated** `security.json` to match the Solr 9.7 built-in 4-tier role hierarchy:
   - `superadmin`: security-edit
   - `admin`: security-read, config-read/edit, core-admin-read/edit, collection-admin-edit
   - `search`: collection-admin-read, read
   - `index`: update
4. **Updated tests** to verify the new behavior

### Files Changed

- `docker-compose.yml` — dev init script
- `docker-compose.prod.yml` — prod init script
- `src/solr/security.json` — authorization config
- `src/solr-search/tests/test_solr_init_script.py` — tests for init script behavior

Working as Brett (Infrastructure Architect).

Closes #1332