### PR TITLE
fix: suppress Redis overcommit and ZooKeeper maxCnxns warnings

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -386,6 +386,7 @@ services:
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
       ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_MAX_CLIENT_CNXNS: "60"
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
     volumes:
@@ -422,6 +423,7 @@ services:
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
       ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_MAX_CLIENT_CNXNS: "60"
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
     volumes:
@@ -458,6 +460,7 @@ services:
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
       ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_MAX_CLIENT_CNXNS: "60"
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    # it is importnant to configure OS memory overcommit
+    # it is important to configure OS memory overcommit
     # https://github.com/nextcloud/all-in-one/discussions/1731
     # run this in your VM:
     # echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/nextcloud-aio-memory-overcommit.conf
@@ -427,6 +427,7 @@ services:
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
       ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_MAX_CLIENT_CNXNS: "60"
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
     volumes:
@@ -467,6 +468,7 @@ services:
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
       ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_MAX_CLIENT_CNXNS: "60"
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
     volumes:
@@ -503,6 +505,7 @@ services:
     environment:
       ZOO_4LW_COMMANDS_WHITELIST: "mntr,conf,ruok"
       ZOO_CFG_EXTRA: "admin.enableServer=false"
+      ZOO_MAX_CLIENT_CNXNS: "60"
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=zoo1:2888:3888;2181 server.2=zoo2:2888:3888;2181 server.3=zoo3:2888:3888;2181
     volumes:

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -49,6 +49,29 @@ Current shipped behavior:
 
 This reduces startup races where the lister, indexer, or admin tools could come up before the queue or cache was actually ready.
 
+## Host Prerequisites
+
+Before starting the Docker Compose stack, apply the following kernel tuning on the **Docker host** (these cannot be set from inside a container).
+
+### Redis memory overcommit
+
+Redis background saves (RDB snapshots) fork the process, which requires the kernel to allow memory overcommit. Without this setting Redis logs `WARNING Memory overcommit must be enabled!` and background saves may fail.
+
+```bash
+# Apply immediately (non-persistent):
+sudo sysctl vm.overcommit_memory=1
+
+# Make persistent across reboots:
+echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/90-redis-overcommit.conf
+sudo sysctl --system
+```
+
+> **Note:** The compose stack sets `stop-writes-on-bgsave-error no` in `src/redis/redis.conf` so Redis remains available even when overcommit is disabled, but applying the host-level setting is still recommended to ensure reliable snapshots.
+
+### ZooKeeper credentials (production hardening)
+
+Solr logs `Using default ZkCredentialsProvider/ZkACLProvider` at startup. This is informational — it means ZooKeeper znodes are world-readable. For production deployments that require ZooKeeper ACL-based access control, see the [Apache Solr ZooKeeper Access Control](https://solr.apache.org/guide/solr/latest/deployment-guide/zookeeper-access-control.html) documentation.
+
 ## Deployment with Docker Compose
 
 ### 1. Choose the host library path

--- a/src/redis/redis.conf
+++ b/src/redis/redis.conf
@@ -19,6 +19,14 @@ loglevel warning
 # Evict least-recently-used keys when the container memory limit is reached.
 maxmemory-policy allkeys-lru
 
+# ── Background-Save Error Handling ────────────────────────────────────────────
+# When vm.overcommit_memory is not set to 1 on the Docker host, Redis
+# background saves (RDB snapshots) may fail.  By default Redis then refuses
+# all writes until a successful save occurs.  Disabling this flag keeps the
+# service available; operators should still enable overcommit on the host
+# (see docs/admin-manual.md – Host Prerequisites).
+stop-writes-on-bgsave-error no
+
 # ── Dangerous Command Restrictions ───────────────────────────────────────────
 # Rename dangerous commands to the empty string, making them completely
 # unavailable to ALL clients.  This mitigates:


### PR DESCRIPTION
## Summary

Addresses pre-release infrastructure warnings from Redis and ZooKeeper.

### Redis (#1368)
- Added `stop-writes-on-bgsave-error no` to `src/redis/redis.conf` so Redis remains writable when the host lacks `vm.overcommit_memory=1`
- Fixed typo in docker-compose.yml comment (`importnant` → `important`)
- Added **Host Prerequisites** section to `docs/admin-manual.md` documenting the host-level sysctl fix

### ZooKeeper/Solr (#1369)
- Added `ZOO_MAX_CLIENT_CNXNS: "60"` to zoo1, zoo2, zoo3 in both `docker-compose.yml` and `docker-compose.prod.yml`
- Documented ZooKeeper ACL hardening as a production step in admin-manual.md (no implementation change)

Closes #1368, Closes #1369