### PR TITLE
fix(ci): source installer-generated Solr credentials for E2E health checks

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -109,6 +109,13 @@ jobs:
             --auth-db-path "$RUNNER_TEMP/aithena-auth/users.db" \
             --reset
 
+          # Export installer-generated credentials so later steps can use them.
+          # The installer writes random Solr passwords to .env; without this,
+          # the health-check step falls back to hardcoded dev defaults and gets 401.
+          if [ -f .env ]; then
+            grep -E '^(SOLR_ADMIN_USER|SOLR_ADMIN_PASS|SOLR_READONLY_USER|SOLR_READONLY_PASS|ADMIN_API_KEY)=' .env >> "$GITHUB_ENV" || true
+          fi
+
           # Browser E2E runs through the reverse proxy, so we use --profile production
           # in the 'up' command to activate nginx (which e2e.yml assigns to the
           # production profile). profiles: [] does NOT clear profiles due to


### PR DESCRIPTION
## Problem

The E2E integration tests have been failing since March 30 due to a Solr authentication mismatch:

1. The **installer** generates random Solr passwords and writes them to `.env`
2. **Docker Compose** reads `.env` automatically → containers use the generated password
4. Solr returns **401 Unauthorized** on every health-check curl for 7.5 minutes → timeout → E2E failure

Evidence from logs:
- solr-init: `SOLR_AUTHENTICATION_OPTS="-Dbasicauth=solr_admin:Wpq5kblMg3MFX5TKQjSgxFuKnX1JuHeRAHpoxTDuwOo"` (random password)

## Fix

After the installer runs in the "Bootstrap CI auth" step, export the generated credentials from `.env` into `$GITHUB_ENV`. This makes them available to subsequent steps via the existing `${SOLR_ADMIN_PASS:-...}` shell fallback pattern.

```bash
if [ -f .env ]; then
  grep -E '^(SOLR_ADMIN_USER|SOLR_ADMIN_PASS|SOLR_READONLY_USER|SOLR_READONLY_PASS|ADMIN_API_KEY)=' .env >> "$GITHUB_ENV" || true
fi
```

This follows the same pattern already used at line 329 for `ADMIN_API_KEY`.

## Unblocks

- PR #1361 (Release v1.18.1) — blocked by E2E gate
- All future PRs targeting `main`

Working as Brett (Infra)