### PR TITLE
fix: prod Solr deprecation + requirements.txt sync

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -498,6 +498,7 @@ services:
       - ./src/solr/entrypoint.sh:/entrypoint.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
+      SOLR_SECURITY_MANAGER_ENABLED: "false"
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
@@ -544,6 +545,7 @@ services:
       - ./src/solr/entrypoint.sh:/entrypoint.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
+      SOLR_SECURITY_MANAGER_ENABLED: "false"
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
@@ -590,6 +592,7 @@ services:
       - ./src/solr/entrypoint.sh:/entrypoint.sh:ro
     environment:
       SOLR_MODULES: extraction,langid
+      SOLR_SECURITY_MANAGER_ENABLED: "false"
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
       SOLR_AUTH_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_AUTH_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}

--- a/src/solr-search/requirements.txt
+++ b/src/solr-search/requirements.txt
@@ -1,6 +1,6 @@
 # DEPRECATED: use pyproject.toml + uv.lock instead.
 # Kept as a fallback for tooling that does not support PEP 517 projects.
-fastapi[all]>=0.115.0,<1
-uvicorn[standard]>=0.30.0,<1
+fastapi[all]>=0.135.3,<1
+uvicorn[standard]>=0.44.0,<1
 requests==2.33.1
 redis==7.4.0


### PR DESCRIPTION
Fixes review comments from release PR #1434:

1. **SOLR_SECURITY_MANAGER_ENABLED on prod Solr nodes** — Added `SOLR_SECURITY_MANAGER_ENABLED=false` to solr, solr2, solr3 in docker-compose.prod.yml (was only on solr-init, leaving prod logs noisy)
2. **requirements.txt sync** — Updated solr-search/requirements.txt to match pyproject.toml (fastapi>=0.135.3, uvicorn>=0.44.0)
3. **Env var validation** — Deferred to #1440 (minimize scope per release process rules)