### PR TITLE
fix: remove duplicate SOLR_VERSION key in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -556,7 +556,6 @@ services:
       - ./src/solr/log4j2.xml:/opt/solr/server/resources/log4j2.xml:ro
     environment:
       SOLR_VERSION: ${SOLR_VERSION:-9}
-      SOLR_VERSION: ${SOLR_VERSION:-9}
       SOLR_MODULES: extraction,langid
       ZK_HOST: "zoo1:2181,zoo2:2181,zoo3:2181"
       SOLR_SECURITY_MANAGER_ENABLED: "false"


### PR DESCRIPTION
Removes duplicate `SOLR_VERSION` environment key on line 559 of docker-compose.yml (solr2 service). The duplicate caused `docker compose config` to fail with `mapping key already defined`, blocking integration tests on the release PR #1485.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>