### PR TITLE
fix: ensure dependabot:batch label exists before PR creation

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,7 +7,6 @@ on:
   workflow_run: # zizmor: ignore[dangerous-triggers] -- guarded by Dependabot-only checks + minimal permissions
     workflows: ["CI - Unit & Integration Tests"]
     types: [completed]
-    branches: [dev]
 
 permissions: read-all
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,6 +7,7 @@ on:
   workflow_run: # zizmor: ignore[dangerous-triggers] -- guarded by Dependabot-only checks + minimal permissions
     workflows: ["CI - Unit & Integration Tests"]
     types: [completed]
+    branches: [dev]
 
 permissions: read-all
 

--- a/.github/workflows/dependabot-batch-merge.yml
+++ b/.github/workflows/dependabot-batch-merge.yml
@@ -301,6 +301,7 @@ jobs:
     if: needs.consolidate.outputs.has-changes == 'true'
     permissions:
       contents: read
+      issues: write
       pull-requests: write
       issues: write
     steps:

--- a/.github/workflows/dependabot-batch-merge.yml
+++ b/.github/workflows/dependabot-batch-merge.yml
@@ -302,12 +302,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Ensure dependabot:batch label exists
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh label create "dependabot:batch" --description "Batch dependabot PR" --color "0366d6" --force 2>/dev/null || true
+          gh label create "dependabot:batch" --repo "$GITHUB_REPOSITORY" --description "Batch dependabot PR" --color "0366d6" --force 2>/dev/null || true
 
       - name: Create consolidated PR
         env:

--- a/.github/workflows/dependabot-batch-merge.yml
+++ b/.github/workflows/dependabot-batch-merge.yml
@@ -303,6 +303,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Ensure dependabot:batch label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "dependabot:batch" --description "Batch dependabot PR" --color "0366d6" --force 2>/dev/null || true
+
       - name: Create consolidated PR
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/dependabot-batch-merge.yml
+++ b/.github/workflows/dependabot-batch-merge.yml
@@ -308,7 +308,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh label create "dependabot:batch" --repo "$GITHUB_REPOSITORY" --description "Batch dependabot PR" --color "0366d6" --force 2>/dev/null || true
+          gh label create "dependabot:batch" --repo "$GITHUB_REPOSITORY" --description "Batch dependabot PR" --color "0366d6" --force
 
       - name: Create consolidated PR
         env:


### PR DESCRIPTION
## Summary

Fixes the 'Open consolidated PR' job in `dependabot-batch-merge.yml` to gracefully handle missing labels.

## Changes

Added a new step before PR creation that ensures the `dependabot:batch` label exists using:
```bash
gh label create "dependabot:batch" --repo "$GITHUB_REPOSITORY" --description "Batch dependabot PR" --color "0366d6" --force
```

The `--force` flag creates the label if missing or updates it if it exists, and the step silently succeeds in both cases.

## Why This Matters

The workflow previously failed when trying to apply a non-existent label (as seen in PR #1414). This fix ensures the workflow is resilient to label creation state.

## Testing

- Verify script (.squad/scripts/verify.sh) will validate workflow syntax
- Manual testing: Run dependabot-batch-merge.yml workflow manually to confirm label creation and PR generation succeeds
- The close-dependabot-batch.yml workflow is already compatible with this change (checks for label presence at line 20)

Closes #1414

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>