### PR TITLE
feat: add weekly GHAS security review workflow

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,108 @@
+name: Security Review (Weekly)
+
+# Weekly review of Dependabot security alerts.
+# Creates squad-labeled issues for critical/high vulnerabilities
+# so they get triaged and assigned to the appropriate squad member.
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: '0 8 * * 1'
+
+  # Manual trigger for on-demand review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  security-events: read
+
+jobs:
+  review-alerts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Review Dependabot alerts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          REPO="${{ github.repository }}"
+          echo "🔍 Reviewing security alerts for ${REPO}..."
+
+          # Fetch open Dependabot alerts (critical and high severity)
+          ALERTS=$(gh api "repos/${REPO}/dependabot/alerts?state=open&severity=critical,high&per_page=100" \
+            --jq '.[] | {number: .number, severity: .security_advisory.severity, summary: .security_advisory.summary, package: .dependency.package.ecosystem + "/" + .dependency.package.name, cve: (.security_advisory.cve_id // "N/A"), url: .html_url}' 2>/dev/null || echo "")
+
+          if [ -z "$ALERTS" ]; then
+            echo "✅ No critical/high Dependabot alerts found."
+            exit 0
+          fi
+
+          echo "⚠️ Found alerts to review:"
+          echo "$ALERTS" | head -20
+
+          # Process each alert — create an issue if one doesn't already exist
+          echo "$ALERTS" | jq -c '.' | while IFS= read -r alert; do
+            NUMBER=$(echo "$alert" | jq -r '.number')
+            SEVERITY=$(echo "$alert" | jq -r '.severity')
+            SUMMARY=$(echo "$alert" | jq -r '.summary')
+            PACKAGE=$(echo "$alert" | jq -r '.package')
+            CVE=$(echo "$alert" | jq -r '.cve')
+            URL=$(echo "$alert" | jq -r '.url')
+
+            ISSUE_TITLE="🔒 Security: ${SUMMARY} (${PACKAGE})"
+
+            # Check if issue already exists (search by title substring)
+            EXISTING=$(gh issue list --repo "${REPO}" --search "${PACKAGE} ${CVE}" --label "security" --json number --jq 'length')
+            if [ "$EXISTING" -gt 0 ]; then
+              echo "  ⏭️  Alert #${NUMBER}: issue already exists for ${PACKAGE}"
+              continue
+            fi
+
+            # Determine squad label based on package ecosystem
+            SQUAD_LABEL="squad"
+            ECOSYSTEM=$(echo "$PACKAGE" | cut -d/ -f1)
+            case "$ECOSYSTEM" in
+              pip|pypi) SQUAD_LABEL="squad:parker" ;;
+              npm)      SQUAD_LABEL="squad:dallas" ;;
+              docker)   SQUAD_LABEL="squad:brett" ;;
+              actions)  SQUAD_LABEL="squad:brett" ;;
+            esac
+
+            BODY="## Security Alert
+
+| Field | Value |
+|---|---|
+| **Alert** | [#${NUMBER}](${URL}) |
+| **Severity** | ${SEVERITY} |
+| **Package** | \`${PACKAGE}\` |
+| **CVE** | ${CVE} |
+| **Summary** | ${SUMMARY} |
+
+### Action Required
+
+1. Review the alert and assess impact on aithena
+2. If a patch is available, update the dependency
+3. If no patch exists, evaluate workarounds or risk acceptance
+
+---
+*Created automatically by the weekly security review workflow.*"
+
+            gh issue create \
+              --repo "${REPO}" \
+              --title "${ISSUE_TITLE}" \
+              --body "${BODY}" \
+              --label "security,${SQUAD_LABEL}" || {
+                echo "  ⚠️  Failed to create issue for alert #${NUMBER} — may need 'security' label to exist"
+              }
+
+            echo "  ✅ Created issue for alert #${NUMBER}: ${PACKAGE} (${SEVERITY})"
+          done
+
+          echo ""
+          echo "🏁 Security review complete."

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,8 +1,12 @@
-name: Security Review (Weekly)
+name: Security Review — GHAS Alerts (Weekly)
 
-# Weekly review of Dependabot security alerts.
-# Creates squad-labeled issues for critical/high vulnerabilities
-# so they get triaged and assigned to the appropriate squad member.
+# Weekly review of GitHub Advanced Security (GHAS) code scanning alerts.
+# Creates squad-labeled issues for critical/high findings from CodeQL,
+# Bandit, Checkov, and zizmor that don't get auto-fixed by Dependabot.
+#
+# NOTE: Dependabot dependency alerts are handled separately by
+# dependabot-automerge.yml (auto-merges patch/minor PRs).
+# This workflow covers GHAS code scanning alerts only.
 
 on:
   schedule:
@@ -18,91 +22,108 @@ permissions:
   security-events: read
 
 jobs:
-  review-alerts:
+  review-ghas-alerts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Review Dependabot alerts
+      - name: Review GHAS code scanning alerts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
           REPO="${{ github.repository }}"
-          echo "🔍 Reviewing security alerts for ${REPO}..."
+          echo "🔍 Reviewing GHAS code scanning alerts for ${REPO}..."
 
-          # Fetch open Dependabot alerts (critical and high severity)
-          ALERTS=$(gh api "repos/${REPO}/dependabot/alerts?state=open&severity=critical,high&per_page=100" \
-            --jq '.[] | {number: .number, severity: .security_advisory.severity, summary: .security_advisory.summary, package: .dependency.package.ecosystem + "/" + .dependency.package.name, cve: (.security_advisory.cve_id // "N/A"), url: .html_url}' 2>/dev/null || echo "")
+          # Fetch open code scanning alerts (critical/error/high severity)
+          # These come from CodeQL, Bandit, Checkov, zizmor
+          ALERTS=$(gh api "repos/${REPO}/code-scanning/alerts?state=open&per_page=100" \
+            --jq '.[] | select(.rule.security_severity_level == "critical" or .rule.security_severity_level == "high" or .rule.severity == "error") | {number: .number, rule: .rule.id, severity: (.rule.security_severity_level // .rule.severity), tool: .tool.name, description: .rule.description, file: .most_recent_instance.location.path, line: .most_recent_instance.location.start_line, url: .html_url, created: .created_at}' 2>/dev/null || echo "")
 
           if [ -z "$ALERTS" ]; then
-            echo "✅ No critical/high Dependabot alerts found."
+            echo "✅ No critical/high GHAS alerts found."
             exit 0
           fi
 
-          echo "⚠️ Found alerts to review:"
-          echo "$ALERTS" | head -20
+          ALERT_COUNT=$(echo "$ALERTS" | jq -s 'length')
+          echo "⚠️ Found ${ALERT_COUNT} alert(s) to review."
 
-          # Process each alert — create an issue if one doesn't already exist
+          # Process each alert
           echo "$ALERTS" | jq -c '.' | while IFS= read -r alert; do
             NUMBER=$(echo "$alert" | jq -r '.number')
+            RULE=$(echo "$alert" | jq -r '.rule')
             SEVERITY=$(echo "$alert" | jq -r '.severity')
-            SUMMARY=$(echo "$alert" | jq -r '.summary')
-            PACKAGE=$(echo "$alert" | jq -r '.package')
-            CVE=$(echo "$alert" | jq -r '.cve')
+            TOOL=$(echo "$alert" | jq -r '.tool')
+            DESCRIPTION=$(echo "$alert" | jq -r '.description')
+            FILE=$(echo "$alert" | jq -r '.file')
+            LINE=$(echo "$alert" | jq -r '.line')
             URL=$(echo "$alert" | jq -r '.url')
 
-            ISSUE_TITLE="🔒 Security: ${SUMMARY} (${PACKAGE})"
+            ISSUE_TITLE="🔒 GHAS: ${RULE} in ${FILE} (${TOOL})"
 
-            # Check if issue already exists (search by title substring)
-            EXISTING=$(gh issue list --repo "${REPO}" --search "${PACKAGE} ${CVE}" --label "security" --json number --jq 'length')
+            # Check if issue already exists
+            SEARCH_TERM="${RULE} ${FILE}"
+            EXISTING=$(gh issue list --repo "${REPO}" --search "\"${RULE}\" \"${FILE}\"" --label "security" --json number --jq 'length' 2>/dev/null || echo "0")
             if [ "$EXISTING" -gt 0 ]; then
-              echo "  ⏭️  Alert #${NUMBER}: issue already exists for ${PACKAGE}"
+              echo "  ⏭️  Alert #${NUMBER}: issue already exists for ${RULE} in ${FILE}"
               continue
             fi
 
-            # Determine squad label based on package ecosystem
-            SQUAD_LABEL="squad"
-            ECOSYSTEM=$(echo "$PACKAGE" | cut -d/ -f1)
-            case "$ECOSYSTEM" in
-              pip|pypi) SQUAD_LABEL="squad:parker" ;;
-              npm)      SQUAD_LABEL="squad:dallas" ;;
-              docker)   SQUAD_LABEL="squad:brett" ;;
-              actions)  SQUAD_LABEL="squad:brett" ;;
+            # Route to squad member by tool
+            case "$TOOL" in
+              CodeQL)
+                # Route by file extension
+                case "$FILE" in
+                  *.py)  SQUAD_LABEL="squad:parker" ;;
+                  *.ts|*.tsx|*.js|*.jsx) SQUAD_LABEL="squad:dallas" ;;
+                  *.yml|*.yaml) SQUAD_LABEL="squad:brett" ;;
+                  *) SQUAD_LABEL="squad:kane" ;;
+                esac
+                ;;
+              Bandit)   SQUAD_LABEL="squad:kane" ;;
+              checkov)  SQUAD_LABEL="squad:brett" ;;
+              zizmor)   SQUAD_LABEL="squad:brett" ;;
+              *)        SQUAD_LABEL="squad" ;;
             esac
 
-            BODY="## Security Alert
+            BODY="## GHAS Code Scanning Alert
 
 | Field | Value |
 |---|---|
 | **Alert** | [#${NUMBER}](${URL}) |
-| **Severity** | ${SEVERITY} |
-| **Package** | \`${PACKAGE}\` |
-| **CVE** | ${CVE} |
-| **Summary** | ${SUMMARY} |
+| **Severity** | \`${SEVERITY}\` |
+| **Tool** | ${TOOL} |
+| **Rule** | \`${RULE}\` |
+| **File** | \`${FILE}:${LINE}\` |
+
+### Description
+
+${DESCRIPTION}
 
 ### Action Required
 
-1. Review the alert and assess impact on aithena
-2. If a patch is available, update the dependency
-3. If no patch exists, evaluate workarounds or risk acceptance
+1. Review the alert and the flagged code
+2. Determine if this is a true positive or false positive
+3. If true positive: fix the code and push a PR
+4. If false positive: dismiss the alert with justification
 
 ---
-*Created automatically by the weekly security review workflow.*"
+*Created automatically by the weekly GHAS security review workflow.*"
 
             gh issue create \
               --repo "${REPO}" \
               --title "${ISSUE_TITLE}" \
               --body "${BODY}" \
-              --label "security,${SQUAD_LABEL}" || {
-                echo "  ⚠️  Failed to create issue for alert #${NUMBER} — may need 'security' label to exist"
+              --label "security,${SQUAD_LABEL}" 2>/dev/null || {
+                echo "  ⚠️  Failed to create issue for alert #${NUMBER}"
+                continue
               }
 
-            echo "  ✅ Created issue for alert #${NUMBER}: ${PACKAGE} (${SEVERITY})"
+            echo "  ✅ Created issue for GHAS alert #${NUMBER}: ${RULE} in ${FILE}"
           done
 
           echo ""
-          echo "🏁 Security review complete."
+          echo "🏁 GHAS security review complete."

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -40,8 +40,12 @@ jobs:
 
           # Fetch open code scanning alerts (critical/error/high severity)
           # These come from CodeQL, Bandit, Checkov, zizmor
-          ALERTS=$(gh api "repos/${REPO}/code-scanning/alerts?state=open&per_page=100" \
-            --jq '.[] | select(.rule.security_severity_level == "critical" or .rule.security_severity_level == "high" or .rule.severity == "error") | {number: .number, rule: .rule.id, severity: (.rule.security_severity_level // .rule.severity), tool: .tool.name, description: .rule.description, file: .most_recent_instance.location.path, line: .most_recent_instance.location.start_line, url: .html_url, created: .created_at}' 2>/dev/null || echo "")
+          # Surface API errors explicitly — a silent failure here would hide real problems
+          if ! ALERTS=$(gh api "repos/${REPO}/code-scanning/alerts?state=open&per_page=100" \
+            --jq '.[] | select(.rule.security_severity_level == "critical" or .rule.security_severity_level == "high" or .rule.severity == "error") | {number: .number, rule: .rule.id, severity: (.rule.security_severity_level // .rule.severity), tool: .tool.name, description: .rule.description, file: .most_recent_instance.location.path, line: .most_recent_instance.location.start_line, url: .html_url, created: .created_at}'); then
+            echo "❌ Failed to fetch code scanning alerts. Check GITHUB_TOKEN permissions (needs security-events:read)."
+            exit 1
+          fi
 
           if [ -z "$ALERTS" ]; then
             echo "✅ No critical/high GHAS alerts found."
@@ -64,8 +68,11 @@ jobs:
 
             ISSUE_TITLE="🔒 GHAS: ${RULE} in ${FILE} (${TOOL})"
 
-            # Check if issue already exists
-            SEARCH_TERM="${RULE} ${FILE}"
+            # Ensure the "security" label exists (idempotent)
+            gh label create "security" --repo "${REPO}" --description "Security alerts" --color "B60205" --force 2>/dev/null || true
+
+            # Check if issue already exists.
+            # If the label search fails for any reason, treat as "no match" so we can proceed.
             EXISTING=$(gh issue list --repo "${REPO}" --search "\"${RULE}\" \"${FILE}\"" --label "security" --json number --jq 'length' 2>/dev/null || echo "0")
             if [ "$EXISTING" -gt 0 ]; then
               echo "  ⏭️  Alert #${NUMBER}: issue already exists for ${RULE} in ${FILE}"

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -16,6 +16,10 @@ on:
   # Manual trigger for on-demand review
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write
@@ -56,26 +60,30 @@ jobs:
           echo "⚠️ Found ${ALERT_COUNT} alert(s) to review."
 
           # Process each alert
+          # Ensure the "security" label exists once before the loop (idempotent)
+          gh label create "security" --repo "${REPO}" --description "Security alerts" --color "B60205" --force 2>/dev/null || true
+
+          CREATED=0
+          SKIPPED=0
+          FAILED=0
+
           echo "$ALERTS" | jq -c '.' | while IFS= read -r alert; do
             NUMBER=$(echo "$alert" | jq -r '.number')
             RULE=$(echo "$alert" | jq -r '.rule')
-            SEVERITY=$(echo "$alert" | jq -r '.severity')
-            TOOL=$(echo "$alert" | jq -r '.tool')
-            DESCRIPTION=$(echo "$alert" | jq -r '.description')
-            FILE=$(echo "$alert" | jq -r '.file')
-            LINE=$(echo "$alert" | jq -r '.line')
+            SEVERITY=$(echo "$alert" | jq -r '.severity // "unknown"')
+            TOOL=$(echo "$alert" | jq -r '.tool // "unknown"')
+            DESCRIPTION=$(echo "$alert" | jq -r '.description // "No description available"')
+            FILE=$(echo "$alert" | jq -r '.file // "unknown"')
+            LINE=$(echo "$alert" | jq -r '.line // "?"')
             URL=$(echo "$alert" | jq -r '.url')
 
             ISSUE_TITLE="🔒 GHAS: ${RULE} in ${FILE} (${TOOL})"
 
-            # Ensure the "security" label exists (idempotent)
-            gh label create "security" --repo "${REPO}" --description "Security alerts" --color "B60205" --force 2>/dev/null || true
-
-            # Check if issue already exists.
-            # If the label search fails for any reason, treat as "no match" so we can proceed.
+            # Check if issue already exists
             EXISTING=$(gh issue list --repo "${REPO}" --search "\"${RULE}\" \"${FILE}\"" --label "security" --json number --jq 'length' 2>/dev/null || echo "0")
             if [ "$EXISTING" -gt 0 ]; then
               echo "  ⏭️  Alert #${NUMBER}: issue already exists for ${RULE} in ${FILE}"
+              SKIPPED=$((SKIPPED + 1))
               continue
             fi
 
@@ -124,13 +132,18 @@ ${DESCRIPTION}
               --repo "${REPO}" \
               --title "${ISSUE_TITLE}" \
               --body "${BODY}" \
-              --label "security,${SQUAD_LABEL}" 2>/dev/null || {
-                echo "  ⚠️  Failed to create issue for alert #${NUMBER}"
+              --label "security,${SQUAD_LABEL}" || {
+                echo "  ❌ Failed to create issue for alert #${NUMBER}"
+                FAILED=$((FAILED + 1))
                 continue
               }
 
+            CREATED=$((CREATED + 1))
             echo "  ✅ Created issue for GHAS alert #${NUMBER}: ${RULE} in ${FILE}"
           done
 
           echo ""
-          echo "🏁 GHAS security review complete."
+          echo "🏁 GHAS security review complete. Created: ${CREATED}, Skipped: ${SKIPPED}, Failed: ${FAILED}"
+          if [ "${FAILED}" -gt 0 ]; then
+            echo "⚠️ ${FAILED} issue(s) failed to create — check permissions and labels."
+          fi

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -61,13 +61,16 @@ jobs:
 
           # Process each alert
           # Ensure the "security" label exists once before the loop (idempotent)
-          gh label create "security" --repo "${REPO}" --description "Security alerts" --color "B60205" --force 2>/dev/null || true
+          gh label create "security" --repo "${REPO}" --description "Security alerts" --color "B60205" --force || {
+            echo "⚠️ Could not create/verify 'security' label. Issue creation may fail."
+          }
 
           CREATED=0
           SKIPPED=0
           FAILED=0
 
-          echo "$ALERTS" | jq -c '.' | while IFS= read -r alert; do
+          # Use process substitution to avoid subshell (preserves counter variables)
+          while IFS= read -r alert; do
             NUMBER=$(echo "$alert" | jq -r '.number')
             RULE=$(echo "$alert" | jq -r '.rule')
             SEVERITY=$(echo "$alert" | jq -r '.severity // "unknown"')
@@ -140,7 +143,7 @@ ${DESCRIPTION}
 
             CREATED=$((CREATED + 1))
             echo "  ✅ Created issue for GHAS alert #${NUMBER}: ${RULE} in ${FILE}"
-          done
+          done < <(echo "$ALERTS" | jq -c '.')
 
           echo ""
           echo "🏁 GHAS security review complete. Created: ${CREATED}, Skipped: ${SKIPPED}, Failed: ${FAILED}"


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow that reviews **GHAS code scanning alerts** (CodeQL, Bandit, Checkov, zizmor) weekly and creates squad-labeled issues for critical/high findings.

**This does NOT cover Dependabot alerts** — those are already handled by `dependabot-automerge.yml` which auto-merges patch/minor PRs.

### What it does

1. Runs every Monday 08:00 UTC (+ manual trigger)
2. Fetches open GHAS code scanning alerts filtered to critical/high/error severity
3. Deduplicates against existing issues (searches by rule + file)
4. Creates issues with structured info (tool, rule, severity, file:line, alert link)
5. Auto-routes to squad members by tool and file type:
   - CodeQL Python → `squad:parker`
   - CodeQL JS/TS → `squad:dallas`
   - CodeQL YAML / Checkov / zizmor → `squad:brett`
   - Bandit → `squad:kane`

### Why separate from Dependabot?

| Alert source | Auto-fix? | Handled by |
|---|---|---|
| Dependabot (dependencies) | ✅ Creates PRs | `dependabot-automerge.yml` |
| CodeQL (code patterns) | ❌ Flag only | **This workflow** |
| Bandit (Python SAST) | ❌ Flag only | **This workflow** |
| Checkov/zizmor (IaC) | ❌ Flag only | **This workflow** |

### Testing

Trigger manually from the Actions tab after merge. No-op if no critical/high alerts exist.