### PR TITLE
feat: add PAT expiry detection and notification across workflows

### DIFF
--- a/.github/workflows/pat-health-check.yml
+++ b/.github/workflows/pat-health-check.yml
@@ -1,0 +1,220 @@
+name: PAT Health Check
+
+on:
+  schedule:
+    # First of each month at 09:00 UTC
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  check-tokens:
+    name: Validate PATs and tokens
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check COPILOT_PAT
+        id: copilot-pat
+        env:
+          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
+        run: |
+          if [ -z "$COPILOT_PAT" ]; then
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Secret is empty or not configured" >> "$GITHUB_OUTPUT"
+            echo "⚠️ COPILOT_PAT is not configured"
+            exit 0
+          fi
+          # Test with a lightweight GitHub API call
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $COPILOT_PAT" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user)
+          if [ "$STATUS" = "200" ]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+            echo "✅ COPILOT_PAT is valid"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "reason=API returned HTTP $STATUS" >> "$GITHUB_OUTPUT"
+            echo "⚠️ COPILOT_PAT returned HTTP $STATUS"
+          fi
+
+      - name: Check COPILOT_ASSIGN_TOKEN
+        id: assign-token
+        env:
+          COPILOT_ASSIGN_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+        run: |
+          if [ -z "$COPILOT_ASSIGN_TOKEN" ]; then
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Secret is empty or not configured" >> "$GITHUB_OUTPUT"
+            echo "⚠️ COPILOT_ASSIGN_TOKEN is not configured"
+            exit 0
+          fi
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $COPILOT_ASSIGN_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/user)
+          if [ "$STATUS" = "200" ]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+            echo "✅ COPILOT_ASSIGN_TOKEN is valid"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "reason=API returned HTTP $STATUS" >> "$GITHUB_OUTPUT"
+            echo "⚠️ COPILOT_ASSIGN_TOKEN returned HTTP $STATUS"
+          fi
+
+      - name: Check HF_TOKEN
+        id: hf-token
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Secret is empty or not configured" >> "$GITHUB_OUTPUT"
+            echo "⚠️ HF_TOKEN is not configured"
+            exit 0
+          fi
+          STATUS=$(curl -sI -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $HF_TOKEN" \
+            https://huggingface.co/api/whoami-v2)
+          if [ "$STATUS" = "200" ]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+            echo "✅ HF_TOKEN is valid"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "reason=API returned HTTP $STATUS" >> "$GITHUB_OUTPUT"
+            echo "⚠️ HF_TOKEN returned HTTP $STATUS"
+          fi
+
+      - name: Create or update tracking issues
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          COPILOT_PAT_VALID: ${{ steps.copilot-pat.outputs.valid }}
+          COPILOT_PAT_REASON: ${{ steps.copilot-pat.outputs.reason }}
+          ASSIGN_TOKEN_VALID: ${{ steps.assign-token.outputs.valid }}
+          ASSIGN_TOKEN_REASON: ${{ steps.assign-token.outputs.reason }}
+          HF_TOKEN_VALID: ${{ steps.hf-token.outputs.valid }}
+          HF_TOKEN_REASON: ${{ steps.hf-token.outputs.reason }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const timestamp = new Date().toISOString();
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            // Ensure label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo,
+                name: 'token-expired',
+                color: 'D93F0B',
+                description: 'A PAT or token may be expired',
+              });
+            } catch (e) { /* already exists */ }
+
+            // Fetch all open token-expired issues once
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner, repo,
+              state: 'open',
+              labels: 'token-expired',
+              per_page: 100,
+            });
+
+            const tokens = [
+              {
+                name: 'COPILOT_PAT',
+                valid: process.env.COPILOT_PAT_VALID === 'true',
+                reason: process.env.COPILOT_PAT_REASON || '',
+                title: '⚠️ COPILOT_PAT may be expired — release docs used fallback template',
+                impact: 'Copilot CLI will be unavailable for release documentation generation.',
+              },
+              {
+                name: 'COPILOT_ASSIGN_TOKEN',
+                valid: process.env.ASSIGN_TOKEN_VALID === 'true',
+                reason: process.env.ASSIGN_TOKEN_REASON || '',
+                title: '⚠️ COPILOT_ASSIGN_TOKEN may be expired — squad assignment degraded',
+                impact: 'Copilot auto-assignment will fall back to GITHUB_TOKEN with limited permissions.',
+              },
+              {
+                name: 'HF_TOKEN',
+                valid: process.env.HF_TOKEN_VALID === 'true',
+                reason: process.env.HF_TOKEN_REASON || '',
+                title: '⚠️ HF_TOKEN may be expired — HuggingFace API access degraded',
+                impact: 'Embedding model downloads and HuggingFace API calls may fail.',
+              },
+            ];
+
+            for (const token of tokens) {
+              const match = openIssues.find(i => i.title === token.title);
+
+              if (!token.valid) {
+                const body = [
+                  '## PAT Health Check — Failed',
+                  '',
+                  `\`${token.name}\` is invalid or not configured.`,
+                  '',
+                  '### Details',
+                  `- **Reason:** ${token.reason}`,
+                  `- **Impact:** ${token.impact}`,
+                  `- **Health check run:** ${runUrl}`,
+                  `- **Timestamp:** ${timestamp}`,
+                  '',
+                  '### Resolution',
+                  `1. Generate a new token for \`${token.name}\``,
+                  '2. Update the repository secret',
+                  '3. Close this issue once resolved',
+                ].join('\n');
+
+                if (match) {
+                  await github.rest.issues.createComment({
+                    owner, repo,
+                    issue_number: match.number,
+                    body: `🔄 **Still invalid** at ${timestamp}\n\nReason: ${token.reason}\nHealth check: ${runUrl}`,
+                  });
+                  core.info(`Updated existing issue #${match.number} for ${token.name}`);
+                } else {
+                  await github.rest.issues.create({
+                    owner, repo,
+                    title: token.title,
+                    body,
+                    labels: ['token-expired'],
+                  });
+                  core.info(`Created issue for invalid ${token.name}`);
+                }
+              } else if (match) {
+                // Token is now valid — close the tracking issue
+                await github.rest.issues.createComment({
+                  owner, repo,
+                  issue_number: match.number,
+                  body: `✅ **Resolved** — \`${token.name}\` is now valid (checked at ${timestamp}).\n\nHealth check: ${runUrl}`,
+                });
+                await github.rest.issues.update({
+                  owner, repo,
+                  issue_number: match.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                core.info(`Closed issue #${match.number} — ${token.name} is valid`);
+              } else {
+                core.info(`${token.name} is valid, no open issue to close`);
+              }
+            }
+
+      - name: Summary
+        if: always()
+        env:
+          COPILOT_PAT_VALID: ${{ steps.copilot-pat.outputs.valid }}
+          ASSIGN_TOKEN_VALID: ${{ steps.assign-token.outputs.valid }}
+          HF_TOKEN_VALID: ${{ steps.hf-token.outputs.valid }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## PAT Health Check Results
+
+          | Token | Status |
+          |-------|--------|
+          | COPILOT_PAT | $([ "$COPILOT_PAT_VALID" = "true" ] && echo "✅ Valid" || echo "❌ Invalid") |
+          | COPILOT_ASSIGN_TOKEN | $([ "$ASSIGN_TOKEN_VALID" = "true" ] && echo "✅ Valid" || echo "❌ Invalid") |
+          | HF_TOKEN | $([ "$HF_TOKEN_VALID" = "true" ] && echo "✅ Valid" || echo "❌ Invalid") |
+
+          _Checked at $(date -u +%Y-%m-%dT%H:%M:%SZ)_
+          EOF

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -408,6 +408,78 @@ jobs:
 
           echo "✅ Fallback template created at $OUTPUT_FILE"
 
+      - name: Notify if fallback was triggered (possible PAT expiry)
+        if: steps.copilot.outputs.fallback == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = '⚠️ COPILOT_PAT may be expired — release docs used fallback template';
+            const timestamp = new Date().toISOString();
+            const runUrl = `https://github.com/${process.env.REPO}/actions/runs/${process.env.RUN_ID}`;
+            const version = process.env.VERSION;
+
+            const body = [
+              '## PAT Expiry Alert',
+              '',
+              `The release-docs workflow fell back to a template for **v${version}** because Copilot CLI failed.`,
+              'This usually means `COPILOT_PAT` is expired or invalid.',
+              '',
+              '### Details',
+              `- **Version:** v${version}`,
+              `- **Workflow run:** ${runUrl}`,
+              `- **Timestamp:** ${timestamp}`,
+              '',
+              '### Resolution',
+              '1. Generate a new fine-grained PAT with "Copilot Requests" permission',
+              '2. Update the `COPILOT_PAT` repository secret',
+              '3. Re-run the release-docs workflow',
+              '4. Close this issue once resolved',
+            ].join('\n');
+
+            // Ensure the label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo,
+                name: 'token-expired',
+                color: 'D93F0B',
+                description: 'A PAT or token may be expired',
+              });
+            } catch (e) {
+              // Label already exists — ignore
+            }
+
+            // Check for existing open issue with same title
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner, repo,
+              state: 'open',
+              labels: 'token-expired',
+              per_page: 100,
+            });
+            const match = existing.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: match.number,
+                body: `🔄 **Recurrence** at ${timestamp}\n\nWorkflow run: ${runUrl}\nVersion: v${version}`,
+              });
+              core.info(`Updated existing issue #${match.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner, repo,
+                title,
+                body,
+                labels: ['token-expired'],
+              });
+              core.info('Created new token-expired issue');
+            }
+
       # ─────────────────────────────────────────────────────────────
       # Step 6: Create PR with generated documentation
       # ─────────────────────────────────────────────────────────────
@@ -524,6 +596,19 @@ jobs:
             --label "${MILESTONE}"
           
           echo "✅ PR created for review"
+
+      - name: Comment on PR if fallback was used
+        if: steps.copilot.outputs.fallback == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          PR_NUMBER=$(gh pr view "$BRANCH" --repo "$REPO" --json number --jq '.number' 2>/dev/null || true)
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "⚠️ **Fallback template used** — Copilot CLI was unavailable (possible \`COPILOT_PAT\` expiry). This release documentation for v${VERSION} needs manual completion. See the tracking issue labeled \`token-expired\` for details."
+          fi
 
       # ─────────────────────────────────────────────────────────────
       # Step 7: Summary

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -171,3 +171,70 @@ jobs:
             } catch (e) {
               core.info(`No squad:copilot label found or error: ${e.message}`);
             }
+
+      - name: Notify if COPILOT_ASSIGN_TOKEN is unavailable
+        if: success()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          HAS_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN != '' }}
+        with:
+          script: |
+            const hasToken = process.env.HAS_TOKEN === 'true';
+            if (hasToken) {
+              core.info('COPILOT_ASSIGN_TOKEN is configured');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = '⚠️ COPILOT_ASSIGN_TOKEN may be expired — squad assignment degraded';
+            const timestamp = new Date().toISOString();
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              '## PAT Expiry Alert',
+              '',
+              'The squad-heartbeat workflow detected that `COPILOT_ASSIGN_TOKEN` is empty or not configured.',
+              'Copilot auto-assignment is falling back to `GITHUB_TOKEN`, which may lack required permissions.',
+              '',
+              '### Details',
+              `- **Workflow run:** ${runUrl}`,
+              `- **Timestamp:** ${timestamp}`,
+              '',
+              '### Resolution',
+              '1. Generate a new PAT with issue write permissions',
+              '2. Update the `COPILOT_ASSIGN_TOKEN` repository secret',
+              '3. Close this issue once resolved',
+            ].join('\n');
+
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo,
+                name: 'token-expired',
+                color: 'D93F0B',
+                description: 'A PAT or token may be expired',
+              });
+            } catch (e) { /* already exists */ }
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner, repo,
+              state: 'open',
+              labels: 'token-expired',
+              per_page: 100,
+            });
+            const match = existing.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: match.number,
+                body: `🔄 **Recurrence** at ${timestamp}\n\nWorkflow run: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo,
+                title,
+                body,
+                labels: ['token-expired'],
+              });
+            }

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -161,3 +161,65 @@ jobs:
                 core.warning(`Fallback also failed: ${err2.message}`);
               }
             }
