### PR TITLE
ci: add dev integration test workflow using single-node topology (#1496)

### DIFF
--- a/.github/workflows/dev-integration-test.yml
+++ b/.github/workflows/dev-integration-test.yml
@@ -1,0 +1,415 @@
+name: Dev Integration Test (Single-Node)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      build: ${{ steps.filter.outputs.build }}
+    steps:
+      - name: Check for build-relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO_NAME: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          NON_BUILD='^(\.squad/|\.github/(ISSUE_TEMPLATE|agents)/|docs/|[^/]*\.md$|LICENSE$|\.gitattributes$|\.gitignore$)'
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if ! CHANGED=$(gh api "repos/$REPO_NAME/pulls/$PR_NUMBER/files" \
+              --paginate --jq '.[].filename'); then
+              echo "Failed to fetch changed files — running all checks"
+              echo "build=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BUILD_FILES=$(echo "$CHANGED" | grep -v -E "$NON_BUILD" || true)
+
+          if [ -n "$BUILD_FILES" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            echo "Build-relevant changes detected"
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "⏭️ No build-relevant changes — skipping integration tests"
+          fi
+
+  run-integration-tests:
+    name: Run integration & E2E tests
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      issues: write
+    env:
+      E2E_LIBRARY_PATH: /tmp/aithena-e2e-library
+      CI_ADMIN_USERNAME: ci-admin
+      CI_ADMIN_PASSWORD: ci-password-ChangeMe123!
+      BASE_URL: http://localhost
+      FALLBACK_BASE_URL: http://localhost
+      SEARCH_API_URL: http://localhost:8080
+      SOLR_URL: http://localhost:8983/solr/books
+      HF_TOKEN: ${{ secrets.HF_TOKEN || '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: e2e/playwright/package-lock.json
+
+      - name: Bootstrap CI auth + compose overrides
+        run: |
+          mkdir -p "$E2E_LIBRARY_PATH"
+          mkdir -p "$RUNNER_TEMP/aithena-auth"
+
+          uv run --project src/solr-search python -m installer \
+            --library-path "$E2E_LIBRARY_PATH" \
+            --admin-user "$CI_ADMIN_USERNAME" \
+            --admin-password "$CI_ADMIN_PASSWORD" \
+            --origin "http://localhost" \
+            --auth-db-path "$RUNNER_TEMP/aithena-auth/users.db" \
+            --reset
+
+          # Export installer-generated credentials so later steps can use them.
+          # The installer writes random Solr passwords to .env; without this,
+          # the health-check step falls back to hardcoded dev defaults and gets 401.
+          if [ -f .env ]; then
+            grep -E '^(SOLR_ADMIN_USER|SOLR_ADMIN_PASS|SOLR_READONLY_USER|SOLR_READONLY_PASS|ADMIN_API_KEY)=' .env >> "$GITHUB_ENV" || true
+          fi
+
+          # Single-node topology override: disable solr2, solr3, zoo2, zoo3 using profiles
+          # and tmpfs volumes for faster startup.
+          cat > docker-compose.github-actions.yml <<'EOF'
+          volumes:
+            rabbitmq-data:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=100m" }
+            certbot-data-conf:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=10m" }
+            certbot-data-www:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=10m" }
+            redis-data:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=100m" }
+            solr-data:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=500m" }
+            zoo-data1_logs:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=50m" }
+            zoo-data1_data:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=50m" }
+            zoo-data1_datalog:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=50m" }
+            zoo-backup:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=50m" }
+            collections-db:
+              driver: local
+              driver_opts: { type: tmpfs, device: tmpfs, o: "size=50m" }
+
+          services:
+            # Single-node Solr: disable solr2 and solr3
+            solr2:
+              profiles: [disabled]
+            solr3:
+              profiles: [disabled]
+            # Single ZooKeeper: disable zoo2 and zoo3
+            zoo2:
+              profiles: [disabled]
+            zoo3:
+              profiles: [disabled]
+            # Reconfigure remaining ZooKeeper node for standalone mode
+            zoo1:
+              environment:
+                ZOO_SERVERS: server.1=zoo1:2888:3888;2181
+          EOF
+
+      - name: Generate sample PDF fixtures
+        run: |
+          python3 e2e/create-sample-docs.py "$E2E_LIBRARY_PATH"
+          find "$E2E_LIBRARY_PATH" -maxdepth 2 -type f -name '*.pdf' -printf '%P\n' | sort
+
+      - name: Validate merged Docker Compose config
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.dev-ports.yml \
+            -f docker/compose.e2e.yml \
+            -f docker-compose.github-actions.yml \
+            --profile production \
+            config >/dev/null
+
+      - name: Build all container images
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.dev-ports.yml \
+            -f docker/compose.e2e.yml \
+            -f docker-compose.github-actions.yml \
+            --profile production \
+            build
+
+      - name: Start single-node stack
+        env:
+          ADMIN_API_KEY: ci-admin-api-key
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.dev-ports.yml \
+            -f docker/compose.e2e.yml \
+            -f docker-compose.github-actions.yml \
+            --profile production \
+            up -d
+
+      - name: Wait for services to become healthy
+        run: |
+          # Solr admin credentials (defaults from docker-compose.yml)
+          SOLR_ADMIN_USER="${SOLR_ADMIN_USER:-solr_admin}"
+          SOLR_ADMIN_PASS="${SOLR_ADMIN_PASS:-SolrAdmin_dev2024!}"
+
+          wait_for_url() {
+            local url="$1"
+            local label="$2"
+            local attempts="${3:-60}"
+            local sleep_seconds="${4:-5}"
+            local auth="${5:-}"
+
+            for ((attempt=1; attempt<=attempts; attempt+=1)); do
+              if [ -n "$auth" ]; then
+                curl_result=$(curl --fail --silent --show-error -u "$auth" "$url" 2>&1) && {
+                  echo "$label is ready ($url)"
+                  return 0
+                }
+              else
+                curl_result=$(curl --fail --silent --show-error "$url" 2>&1) && {
+                  echo "$label is ready ($url)"
+                  return 0
+                }
+              fi
+
+              echo "[$attempt/$attempts] Waiting for $label at $url"
+              sleep "$sleep_seconds"
+            done
+
+            echo "$label did not become ready in time ($url)" >&2
+            return 1
+          }
+
+          wait_for_solr_cluster() {
+            local attempts="${1:-30}"
+            local sleep_seconds="${2:-10}"
+
+            for ((attempt=1; attempt<=attempts; attempt+=1)); do
+              status=$(curl --fail --silent \
+                -u "${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}" \
+                "http://localhost:8983/solr/admin/collections?action=CLUSTERSTATUS&wt=json" \
+                2>/dev/null) || true
+
+              if echo "$status" | python3 -c "
+          import json, sys
+          try:
+              data = json.load(sys.stdin)
+              colls = data.get('cluster', {}).get('collections', {})
+              books = colls.get('books', {})
+              shards = books.get('shards', {})
+              if not shards:
+                  sys.exit(1)
+              for shard_name, shard in shards.items():
+                  for replica_name, replica in shard.get('replicas', {}).items():
+                      if replica.get('state') != 'active':
+                          sys.exit(1)
+              sys.exit(0)
+          except Exception:
+              sys.exit(1)
+          "; then
+                echo "Solr cluster healthy — all replicas active"
+                return 0
+              fi
+
+              echo "[$attempt/$attempts] Waiting for all Solr replicas to become active..."
+              sleep "$sleep_seconds"
+            done
+
+            echo "Solr cluster did not become fully active in time" >&2
+            return 1
+          }
+
+          # Solr endpoints require basic auth after security bootstrap
+          SOLR_AUTH="${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}"
+          wait_for_url "http://localhost:8983/solr/admin/info/system" "Solr" 90 5 "$SOLR_AUTH"
+          wait_for_url "http://localhost:8983/solr/books/admin/ping?distrib=true" "Solr books collection" 90 5 "$SOLR_AUTH"
+          wait_for_solr_cluster 30 10
+          wait_for_url "http://localhost:8080/health" "solr-search API"
+          wait_for_url "http://localhost/health" "nginx"
+          wait_for_url "http://localhost/search" "Aithena UI"
+
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.dev-ports.yml \
+            -f docker/compose.e2e.yml \
+            -f docker-compose.github-actions.yml \
+            --profile production \
+            ps
+
+      - name: Install Python E2E dependencies
+        working-directory: e2e
+        run: pip install -r requirements.txt
+
+      - name: Run Python E2E tests
+        working-directory: e2e
+        env:
+          E2E_USERNAME: ${{ env.CI_ADMIN_USERNAME }}
+          E2E_PASSWORD: ${{ env.CI_ADMIN_PASSWORD }}
+          RATE_LIMIT_REQUESTS_PER_MINUTE: "0"
+        run: |
+          if ! sudo chmod -R a+rwX "$E2E_LIBRARY_PATH" 2>/dev/null; then
+            echo "Warning: Failed to adjust permissions on E2E_LIBRARY_PATH: $E2E_LIBRARY_PATH"
+            ls -ld "$E2E_LIBRARY_PATH" 2>/dev/null || true
+            stat "$E2E_LIBRARY_PATH" 2>/dev/null || true
+          fi
+          ADMIN_API_KEY=$(grep '^ADMIN_API_KEY=' ../.env 2>/dev/null | cut -d= -f2 || true)
+          export ADMIN_API_KEY="${ADMIN_API_KEY:-ci-admin-api-key}"
+          pytest -v --junitxml=pytest-results.xml
+
+      - name: Install Playwright dependencies
+        working-directory: e2e/playwright
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright browser tests
+        working-directory: e2e/playwright
+        env:
+          E2E_USERNAME: ${{ env.CI_ADMIN_USERNAME }}
+          E2E_PASSWORD: ${{ env.CI_ADMIN_PASSWORD }}
+        run: |
+          export E2E_AUTH_COOKIE_NAME=aithena_auth
+          export E2E_API_TOKEN="$(curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            -d "$(python3 -c 'import json, os; print(json.dumps({"username": os.environ["E2E_USERNAME"], "password": os.environ["E2E_PASSWORD"]}))')" \
+            http://localhost/v1/auth/login | python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])')"
+          npx playwright test
+
+      - name: Upload Python E2E results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: python-e2e-results
+          path: e2e/pytest-results.xml
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload Playwright report and screenshots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: playwright-e2e-results
+          path: |
+            e2e/playwright/playwright-report
+            e2e/playwright/test-results
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Dump Compose logs on failure
+        if: failure()
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.dev-ports.yml \
+            -f docker/compose.e2e.yml \
+            -f docker-compose.github-actions.yml \
+            --profile production \
+            logs --no-color
+
+      - name: Gather Docker Compose logs for analysis
+        if: always()
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.dev-ports.yml \
+            -f docker/compose.e2e.yml \
+            -f docker-compose.github-actions.yml \
+            --profile production \
+            logs --no-color > "$RUNNER_TEMP/compose-logs.txt" 2>&1
+
+      - name: Tear down integration stack
+        if: always()
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.dev-ports.yml \
+            -f docker/compose.e2e.yml \
+            -f docker-compose.github-actions.yml \
+            --profile production \
+            down -v --remove-orphans
+          rm -f docker-compose.github-actions.yml
+
+  integration-gate:
+    name: Dev integration tests (single-node)
+    if: always()
+    needs: [changes, run-integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate results
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TEST_RESULT: ${{ needs.run-integration-tests.result }}
+        run: |
+          if [ "$CHANGES_RESULT" = "failure" ] || [ "$CHANGES_RESULT" = "cancelled" ]; then
+            echo "❌ Change detection failed"
+            exit 1
+          fi
+          if [ "$TEST_RESULT" = "failure" ] || [ "$TEST_RESULT" = "cancelled" ]; then
+            echo "❌ Integration tests failed"
+            exit 1
+          fi
+          if [ "$TEST_RESULT" = "skipped" ]; then
+            echo "⏭️ Integration tests skipped — no build-relevant changes"
+          else
+            echo "✅ Integration tests passed (single-node)"
+          fi

--- a/.github/workflows/dev-integration-test.yml
+++ b/.github/workflows/dev-integration-test.yml
@@ -167,6 +167,26 @@ jobs:
             zoo1:
               environment:
                 ZOO_SERVERS: server.1=zoo1:2888:3888;2181
+                ZOO_STANDALONE_ENABLED: "true"
+            # Single Solr node depends only on zoo1
+            solr:
+              environment:
+                ZK_HOST: "zoo1:2181"
+              depends_on:
+                zoo1:
+                  condition: service_healthy
+            # Override solr-init to only depend on single Solr node
+            solr-init:
+              depends_on:
+                solr:
+                  condition: service_healthy
+              environment:
+                SOLR_NUM_SHARDS: "1"
+                SOLR_REPLICATION_FACTOR: "1"
+            # Point solr-search at standalone ZooKeeper
+            solr-search:
+              environment:
+                ZOOKEEPER_HOSTS: zoo1:2181
           EOF
 
       - name: Generate sample PDF fixtures

--- a/.github/workflows/dev-integration-test.yml
+++ b/.github/workflows/dev-integration-test.yml
@@ -169,15 +169,16 @@ jobs:
                 ZOO_SERVERS: server.1=zoo1:2888:3888;2181
                 ZOO_STANDALONE_ENABLED: "true"
             # Single Solr node depends only on zoo1
+            # !override replaces (not merges) the base depends_on map
             solr:
               environment:
                 ZK_HOST: "zoo1:2181"
-              depends_on:
+              depends_on: !override
                 zoo1:
                   condition: service_healthy
             # Override solr-init to only depend on single Solr node
             solr-init:
-              depends_on:
+              depends_on: !override
                 solr:
                   condition: service_healthy
               environment:

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -123,6 +123,7 @@ Use overlay files (not profiles) when making a sidecar optional affects the main
 | — | #1153,#1154/PR#1213 | GPU compose override files (NVIDIA + Intel) for embeddings-server |
 | — | #1286 | Add intel-extension-for-pytorch (IPEX) to openvino extras |
 | — | #1325/PR#1328 | BuildKit --mount=from + --inexact for embeddings-server layer optimization (~95% reduction) |
+| 2026-04-21 | #1496/PR#1504 | Dev integration test workflow using single-node topology |
 
 ---
 
@@ -354,3 +355,22 @@ Added `intel-extension-for-pytorch` (IPEX) to `src/embeddings-server/pyproject.t
 - `.squad/analysis/standalone-solr-capacity-54m-vectors.md` — Baseline (130 GB)
 - `docs/research/standalone-vs-cloud-infrastructure-analysis.md` — Brett's original analysis (cost comparison)
 - `.squad/decisions.md` — Decision added: "32GB RAM Solr Optimization Strategy"
+## 2026-04-21 — Dev Integration Test Workflow (#1496)
+
+**Status:** ✅ PR #1504 created targeting dev.
+
+**What happened:**
+- Created `.github/workflows/dev-integration-test.yml` for faster CI on dev branch
+- Triggers on push to dev and PRs to dev (separate from integration-test.yml which targets main)
+- Uses single-node topology: 1 Solr + 1 ZooKeeper (vs 3-node SolrCloud)
+- Runs same test suite: Python E2E + Playwright browser tests
+- Uses Docker Compose profile overrides to disable solr2, solr3, zoo2, zoo3
+- Timeout: 45 minutes (vs 75 for full integration test)
+- Resource usage: ~6 containers vs 17
+
+**Key pattern:** Docker Compose profiles can disable services at the workflow level via `services: { service_name: { profiles: [disabled] } }` in override files. This is cleaner than maintaining separate compose files for each topology variant.
+
+**Design decisions:**
+- Why single-node for dev? SolrCloud resilience (replication, leader election) isn't needed for dev CI. Faster feedback wins.
+- Why not a separate compose.single-node.yml overlay? Kept the profile override in-CI to avoid maintaining another compose file. Consistent with docker/compose.e2e.yml pattern (minimal, focused overrides).
+- 45-min timeout is conservative; single-node should complete in 30-35 min with cold docker build, 20 min with warm caches.

--- a/docker/compose.single-node.yml
+++ b/docker/compose.single-node.yml
@@ -23,10 +23,11 @@ services:
     profiles: ["distributed-only"]
 
   # Single Solr node depends only on zoo1
+  # !override replaces (not merges) the base depends_on map
   solr:
     environment:
       ZK_HOST: "zoo1:2181"
-    depends_on:
+    depends_on: !override
       zoo1:
         condition: service_healthy
 
@@ -38,7 +39,7 @@ services:
 
   # solr-init only waits for the single Solr node
   solr-init:
-    depends_on:
+    depends_on: !override
       solr:
         condition: service_healthy
     environment:


### PR DESCRIPTION
Closes #1496

Adds a lightweight integration test workflow that uses single-node Solr topology for faster CI on dev.

## What Changed
- New workflow: `.github/workflows/dev-integration-test.yml`
- Triggers on push to `dev` branch and PRs to `dev`
- Uses 1-node Solr topology (vs 3-node SolrCloud in integration-test.yml)
- Uses 1 ZooKeeper node (vs 3-node quorum)
- Runs full integration test suite: Python E2E + Playwright browser tests
- Configured via Docker Compose profile overrides in CI step

## Benefits
- Faster CI feedback (45-minute timeout vs 75 for full workflow)
- Reduced resource usage: ~6 containers vs 17
- Ideal for dev branch PRs where SolrCloud resilience isn't needed
- Full SolrCloud testing still available in integration-test.yml for main branch