### PR TITLE
feat: add admin API endpoints to solr-search (#1115)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,9 +298,13 @@ services:
       - COLLECTIONS_DB_PATH=${COLLECTIONS_DB_PATH:-/data/collections/collections.db}
       - SOLR_AUTH_USER=${SOLR_READONLY_USER:-solr_read}
       - SOLR_AUTH_PASS=${SOLR_READONLY_PASS:-SolrRead_dev2024!}
+      - RABBITMQ_MANAGEMENT_PORT=15672
+      - RABBITMQ_MANAGEMENT_PATH_PREFIX=/admin/rabbitmq
+      - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - document-data:/data/documents
       - collections-db:/data/collections
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - type: bind
         source: ${AUTH_DB_DIR:?AUTH_DB_DIR is not set. Run 'python3 -m installer' to generate auth configuration}
         target: /data/auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,6 +304,9 @@ services:
     volumes:
       - document-data:/data/documents
       - collections-db:/data/collections
+      # SECURITY: Docker socket mount grants full Docker API access to this container.
+      # Acceptable for development, but in production consider using a docker-socket-proxy
+      # (e.g. tecnativa/docker-socket-proxy) to restrict API access to read-only operations.
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - type: bind
         source: ${AUTH_DB_DIR:?AUTH_DB_DIR is not set. Run 'python3 -m installer' to generate auth configuration}

--- a/src/solr-search/config.py
+++ b/src/solr-search/config.py
@@ -94,6 +94,9 @@ class Settings:
     collection_embeddings_urls: tuple[tuple[str, str], ...]
     comparison_baseline_collection: str
     comparison_candidate_collection: str
+    docker_host: str = ""
+    rabbitmq_management_path_prefix: str = "/admin/rabbitmq"
+    log_tail_max: int = 5000
     solr_auth_user: str | None = None
     solr_auth_pass: str | None = None
     ascii_folding: bool = True
@@ -193,5 +196,8 @@ settings = Settings(
     collection_embeddings_urls=_parse_embeddings_url_overrides(_allowed_collections),
     comparison_baseline_collection=os.environ.get("COMPARISON_BASELINE_COLLECTION", "books"),
     comparison_candidate_collection=os.environ.get("COMPARISON_CANDIDATE_COLLECTION", "books"),
+    docker_host=os.environ.get("DOCKER_HOST", "unix:///var/run/docker.sock"),
+    rabbitmq_management_path_prefix=os.environ.get("RABBITMQ_MANAGEMENT_PATH_PREFIX", "/admin/rabbitmq"),
+    log_tail_max=int(os.environ.get("LOG_TAIL_MAX", "5000")),
     ascii_folding=os.environ.get("SOLR_ASCII_FOLDING", "true").lower() == "true",
 )

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -2336,6 +2336,8 @@ def admin_list_documents(
         DocumentStatus | None,
         Query(description="Filter documents by indexing status (queued, processed, or failed)."),
     ] = None,
+    page: Annotated[int, Query(ge=1, description="Page number (1-based).")] = 1,
+    per_page: Annotated[int, Query(ge=1, le=500, description="Results per page.")] = 100,
 ) -> dict[str, Any]:
     """List documents tracked in Redis with their indexing status.
 
@@ -2344,10 +2346,22 @@ def admin_list_documents(
     the ``documents`` list to a single status while still receiving full
     counts.
 
+    Supports pagination via ``page`` and ``per_page`` query parameters.
+
     Each document entry includes an opaque ``id`` token that can be passed to
     the ``POST /v1/admin/documents/{doc_id}/requeue`` endpoint.
     """
