### PR TITLE
feat: make Solr shards and replication factor configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,25 @@ BUILD_DATE=1970-01-01T00:00:00Z
 #
 # Optional: override the embeddings-server image tag independently
 # EMBEDDINGS_VERSION=1.17.0-openvino
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Solr Collection Topology
+# ──────────────────────────────────────────────────────────────────────────────
+# These control how the Solr "books" collection is created at first startup.
+# They only take effect during initial collection creation — changing them
+# after the collection exists requires deleting and recreating it.
+#
+# Personal deployment (single machine, ≤30K docs):
+#   SOLR_NUM_SHARDS=1
+#   SOLR_REPLICATION_FACTOR=1
+#
+# Medium deployment (single machine, 30K-100K docs):
+#   SOLR_NUM_SHARDS=2
+#   SOLR_REPLICATION_FACTOR=1
+#
+# Distributed deployment (multi-node, HA) — the default:
+#   SOLR_NUM_SHARDS=1
+#   SOLR_REPLICATION_FACTOR=3
+#
+# SOLR_NUM_SHARDS=1
+# SOLR_REPLICATION_FACTOR=3

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -643,6 +643,8 @@ services:
       SOLR_READONLY_PASS: ${SOLR_READONLY_PASS:?Set SOLR_READONLY_PASS}
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
+      SOLR_NUM_SHARDS: ${SOLR_NUM_SHARDS:-1}
+      SOLR_REPLICATION_FACTOR: ${SOLR_REPLICATION_FACTOR:-3}
     entrypoint:
       - /bin/bash
       - -ceu
@@ -710,7 +712,7 @@ services:
           fi
 
           if ! curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=LIST&wt=json" | grep -q '"books"'; then
-            curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=CREATE&name=books&collection.configName=books&numShards=1&replicationFactor=3&waitForFinalState=true&wt=json"
+            curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=CREATE&name=books&collection.configName=books&numShards=$${SOLR_NUM_SHARDS:-1}&replicationFactor=$${SOLR_REPLICATION_FACTOR:-3}&waitForFinalState=true&wt=json"
           fi
 
           SOLR_BASE_URL="$$SOLR_URL" SOLR_COLLECTION="books" SOLR_AUTH_USER="$$SOLR_AUTH_USER" SOLR_AUTH_PASS="$$SOLR_AUTH_PASS" sh /scripts/add-conf-overlay.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -692,6 +692,8 @@ services:
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:-SolrAdmin_dev2024!}
       SOLR_READONLY_USER: ${SOLR_READONLY_USER:-solr_read}
       SOLR_READONLY_PASS: ${SOLR_READONLY_PASS:-SolrRead_dev2024!}
+      SOLR_NUM_SHARDS: ${SOLR_NUM_SHARDS:-1}
+      SOLR_REPLICATION_FACTOR: ${SOLR_REPLICATION_FACTOR:-3}
     volumes:
       - ./src/solr/books:/configsets/books:ro
       - ./src/solr/add-conf-overlay.sh:/scripts/add-conf-overlay.sh:ro
@@ -767,7 +769,7 @@ services:
           fi
 
           if ! curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=LIST&wt=json" | grep -q '"books"'; then
-            curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=CREATE&name=books&collection.configName=books&numShards=1&replicationFactor=3&waitForFinalState=true&wt=json"
+            curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=CREATE&name=books&collection.configName=books&numShards=$${SOLR_NUM_SHARDS:-1}&replicationFactor=$${SOLR_REPLICATION_FACTOR:-3}&waitForFinalState=true&wt=json"
           fi
 
           SOLR_BASE_URL="$$SOLR_URL" SOLR_COLLECTION="books" SOLR_AUTH_USER="$$SOLR_AUTH_USER" SOLR_AUTH_PASS="$$SOLR_AUTH_PASS" sh /scripts/add-conf-overlay.sh

--- a/docs/deployment/sizing-guide.md
+++ b/docs/deployment/sizing-guide.md
@@ -75,9 +75,48 @@ The shipped Compose stack allocates three Solr nodes:
 - `solr`, `solr2`, `solr3`
 - limit: **2 GB RAM per node**
 - reservation: **1 GB RAM per node**