+
+      - name: Notify if copilot assignment failed (possible PAT expiry)
+        if: github.event.label.name == 'squad:copilot' && failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = '⚠️ COPILOT_ASSIGN_TOKEN may be expired — squad assignment degraded';
+            const timestamp = new Date().toISOString();
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const issueNum = context.payload.issue.number;
+
+            const body = [
+              '## PAT Expiry Alert',
+              '',
+              `The squad-issue-assign workflow failed to assign @copilot to issue #${issueNum}.`,
+              'This usually means \`COPILOT_ASSIGN_TOKEN\` is expired or invalid.',
+              '',
+              '### Details',
+              `- **Trigger issue:** #${issueNum}`,
+              `- **Workflow run:** ${runUrl}`,
+              `- **Timestamp:** ${timestamp}`,
+              '',
+              '### Resolution',
+              '1. Generate a new PAT with issue write permissions',
+              '2. Update the \`COPILOT_ASSIGN_TOKEN\` repository secret',
+              '3. Re-apply the \`squad:copilot\` label to retry',
+              '4. Close this issue once resolved',
+            ].join('\n');
+
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo,
+                name: 'token-expired',
+                color: 'D93F0B',
+                description: 'A PAT or token may be expired',
+              });
+            } catch (e) { /* already exists */ }
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner, repo,
+              state: 'open',
+              labels: 'token-expired',
+              per_page: 100,
+            });
+            const match = existing.find(i => i.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: match.number,
+                body: `🔄 **Recurrence** at ${timestamp}\n\nTrigger: issue #${issueNum}\nWorkflow run: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo,
+                title,
+                body,
+                labels: ['token-expired'],
+              });
+            }


### PR DESCRIPTION
## Summary

Adds automatic detection and notification when PATs expire or become invalid, preventing silent workflow degradation.

### Changes

**Modified workflows:**
- **release-docs.yml** — Creates/updates a `token-expired` issue when fallback template is triggered (COPILOT_PAT likely expired). Also adds a PR comment on the generated docs PR.
- **squad-issue-assign.yml** — Notifies via issue when @copilot assignment fails (COPILOT_ASSIGN_TOKEN likely expired).
- **squad-heartbeat.yml** — Detects when COPILOT_ASSIGN_TOKEN is empty/missing and creates a tracking issue.

**New workflow:**
- **pat-health-check.yml** — Monthly cron job that validates COPILOT_PAT, COPILOT_ASSIGN_TOKEN, and HF_TOKEN. Creates tracking issues for invalid tokens and auto-closes them when tokens become valid again.

### Design decisions
- All notification steps use `GITHUB_TOKEN` (not the PATs being tested) for creating issues
- Issues are deduplicated by title — recurring failures add comments instead of new issues
- Shared `token-expired` label across all notifications
- Health check auto-closes issues when tokens are validated successfully

Closes #1451