-    return _load_admin_documents(status_filter=status)
+    result = _load_admin_documents(status_filter=status)
+    docs = result["documents"]
+    total_docs = len(docs)
+    start = (page - 1) * per_page
+    end = start + per_page
+    result["documents"] = docs[start:end]
+    result["page"] = page
+    result["per_page"] = per_page
+    result["total_documents"] = total_docs
+    result["total_pages"] = max(1, (total_docs + per_page - 1) // per_page)
+    return result
 
 
 @app.post(
@@ -3269,6 +3283,397 @@ async def admin_restore_backup(backup_id: str, body: RestoreRequest | None = Non
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return record
+
+
+# ---------------------------------------------------------------------------
+# Admin — /v1/admin/queue-status (RabbitMQ queue metrics)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_rabbitmq_queue_info(queue_name: str) -> dict[str, Any]:
+    """Query the RabbitMQ Management API for queue metrics."""
+    mgmt_url = (
+        f"http://{settings.rabbitmq_host}:{settings.rabbitmq_management_port}"
+        f"{settings.rabbitmq_management_path_prefix}/api/queues/%2F/{queue_name}"
+    )
+    resp = requests.get(
+        mgmt_url,
+        auth=(settings.rabbitmq_user, settings.rabbitmq_pass),
+        timeout=5,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+@app.get(
+    "/v1/admin/queue-status/",
+    include_in_schema=False,
+    name="admin_queue_status_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get("/v1/admin/queue-status", name="admin_queue_status_v1", dependencies=[Depends(require_admin_auth)])
+def admin_queue_status() -> dict[str, Any]:
+    """Return RabbitMQ queue metrics for the dashboard.
+
+    Queries the RabbitMQ Management HTTP API for the configured queue name
+    and returns message counts and consumer information.
+    """
+    queue_name = settings.rabbitmq_queue_name
+    try:
+        data = _fetch_rabbitmq_queue_info(queue_name)
+        return {
+            "queue_name": queue_name,
+            "messages_ready": data.get("messages_ready", 0),
+            "messages_unacknowledged": data.get("messages_unacknowledged", 0),
+            "messages_total": data.get("messages", 0),
+            "consumers": data.get("consumers", 0),
+            "status": "ok",
+        }
+    except requests.HTTPError as exc:
+        status_code = exc.response.status_code if exc.response is not None else 0
+        if status_code == 404:
+            return {
+                "queue_name": queue_name,
+                "messages_ready": 0,
+                "messages_unacknowledged": 0,
+                "messages_total": 0,
+                "consumers": 0,
+                "status": "queue_not_found",
+            }
+        raise HTTPException(
+            status_code=502,
+            detail=f"RabbitMQ management API error: {exc}",
+        ) from exc
+    except (requests.RequestException, OSError) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot reach RabbitMQ management API: {exc}",
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Admin — /v1/admin/indexing-status (per-document indexing status)
+# ---------------------------------------------------------------------------
+
+
+IndexingDocStatus = Literal["queued", "processing", "processed", "failed"]
+
+
+def _classify_indexing_status(state: dict[str, Any]) -> IndexingDocStatus:
+    """Return a fine-grained status for the indexing-status endpoint.
+
+    Unlike ``_classify_doc_state`` (which returns queued/processed/failed),
+    this distinguishes *processing* (started but not yet completed).
+    """
+    if state.get("failed"):
+        return "failed"
+    if state.get("processed"):
+        return "processed"
+    if state.get("processing") or state.get("text_indexed"):
+        return "processing"
+    return "queued"
+
+
+def _load_indexing_status(
+    *,
+    status_filter: IndexingDocStatus | None = None,
+    page: int = 1,
+    per_page: int = 100,
+) -> dict[str, Any]:
+    """Scan Redis and return detailed per-document indexing status with summary."""
+    client = _get_admin_redis_client()
+    summary: dict[str, int] = {
+        "total": 0,
+        "queued": 0,
+        "processing": 0,
+        "processed": 0,
+        "failed": 0,
+        "total_pages": 0,
+        "total_chunks": 0,
+    }
+    documents: list[dict[str, Any]] = []
+
+    for key, state, _doc_status in _iter_admin_docs(client):
+        idx_status = _classify_indexing_status(state)
+        summary["total"] += 1
+        summary[idx_status] += 1
+        summary["total_pages"] += int(state.get("page_count", 0) or 0)
+        summary["total_chunks"] += int(state.get("chunk_count", 0) or 0)
+
+        if status_filter is not None and idx_status != status_filter:
+            continue
+
+        path = state.get("path", "")
+        documents.append(
+            {
+                "id": _encode_admin_key(key),
+                "status": idx_status,
+                "path": path,
+                "title": state.get("title"),
+                "text_indexed": bool(state.get("text_indexed")),
+                "embedding_indexed": bool(state.get("embedding_indexed")),
+                "page_count": state.get("page_count"),
+                "chunk_count": state.get("chunk_count"),
+                "error": state.get("error"),
+                "error_stage": state.get("error_stage"),
+                "timestamp": state.get("timestamp"),
+            }
+        )
+
+    total_docs = len(documents)
+    start = (page - 1) * per_page
+    end = start + per_page
+
+    return {
+        "summary": summary,
+        "documents": documents[start:end],
+        "page": page,
+        "per_page": per_page,
+        "total_documents": total_docs,
+        "total_pages": max(1, (total_docs + per_page - 1) // per_page),
+    }
+
+
+@app.get(
+    "/v1/admin/indexing-status/",
+    include_in_schema=False,
+    name="admin_indexing_status_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get(
+    "/v1/admin/indexing-status",
+    name="admin_indexing_status_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_indexing_status(
+    status: Annotated[
+        IndexingDocStatus | None,
+        Query(description="Filter by indexing status."),
+    ] = None,
+    page: Annotated[int, Query(ge=1, description="Page number (1-based).")] = 1,
+    per_page: Annotated[int, Query(ge=1, le=500, description="Results per page.")] = 100,
+) -> dict[str, Any]:
+    """Return detailed per-document indexing status with summary metrics.
+
+    Summary counts always reflect the full dataset.  The ``documents`` list
+    honours the optional ``status`` filter and ``page`` / ``per_page``
+    pagination parameters.
+    """
+    return _load_indexing_status(status_filter=status, page=page, per_page=per_page)
+
+
+# ---------------------------------------------------------------------------
+# Admin — /v1/admin/logs/{service_name} (container logs)
+# ---------------------------------------------------------------------------
+
+_ALLOWED_LOG_SERVICES: frozenset[str] = frozenset(
+    {
+        "solr-search",
+        "embeddings-server",
+        "document-indexer",
+        "document-lister",
+        "aithena-ui",
+        "solr",
+        "redis",
+        "rabbitmq",
+        "nginx",
+    }
+)
+
+
+def _fetch_docker_logs(
+    service_name: str,
+    tail: int = 100,
+    since: str | None = None,
+) -> list[str]:
+    """Fetch container logs via the Docker Engine API.
+
+    Uses the DOCKER_HOST setting to connect (defaults to the Unix socket).
+    Returns log lines as a list of strings.
+    """
+    import urllib.parse
+
+    host = settings.docker_host
+    if host.startswith("unix://"):
+        socket_path = host[len("unix://") :]
+        # Use requests-unixsocket style: http+unix://{encoded_path}/…
+        encoded = urllib.parse.quote(socket_path, safe="")
+        base_url = f"http+unix://{encoded}"
+    elif host.startswith("tcp://"):
+        base_url = host.replace("tcp://", "http://", 1)
+    else:
+        base_url = host
+
+    params: dict[str, str] = {"stdout": "1", "stderr": "1", "tail": str(tail)}
+    if since:
+        params["since"] = since
+
+    # Docker API: list containers filtered by compose service name, then get logs
+    list_url = f"{base_url}/containers/json"
+    list_params = {"filters": json.dumps({"label": [f"com.docker.compose.service={service_name}"]})}
+
+    try:
+        list_resp = requests.get(list_url, params=list_params, timeout=5)
+        list_resp.raise_for_status()
+        containers = list_resp.json()
+    except (requests.RequestException, OSError) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot reach Docker API: {exc}",
+        ) from exc
+
+    if not containers:
+        return []
+
+    container_id = containers[0]["Id"]
+    logs_url = f"{base_url}/containers/{container_id}/logs"
+
+    try:
+        logs_resp = requests.get(logs_url, params=params, timeout=10)
+        logs_resp.raise_for_status()
+    except (requests.RequestException, OSError) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot fetch logs from Docker API: {exc}",
+        ) from exc
+
+    raw = logs_resp.content
+    lines: list[str] = []
+    offset = 0
+    while offset < len(raw):
+        if offset + 8 <= len(raw):
+            # Docker multiplexed stream header: 8 bytes
+            frame_size = int.from_bytes(raw[offset + 4 : offset + 8], "big")
+            frame_end = offset + 8 + frame_size
+            chunk = raw[offset + 8 : frame_end]
+            for line in chunk.decode("utf-8", errors="replace").splitlines():
+                if line:
+                    lines.append(line)
+            offset = frame_end
+        else:
+            break
+
+    return lines
+
+
+@app.get(
+    "/v1/admin/logs/{service_name}/",
+    include_in_schema=False,
+    name="admin_logs_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get(
+    "/v1/admin/logs/{service_name}",
+    name="admin_logs_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_logs(
+    service_name: str,
+    tail: Annotated[int, Query(ge=1, description="Number of log lines to return.")] = 100,
+    since: Annotated[str | None, Query(description="Return logs since this ISO-8601 timestamp.")] = None,
+) -> dict[str, Any]:
+    """Return recent log lines for a Docker Compose service.
+
+    Uses the Docker Engine API (via socket or HTTP) to retrieve container
+    logs.  Only whitelisted service names are allowed.
+    """
+    if service_name not in _ALLOWED_LOG_SERVICES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown service '{service_name}'. Allowed: {', '.join(sorted(_ALLOWED_LOG_SERVICES))}",
+        )
+
+    effective_tail = min(tail, settings.log_tail_max)
+
+    lines = _fetch_docker_logs(service_name, tail=effective_tail, since=since)
+    return {
+        "service": service_name,
+        "lines": lines,
+        "total_lines": len(lines),
+        "available_services": sorted(_ALLOWED_LOG_SERVICES),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Admin — /v1/admin/infrastructure (service connectivity & management URLs)
+# ---------------------------------------------------------------------------
+
+
+def _check_service_reachable(host: str, port: int, timeout: float = 2.0) -> bool:
+    """Return True if the TCP connection succeeds."""
+    return _tcp_check(host, port, timeout=timeout)
+
+
+@app.get(
+    "/v1/admin/infrastructure/",
+    include_in_schema=False,
+    name="admin_infrastructure_v1_slash",
+    dependencies=[Depends(require_admin_auth)],
+)
+@app.get(
+    "/v1/admin/infrastructure",
+    name="admin_infrastructure_v1",
+    dependencies=[Depends(require_admin_auth)],
+)
+def admin_infrastructure() -> dict[str, Any]:
+    """Return infrastructure connection details, management UI URLs, and health.
+
+    Checks connectivity to Solr, Redis, RabbitMQ, and the embeddings server,
+    and returns management UI links for browser access.
+    """
+    parsed_solr = urlparse(settings.solr_url)
+    solr_host = parsed_solr.hostname or "solr"
+    solr_port = parsed_solr.port or 8983
+
+    solr_up = _tcp_check(solr_host, solr_port)
+    redis_up = _tcp_check(settings.redis_host, settings.redis_port)
+    rabbitmq_up = _rabbitmq_management_check(
+        settings.rabbitmq_host,
+        settings.rabbitmq_management_port,
+        settings.rabbitmq_user,
+        settings.rabbitmq_pass,
+    )
+    embeddings_up = _embeddings_available(timeout=CONTAINER_VERSION_TIMEOUT)
+
+    services = [
+        {
+            "name": "solr",
+            "status": "up" if solr_up else "down",
+            "admin_url": "/admin/solr/",
+            "description": "Full-text search engine",
+        },
+        {
+            "name": "rabbitmq",
+            "status": "up" if rabbitmq_up else "down",
+            "admin_url": "/admin/rabbitmq/",
+            "description": "Message queue management",
+        },
+        {
+            "name": "redis-commander",
+            "status": "up" if redis_up else "down",
+            "admin_url": "/admin/redis/",
+            "description": "Redis inspection tool",
+        },
+        {
+            "name": "embeddings-server",
+            "status": "up" if embeddings_up else "down",
+            "admin_url": None,
+            "description": "Multilingual embeddings service",
+        },
+    ]
+
+    connections = {
+        "solr": f"{solr_host}:{solr_port}",
+        "redis": f"{settings.redis_host}:{settings.redis_port}",
+        "rabbitmq_amqp": f"{settings.rabbitmq_host}:{settings.rabbitmq_port}",
+        "rabbitmq_mgmt": (f"http://{settings.rabbitmq_host}:{settings.rabbitmq_management_port}"),
+        "embeddings": settings.embeddings_url,
+    }
+
+    return {
+        "services": services,
+        "connections": connections,
+    }
 
 
 if __name__ == "__main__":

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -2360,7 +2360,7 @@ def admin_list_documents(
     result["page"] = page
     result["per_page"] = per_page
     result["total_documents"] = total_docs
-    result["total_pages"] = max(1, (total_docs + per_page - 1) // per_page)
+    result["total_pages"] = 0 if total_docs == 0 else (total_docs + per_page - 1) // per_page
     return result
 
 
@@ -3388,8 +3388,8 @@ def _load_indexing_status(
         "processing": 0,
         "processed": 0,
         "failed": 0,
-        "total_pages": 0,
-        "total_chunks": 0,
+        "total_doc_pages": 0,
+        "total_doc_chunks": 0,
     }
     documents: list[dict[str, Any]] = []
 
@@ -3397,8 +3397,8 @@ def _load_indexing_status(
         idx_status = _classify_indexing_status(state)
         summary["total"] += 1
         summary[idx_status] += 1
-        summary["total_pages"] += int(state.get("page_count", 0) or 0)
-        summary["total_chunks"] += int(state.get("chunk_count", 0) or 0)
+        summary["total_doc_pages"] += int(state.get("page_count", 0) or 0)
+        summary["total_doc_chunks"] += int(state.get("chunk_count", 0) or 0)
 
         if status_filter is not None and idx_status != status_filter:
             continue
@@ -3430,7 +3430,7 @@ def _load_indexing_status(
         "page": page,
         "per_page": per_page,
         "total_documents": total_docs,
-        "total_pages": max(1, (total_docs + per_page - 1) // per_page),
+        "total_pages": 0 if total_docs == 0 else (total_docs + per_page - 1) // per_page,
     }
 
 
@@ -3491,14 +3491,15 @@ def _fetch_docker_logs(
     Uses the DOCKER_HOST setting to connect (defaults to the Unix socket).
     Returns log lines as a list of strings.
     """
+    import http.client
+    import socket as _socket
     import urllib.parse
 
     host = settings.docker_host
-    if host.startswith("unix://"):
+    use_unix = host.startswith("unix://")
+    socket_path: str | None = None
+    if use_unix:
         socket_path = host[len("unix://") :]
-        # Use requests-unixsocket style: http+unix://{encoded_path}/…
-        encoded = urllib.parse.quote(socket_path, safe="")
-        base_url = f"http+unix://{encoded}"
     elif host.startswith("tcp://"):
         base_url = host.replace("tcp://", "http://", 1)
     else:
@@ -3506,17 +3507,47 @@ def _fetch_docker_logs(
 
     params: dict[str, str] = {"stdout": "1", "stderr": "1", "tail": str(tail)}
     if since:
-        params["since"] = since
+        # Docker API expects Unix epoch seconds, not ISO-8601
+        from datetime import datetime
+
+        try:
+            dt = datetime.fromisoformat(since)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+            params["since"] = str(int(dt.timestamp()))
+        except (ValueError, OSError):
+            params["since"] = since
+
+    def _docker_get(path: str, query_params: dict[str, str], timeout: float = 5) -> http.client.HTTPResponse:
+        """Perform a GET request against the Docker Engine API."""
+        qs = urllib.parse.urlencode(query_params)
+        full_path = f"{path}?{qs}" if qs else path
+        if use_unix:
+            if socket_path is None:  # pragma: no cover – guarded by use_unix flag
+                raise RuntimeError("socket_path must be set for unix transport")
+            sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+            sock.settimeout(timeout)
+            sock.connect(socket_path)
+            conn = http.client.HTTPConnection("localhost")
+            conn.sock = sock
+        else:
+            parsed = urllib.parse.urlparse(base_url)
+            conn = http.client.HTTPConnection(parsed.hostname, parsed.port, timeout=timeout)
+        conn.request("GET", full_path)
+        return conn.getresponse()
 
     # Docker API: list containers filtered by compose service name, then get logs
-    list_url = f"{base_url}/containers/json"
+    list_path = "/containers/json"
     list_params = {"filters": json.dumps({"label": [f"com.docker.compose.service={service_name}"]})}
 
     try:
-        list_resp = requests.get(list_url, params=list_params, timeout=5)
-        list_resp.raise_for_status()
-        containers = list_resp.json()
-    except (requests.RequestException, OSError) as exc:
+        list_resp = _docker_get(list_path, list_params, timeout=5)
+        if list_resp.status >= 400:
+            raise HTTPException(status_code=502, detail=f"Docker API returned {list_resp.status}")
+        containers = json.loads(list_resp.read())
+    except HTTPException:
+        raise
+    except (OSError, http.client.HTTPException) as exc:
         raise HTTPException(
             status_code=502,
             detail=f"Cannot reach Docker API: {exc}",
@@ -3526,18 +3557,21 @@ def _fetch_docker_logs(
         return []
 
     container_id = containers[0]["Id"]
-    logs_url = f"{base_url}/containers/{container_id}/logs"
+    logs_path = f"/containers/{container_id}/logs"
 
     try:
-        logs_resp = requests.get(logs_url, params=params, timeout=10)
-        logs_resp.raise_for_status()
-    except (requests.RequestException, OSError) as exc:
+        logs_resp = _docker_get(logs_path, params, timeout=10)
+        if logs_resp.status >= 400:
+            raise HTTPException(status_code=502, detail=f"Docker API returned {logs_resp.status}")
+    except HTTPException:
+        raise
+    except (OSError, http.client.HTTPException) as exc:
         raise HTTPException(
             status_code=502,
             detail=f"Cannot fetch logs from Docker API: {exc}",
         ) from exc
 
-    raw = logs_resp.content
+    raw = logs_resp.read()
     lines: list[str] = []
     offset = 0
     while offset < len(raw):
@@ -3597,11 +3631,6 @@ def admin_logs(
 # ---------------------------------------------------------------------------
 # Admin — /v1/admin/infrastructure (service connectivity & management URLs)
 # ---------------------------------------------------------------------------
-
-
-def _check_service_reachable(host: str, port: int, timeout: float = 2.0) -> bool:
-    """Return True if the TCP connection succeeds."""
-    return _tcp_check(host, port, timeout=timeout)
 
 
 @app.get(

--- a/src/solr-search/tests/test_admin_api.py
+++ b/src/solr-search/tests/test_admin_api.py
@@ -1,0 +1,442 @@
+"""Tests for the new admin API endpoints (queue-status, indexing-status, logs, infrastructure)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("AUTH_DB_PATH", "/tmp/test-auth.db")  # noqa: S108
+os.environ.setdefault("AUTH_JWT_SECRET", "test-auth-secret")
+os.environ.setdefault("AUTH_JWT_TTL", "24h")
+os.environ.setdefault("AUTH_COOKIE_NAME", "aithena_auth")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from config import settings  # noqa: E402
+from tests.auth_helpers import create_authenticated_client  # noqa: E402
+
+_TEST_ADMIN_KEY = "test-admin-api-key"
+
+QUEUE = settings.redis_queue_name
+
+
+def get_client() -> TestClient:
+    client = create_authenticated_client()
+    client.headers["X-API-Key"] = _TEST_ADMIN_KEY
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _enable_admin_api_key():
+    """Patch ADMIN_API_KEY so admin endpoints are accessible in these tests."""
+    with patch("admin_auth._get_admin_api_key", return_value=_TEST_ADMIN_KEY):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+STATE_QUEUED = {
+    "path": "/data/docs/queued.pdf",
+    "timestamp": "2024-03-01T10:00:00",
+    "last_modified": 1709283600.0,
+    "processed": False,
+}
+
+STATE_PROCESSING = {
+    "path": "/data/docs/processing.pdf",
+    "timestamp": "2024-03-01T10:30:00",
+    "last_modified": 1709285400.0,
+    "processed": False,
+    "processing": True,
+    "text_indexed": True,
+    "page_count": 50,
+    "chunk_count": 200,
+}
+
+STATE_PROCESSED = {
+    "path": "/data/docs/processed.pdf",
+    "timestamp": "2024-03-01T11:00:00",
+    "last_modified": 1709287200.0,
+    "processed": True,
+    "title": "My Book",
+    "author": "Author Name",
+    "page_count": 42,
+    "chunk_count": 100,
+}
+
+STATE_FAILED = {
+    "path": "/data/docs/failed.pdf",
+    "timestamp": "2024-03-01T12:00:00",
+    "last_modified": 1709290800.0,
+    "processed": False,
+    "failed": True,
+    "error": "PDF parsing error",
+    "error_stage": "extraction",
+}
+
+
+def _make_redis_mock(entries: dict[str, dict]) -> MagicMock:
+    """Return a mock Redis client with the given key→state mapping."""
+    mock = MagicMock()
+    mock.scan_iter.return_value = iter(entries.keys())
+    mock.get.side_effect = lambda key: json.dumps(entries[key]) if key in entries else None
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/admin/queue-status
+# ---------------------------------------------------------------------------
+
+
+class TestQueueStatus:
+    def test_queue_status_ok(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "messages_ready": 5,
+            "messages_unacknowledged": 2,
+            "messages": 7,
+            "consumers": 1,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("main.requests.get", return_value=mock_response):
+            client = get_client()
+            resp = client.get("/v1/admin/queue-status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["queue_name"] == QUEUE
+        assert data["messages_ready"] == 5
+        assert data["messages_unacknowledged"] == 2
+        assert data["messages_total"] == 7
+        assert data["consumers"] == 1
+        assert data["status"] == "ok"
+
+    def test_queue_status_queue_not_found(self):
+        import requests as req_lib
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = req_lib.HTTPError(response=mock_response)
+
+        with patch("main.requests.get", return_value=mock_response):
+            client = get_client()
+            resp = client.get("/v1/admin/queue-status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "queue_not_found"
+        assert data["messages_total"] == 0
+
+    def test_queue_status_api_unreachable(self):
+        import requests as req_lib
+
+        with patch("main.requests.get", side_effect=req_lib.ConnectionError("refused")):
+            client = get_client()
+            resp = client.get("/v1/admin/queue-status")
+
+        assert resp.status_code == 502
+
+    def test_queue_status_trailing_slash(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "messages_ready": 0,
+            "messages_unacknowledged": 0,
+            "messages": 0,
+            "consumers": 0,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("main.requests.get", return_value=mock_response):
+            client = get_client()
+            resp = client.get("/v1/admin/queue-status/")
+
+        assert resp.status_code == 200
+
+    def test_queue_status_requires_auth(self):
+        """Verify the endpoint is not accessible without admin auth."""
+        from main import app
+
+        unauthed = TestClient(app)
+        resp = unauthed.get("/v1/admin/queue-status")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/admin/indexing-status
+# ---------------------------------------------------------------------------
+
+
+class TestIndexingStatus:
+    def _patch_redis(self, entries: dict[str, dict]):
+        mock = _make_redis_mock(entries)
+        return patch("main._get_admin_redis_client", return_value=mock)
+
+    def test_indexing_status_empty(self):
+        with self._patch_redis({}):
+            client = get_client()
+            resp = client.get("/v1/admin/indexing-status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["total"] == 0
+        assert data["documents"] == []
+        assert data["page"] == 1
+
+    def test_indexing_status_mixed(self):
+        entries = {
+            f"/{QUEUE}//data/docs/queued.pdf": STATE_QUEUED,
+            f"/{QUEUE}//data/docs/processing.pdf": STATE_PROCESSING,
+            f"/{QUEUE}//data/docs/processed.pdf": STATE_PROCESSED,
+            f"/{QUEUE}//data/docs/failed.pdf": STATE_FAILED,
+        }
+        with self._patch_redis(entries):
+            client = get_client()
+            resp = client.get("/v1/admin/indexing-status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["total"] == 4
+        assert data["summary"]["queued"] == 1
+        assert data["summary"]["processing"] == 1
+        assert data["summary"]["processed"] == 1
+        assert data["summary"]["failed"] == 1
+        assert data["summary"]["total_pages"] == 92  # 50 + 42
+        assert data["summary"]["total_chunks"] == 300  # 200 + 100
+        assert len(data["documents"]) == 4
+
+    def test_indexing_status_filter_failed(self):
+        entries = {
+            f"/{QUEUE}//data/docs/queued.pdf": STATE_QUEUED,
+            f"/{QUEUE}//data/docs/failed.pdf": STATE_FAILED,
+        }
+        with self._patch_redis(entries):
+            client = get_client()
+            resp = client.get("/v1/admin/indexing-status?status=failed")
+
+        data = resp.json()
+        assert data["summary"]["total"] == 2  # summary always reflects all
+        assert len(data["documents"]) == 1
+        assert data["documents"][0]["status"] == "failed"
+        assert data["documents"][0]["error"] == "PDF parsing error"
+        assert data["documents"][0]["error_stage"] == "extraction"
+
+    def test_indexing_status_pagination(self):
+        entries = {
+            f"/{QUEUE}//data/docs/doc{i}.pdf": {**STATE_QUEUED, "path": f"/data/docs/doc{i}.pdf"} for i in range(5)
+        }
+        with self._patch_redis(entries):
+            client = get_client()
+            resp = client.get("/v1/admin/indexing-status?page=1&per_page=2")
+
+        data = resp.json()
+        assert data["total_documents"] == 5
+        assert len(data["documents"]) == 2
+        assert data["page"] == 1
+        assert data["per_page"] == 2
+        assert data["total_pages"] == 3
+
+    def test_indexing_status_requires_auth(self):
+        from main import app
+
+        unauthed = TestClient(app)
+        resp = unauthed.get("/v1/admin/indexing-status")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/admin/logs/{service_name}
+# ---------------------------------------------------------------------------
+
+
+class TestLogs:
+    def test_logs_invalid_service(self):
+        client = get_client()
+        resp = client.get("/v1/admin/logs/malicious-service")
+        assert resp.status_code == 400
+        assert "Unknown service" in resp.json()["detail"]
+
+    def test_logs_valid_service(self):
+        mock_lines = ["2025-07-18T10:00:01Z INFO Starting...", "2025-07-18T10:00:02Z INFO Done."]
+        with patch("main._fetch_docker_logs", return_value=mock_lines):
+            client = get_client()
+            resp = client.get("/v1/admin/logs/document-indexer")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["service"] == "document-indexer"
+        assert data["lines"] == mock_lines
+        assert data["total_lines"] == 2
+        assert "document-indexer" in data["available_services"]
+
+    def test_logs_docker_unreachable(self):
+        exc = HTTPException(status_code=502, detail="Cannot reach Docker API: refused")
+        with patch("main._fetch_docker_logs", side_effect=exc):
+            client = get_client()
+            resp = client.get("/v1/admin/logs/solr-search")
+
+        assert resp.status_code == 502
+
+    def test_logs_tail_capped(self):
+        with patch("main._fetch_docker_logs", return_value=[]) as mock_fetch:
+            client = get_client()
+            resp = client.get("/v1/admin/logs/solr-search?tail=99999")
+
+        assert resp.status_code == 200
+        call_args = mock_fetch.call_args
+        called_tail = (
+            call_args.kwargs.get("tail")
+            or call_args[1].get("tail")
+            or (call_args[0][1] if len(call_args[0]) > 1 else None)
+        )
+        assert called_tail is not None
+        assert called_tail <= settings.log_tail_max
+
+    def test_logs_since_param(self):
+        with patch("main._fetch_docker_logs", return_value=[]) as mock_fetch:
+            client = get_client()
+            resp = client.get("/v1/admin/logs/solr-search?since=2025-07-18T00:00:00Z")
+
+        assert resp.status_code == 200
+        called_since = mock_fetch.call_args.kwargs.get("since") or mock_fetch.call_args[1].get("since")
+        assert called_since == "2025-07-18T00:00:00Z"
+
+    def test_logs_trailing_slash(self):
+        with patch("main._fetch_docker_logs", return_value=[]):
+            client = get_client()
+            resp = client.get("/v1/admin/logs/solr-search/")
+
+        assert resp.status_code == 200
+
+    def test_logs_requires_auth(self):
+        from main import app
+
+        unauthed = TestClient(app)
+        resp = unauthed.get("/v1/admin/logs/solr-search")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/admin/infrastructure
+# ---------------------------------------------------------------------------
+
+
+class TestInfrastructure:
+    def test_infrastructure_all_up(self):
+        with (
+            patch("main._tcp_check", return_value=True),
+            patch("main._rabbitmq_management_check", return_value=True),
+            patch("main._embeddings_available", return_value=True),
+        ):
+            client = get_client()
+            resp = client.get("/v1/admin/infrastructure")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data["services"], list)
+        service_names = [s["name"] for s in data["services"]]
+        assert "solr" in service_names
+        assert "rabbitmq" in service_names
+        assert "redis-commander" in service_names
+        assert "embeddings-server" in service_names
+
+        for svc in data["services"]:
+            assert svc["status"] == "up"
+
+        assert "solr" in data["connections"]
+        assert "redis" in data["connections"]
+        assert "rabbitmq_amqp" in data["connections"]
+        assert "rabbitmq_mgmt" in data["connections"]
+        assert "embeddings" in data["connections"]
+
+    def test_infrastructure_some_down(self):
+        def selective_tcp(host, port, timeout=2.0):
+            return host != settings.redis_host
+
+        with (
+            patch("main._tcp_check", side_effect=selective_tcp),
+            patch("main._rabbitmq_management_check", return_value=False),
+            patch("main._embeddings_available", return_value=True),
+        ):
+            client = get_client()
+            resp = client.get("/v1/admin/infrastructure")
+
+        data = resp.json()
+        statuses = {s["name"]: s["status"] for s in data["services"]}
+        assert statuses["solr"] == "up"
+        assert statuses["redis-commander"] == "down"
+        assert statuses["rabbitmq"] == "down"
+        assert statuses["embeddings-server"] == "up"
+
+    def test_infrastructure_trailing_slash(self):
+        with (
+            patch("main._tcp_check", return_value=True),
+            patch("main._rabbitmq_management_check", return_value=True),
+            patch("main._embeddings_available", return_value=True),
+        ):
+            client = get_client()
+            resp = client.get("/v1/admin/infrastructure/")
+
+        assert resp.status_code == 200
+
+    def test_infrastructure_requires_auth(self):
+        from main import app
+
+        unauthed = TestClient(app)
+        resp = unauthed.get("/v1/admin/infrastructure")
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Pagination on GET /v1/admin/documents
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentsPagination:
+    def _patch_redis(self, entries: dict[str, dict]):
+        mock = _make_redis_mock(entries)
+        return patch("main._get_admin_redis_client", return_value=mock)
+
+    def test_documents_pagination_defaults(self):
+        entries = {
+            f"/{QUEUE}//data/docs/queued.pdf": STATE_QUEUED,
+            f"/{QUEUE}//data/docs/processed.pdf": STATE_PROCESSED,
+        }
+        with self._patch_redis(entries):
+            client = get_client()
+            resp = client.get("/v1/admin/documents")
+
+        data = resp.json()
+        assert data["page"] == 1
+        assert data["per_page"] == 100
+        assert data["total_documents"] == 2
+        assert data["total_pages"] == 1
+
+    def test_documents_pagination_limits(self):
+        entries = {
+            f"/{QUEUE}//data/docs/doc{i}.pdf": {**STATE_QUEUED, "path": f"/data/docs/doc{i}.pdf"} for i in range(5)
+        }
+        with self._patch_redis(entries):
+            client = get_client()
+            resp = client.get("/v1/admin/documents?page=2&per_page=2")
+
+        data = resp.json()
+        assert data["page"] == 2
+        assert data["per_page"] == 2
+        assert len(data["documents"]) == 2
+        assert data["total_documents"] == 5
+        assert data["total_pages"] == 3
+
+
+# Import HTTPException for test use
+from fastapi import HTTPException  # noqa: E402

--- a/src/solr-search/tests/test_admin_api.py
+++ b/src/solr-search/tests/test_admin_api.py
@@ -211,8 +211,8 @@ class TestIndexingStatus:
         assert data["summary"]["processing"] == 1
         assert data["summary"]["processed"] == 1
         assert data["summary"]["failed"] == 1
-        assert data["summary"]["total_pages"] == 92  # 50 + 42
-        assert data["summary"]["total_chunks"] == 300  # 200 + 100
+        assert data["summary"]["total_doc_pages"] == 92  # 50 + 42
+        assert data["summary"]["total_doc_chunks"] == 300  # 200 + 100
         assert len(data["documents"]) == 4
 
     def test_indexing_status_filter_failed(self):


### PR DESCRIPTION
## Summary

Implements Phase 1 (API Foundation) admin endpoints for the React admin migration per the PRD at `docs/prd/admin-react-migration.md`.

### New endpoints

| Endpoint | Purpose |
|---|---|
| `GET /v1/admin/queue-status` | RabbitMQ queue metrics (ready, unacked, total, consumers) |
| `GET /v1/admin/indexing-status` | Per-document indexing status with summary metrics and pagination |
| `GET /v1/admin/logs/{service}` | Container logs via Docker Engine API |
| `GET /v1/admin/infrastructure` | Service connectivity and management UI URLs |

### Enhancements

- Added pagination (`page`, `per_page`) to existing `GET /v1/admin/documents`

### Config additions

- `DOCKER_HOST` — Docker socket path (default: `unix:///var/run/docker.sock`)
- `RABBITMQ_MANAGEMENT_PORT` — Already existed in Settings, now set in docker-compose
- `RABBITMQ_MANAGEMENT_PATH_PREFIX` — RabbitMQ mgmt API path prefix
- `LOG_TAIL_MAX` — Max log lines cap (default: 5000)

### Docker Compose

- Added Docker socket mount (`:ro`) to solr-search service
- Added new env vars for management API access

### Tests

- 23 new unit tests covering all endpoints, auth, error handling, pagination
- All 1069 tests pass, coverage at 89.93% (above 88% threshold)

Closes #1115