-- collection bootstrap: `numShards=1`, `replicationFactor=3`
+- collection bootstrap: `numShards=1`, `replicationFactor=3` (configurable)
 
 Because the collection currently has one shard with three replicas, each node hosts one replica core for the `books` collection.
+
+### Configurable shards and replication
+
+Both `docker-compose.yml` and `docker-compose.prod.yml` read shard topology from environment variables with sensible defaults:
+
+| Variable | Default | Description |
+|---|---|---|
+| `SOLR_NUM_SHARDS` | `1` | Number of shards to split the collection across |
+| `SOLR_REPLICATION_FACTOR` | `3` | Number of replicas per shard |
+
+Set these in your `.env` file or export them before running `docker compose up`:
+
+```bash
+# Personal deployment (single machine, ≤30K docs)
+SOLR_NUM_SHARDS=1
+SOLR_REPLICATION_FACTOR=1
+
+# Medium deployment (single machine, 30K-100K docs)
+SOLR_NUM_SHARDS=2
+SOLR_REPLICATION_FACTOR=1
+
+# Distributed deployment (multi-node, HA required) — the default
+SOLR_NUM_SHARDS=1
+SOLR_REPLICATION_FACTOR=3
+```
+
+**How to choose:**
+
+| Library size | Shards | Replication | Why |
+|---|---:|---:|---|
+| ≤30K PDFs, single machine | 1 | 1 | One core fits in 8-12 GB; RF=1 avoids 3× disk/RAM waste |
+| 30K-100K PDFs, single machine | 2 | 1 | Splits the vector index across cores for better page-cache utilization |
+| Any size, HA required | 1-2 | 3 | RF=3 survives node failures; requires ≥3 Solr nodes |
+
+**Important notes:**
+
+- These variables only take effect during **initial collection creation**. If the `books` collection already exists, changing them requires deleting and recreating the collection (which re-indexes all documents).
+- `SOLR_REPLICATION_FACTOR` should not exceed the number of Solr nodes in the cluster.
+- For a personal/lite profile with a single Solr node, set `SOLR_REPLICATION_FACTOR=1`. RF>1 with only one node means Solr creates multiple replicas on the same machine, wasting disk without adding fault tolerance.
 
 ### Memory per core
 


### PR DESCRIPTION
## Summary

Make Solr collection topology (shards and replication factor) configurable via environment variables, enabling personal deployments to avoid the 3× resource overhead of the default RF=3 SolrCloud setup.

Relates to #1373 (Phase 1 — personal deployment profile)

## Changes

### `docker-compose.yml` + `docker-compose.prod.yml`
- Added `SOLR_NUM_SHARDS` and `SOLR_REPLICATION_FACTOR` environment variables to `solr-init` service
- Replaced hardcoded `numShards=1&replicationFactor=3` in the collection CREATE command with `$${SOLR_NUM_SHARDS:-1}&replicationFactor=$${SOLR_REPLICATION_FACTOR:-3}`
- Defaults unchanged (1 shard, RF=3) — fully backward compatible

### `docs/deployment/sizing-guide.md`
- Added "Configurable shards and replication" section with:
  - Variable reference table
  - Configuration examples for personal, medium, and distributed profiles
  - Guidance on when to use each setting
  - Notes on when changes take effect and constraints

### `.env.example`
- Added "Solr Collection Topology" section with commented examples for all three deployment profiles

## How to use

```bash
# Personal deployment (single machine, ≤30K docs)
SOLR_NUM_SHARDS=1 SOLR_REPLICATION_FACTOR=1 docker compose up -d

# Or set in .env:
echo "SOLR_NUM_SHARDS=1" >> .env
echo "SOLR_REPLICATION_FACTOR=1" >> .env
```

## Important

- Variables only take effect during **initial collection creation**
- Changing after collection exists requires deleting and recreating the collection
- `SOLR_REPLICATION_FACTOR` should not exceed the number of Solr nodes