### PR TITLE
docs: HNSW vs hybrid-rerank architecture analysis (#1506)

### DIFF
--- a/.squad/analysis/api-search-architecture-modes.md
+++ b/.squad/analysis/api-search-architecture-modes.md
@@ -1,0 +1,355 @@
+# API & Backend Analysis: Dual Search Architecture Modes
+
+**Author:** Parker (Backend Dev)
+**Date:** 2026-07-15
+**Status:** Analysis Complete
+
+---
+
+## 1. Current Search API — `src/solr-search/main.py`
+
+### Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/search` (`/v1/search`) | GET | Main search — keyword, semantic, hybrid |
+| `/books/{id}/similar` (`/v1/books/{id}/similar`) | GET | kNN similarity search for a specific document |
+| `/facets` (`/v1/facets`) | GET | Standalone facet counts |
+| `/v1/search/compare` | GET | Side-by-side comparison across two collections |
+| `/books` (`/v1/books`) | GET | Browse/list books |
+| `/stats` (`/v1/stats`) | GET | Collection statistics |
+
+### Search Parameters
+
+The `/search` endpoint accepts:
+- `q` (str): Search query (empty = all for keyword mode)
+- `page` (int, ≥1): Pagination
+- `limit` / `page_size` (int): Results per page (max from `MAX_PAGE_SIZE`)
+- `sort` / `sort_by` / `sort_order`: Sorting (score, title, author, year, category, language)
+- `fq_author`, `fq_category`, `fq_language`, `fq_year`, `fq_series`, `fq_folder`: Filter queries
+- `mode` (str): `keyword` | `semantic` | `hybrid` (default from `DEFAULT_SEARCH_MODE` env var)
+- `collection` (str): Target Solr collection (default: `books`)
+
+### How `search_type` (mode) Is Handled
+
+```
+search() → dispatches based on mode:
+  ├─ "keyword"  → _search_keyword()  → BM25 via edismax
+  ├─ "semantic" → _search_semantic() → kNN via {!knn} query parser
+  └─ "hybrid"   → _search_hybrid()  → parallel BM25 + kNN → RRF fusion
+```
+
+**Keyword:** Builds Solr edismax params via `build_solr_params()`, queries Solr, enriches with chunk page ranges.
+
+**Semantic:** Calls `_fetch_embedding()` → embeddings server, then `build_knn_params()` → `{!knn f=embedding_v topK=N}[vector]`. No facets or highlighting. Degrades to keyword if embeddings unavailable (502/503/504).
+
+**Hybrid:** Runs BM25 + embedding fetch concurrently via `ThreadPoolExecutor(max_workers=2)`. Then fires kNN query. Merges with `reciprocal_rank_fusion(kw_results, sem_results, k=settings.rrf_k)`. Facets come from BM25 leg. Degrades to keyword on embedding failure.
+
+### Solr Client
+
+- **Library:** `requests` (no dedicated Solr client)
+- **Transport:** `requests.post(url, data=params)` to `{solr_url}/{collection}/select`
+- **Circuit breaker:** `solr_circuit` wraps all queries; `embeddings_circuit` wraps embedding calls
+- **Auth:** Optional HTTP Basic Auth via `SOLR_AUTH_USER`/`SOLR_AUTH_PASS`
+
+### Result Format
+
+```json
+{
+  "query": "...",
+  "mode": "keyword|semantic|hybrid",
+  "sort": {"by": "score", "order": "desc"},
+  "degraded": false,
+  "total": 42,
+  "page": 1,
+  "page_size": 20,
+  "total_pages": 3,
+  "results": [{ "id": "...", "title": "...", "score": 0.95, ... }],
+  "facets": { "author": [...], "category": [...], "year": [...], "language": [...] },
+  "message": "..." // optional, present on degradation
+}
+```
+
+---
+
+## 2. Reranking Implementation Design
+
+### Where to Insert Reranking
+
+The reranking step replaces the Solr-side kNN query in `hybrid` and `semantic` modes when `SEARCH_ARCHITECTURE=hybrid-rerank`.
+
+**For hybrid mode** (`_search_hybrid()`):
+1. Current flow: BM25 query → kNN query → `reciprocal_rank_fusion()`
+2. New flow: BM25 query (with `fl=...,embedding_v`) → app-side cosine rerank → `reciprocal_rank_fusion()`
+
+**For semantic mode** (`_search_semantic()`):
+1. Current flow: embedding → `{!knn}` query
+2. New flow: BM25 `*:*` query (or boosted q) → retrieve stored vectors → cosine rerank
+
+**Implementation location:** New function in `search_service.py`:
+
+```python
+def rerank_by_cosine_similarity(
+    docs: list[dict[str, Any]],
+    query_vector: list[float],
+    embedding_field: str = "embedding_v",
+    top_k: int | None = None,
+) -> list[dict[str, Any]]:
+    """Rerank documents by cosine similarity to query vector."""
+    import numpy as np
+
+    q_vec = np.array(query_vector, dtype=np.float32)
+    q_norm = np.linalg.norm(q_vec)
+    if q_norm == 0:
+        return docs
+
+    scored = []
+    for doc in docs:
+        vec = doc.get(embedding_field)
+        if vec is None:
+            continue
+        d_vec = np.array(vec, dtype=np.float32)
+        d_norm = np.linalg.norm(d_vec)
+        if d_norm == 0:
+            continue
+        sim = float(np.dot(q_vec, d_vec) / (q_norm * d_norm))
+        scored.append((doc, sim))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    if top_k:
+        scored = scored[:top_k]
+    return [dict(doc, score=sim) for doc, sim in scored]
+```
+
+### Retrieving Stored Vectors from Solr
+
+Add the embedding field to the Solr field list in the BM25 query:
+- Modify `SOLR_FIELD_LIST` conditionally (or pass an extended `fl` param)
+- In `build_solr_params()`, append `embedding_v` (or `embedding_byte_v`) to the `fl` parameter
+- The field must be **stored** in the Solr schema (Ash's domain — we need `stored="true"` on the vector field)
+
+**Key detail:** In HNSW mode, vector fields are typically `indexed="true" stored="false"` for performance. In hybrid-rerank mode, they MUST be `stored="true" indexed="false"` — stored-only, no HNSW index overhead.
+
+### RRF Score Fusion
+
+The existing `reciprocal_rank_fusion()` in `search_service.py` (line 419) already implements:
+```
+score(d) = 1/(k + rank_bm25) + 1/(k + rank_vector)
+```
+with k=60 (configurable via `RRF_K` env var). **No changes needed** — just feed it cosine-reranked results instead of kNN results.
+
+### Performance: Reranking 200 Candidates × 768D Vectors
+
+```python
+# Benchmark estimate:
+# - 200 vectors × 768 floats = 614,400 floats (≈2.4 MB)
+# - Cosine similarity = dot product + 2 norms per vector
+# - NumPy vectorized: ~0.2ms for 200 cosine similarities
+# - With Python loop overhead: ~1-3ms
+# - Sorting 200 items: negligible
+```
+
+**Total estimated latency: 1-5ms** for 200 candidates with 768D vectors. This is negligible compared to the Solr BM25 query latency (~20-50ms) and embedding generation (~50-200ms). **No performance concern.**
+
+For larger candidate sets (1000+), use numpy broadcasting for batch cosine:
+```python
+# Batch cosine: Q @ D^T / (||Q|| * ||D||)
+# 1000 × 768: ~2ms with numpy
+```
+
+---
+
+## 3. Capabilities Endpoint
+
+### Proposed: `GET /v1/capabilities`
+
+```python
+@app.get("/v1/capabilities")
+def capabilities() -> dict[str, Any]:
+    """Returns server capabilities for UI feature negotiation."""
+    return {
+        "search_architecture": settings.search_architecture,  # "hnsw" | "hybrid-rerank"
+        "available_modes": list(VALID_SEARCH_MODES),           # always ["keyword", "semantic", "hybrid"]
+        "vector_search": {
+            "type": settings.search_architecture,
+            "knn_available": settings.search_architecture == "hnsw",
+            "rerank_available": settings.search_architecture == "hybrid-rerank",
+        },
+        "quantization": {
+            "mode": settings.vector_quantization,              # "none" | "fp16" | "int8"
+        },
+        "embedding": {
+            "dimensions": settings.embedding_dimensions,       # fetched from embeddings server at startup
+            "field": settings.knn_field,
+        },
+        "collections": {
+            "default": settings.default_collection,
+            "allowed": sorted(settings.allowed_collections),
+        },
+    }
+```
+
+**Why this matters:**
+- The UI currently assumes HNSW kNN is always available
+- With hybrid-rerank mode, semantic/hybrid search still works but uses a different backend path
+- The UI should call `/v1/capabilities` at startup to discover what's available
+- Future modes (e.g., pure BM25 without any vectors) can be added without UI code changes
+
+**Auth:** This endpoint should be **public** (no auth required) — add to `PUBLIC_PATHS` set. It contains no sensitive data and is needed before login.
+
+---
+
+## 4. Configuration
+
+### New Environment Variables
+
+| Variable | Values | Default | Where |
+|----------|--------|---------|-------|
+| `SEARCH_ARCHITECTURE` | `hnsw`, `hybrid-rerank` | `hnsw` | solr-search `config.py` |
+| `VECTOR_QUANTIZATION` | `none`, `fp16`, `int8` | `none` | embeddings-server `config/__init__.py` (already exists) |
+
+### New Settings Fields (solr-search `config.py`)
+
+```python
+# Add to Settings dataclass:
+search_architecture: str  # "hnsw" | "hybrid-rerank"
+vector_quantization: str  # "none" | "fp16" | "int8" (informational, from embeddings server)
+embedding_dimensions: int  # populated at startup from embeddings server /v1/embeddings/model
+rerank_candidates: int  # number of BM25 candidates for reranking (default 200)
+```
+
+```python
+# Add to settings instantiation:
+search_architecture=os.environ.get("SEARCH_ARCHITECTURE", "hnsw"),
+vector_quantization=os.environ.get("VECTOR_QUANTIZATION", "none").lower(),
+embedding_dimensions=int(os.environ.get("EMBEDDING_DIMENSIONS", "768")),
+rerank_candidates=int(os.environ.get("RERANK_CANDIDATES", "200")),
+```
+
+### Interaction with `VECTOR_QUANTIZATION`
+
+| Architecture | Quantization | Solr Field | Indexed? | Stored? |
+|-------------|-------------|------------|----------|---------|
+| `hnsw` | `none` | `embedding_v` | ✅ (HNSW) | ❌ |
+| `hnsw` | `fp16` | `embedding_v` | ✅ (HNSW) | ❌ |
+| `hnsw` | `int8` | `embedding_byte_v` | ✅ (HNSW, ByteEncoding) | ❌ |
+| `hybrid-rerank` | `none` | `embedding_v` | ❌ | ✅ |
+| `hybrid-rerank` | `fp16` | `embedding_v` | ❌ | ✅ |
+| `hybrid-rerank` | `int8` | `embedding_byte_v` | ❌ | ✅ |
+
+**Key insight:** The quantization mode determines which field name the embeddings server returns (`embedding` → `embedding_v`, `embedding_byte` → `embedding_byte_v`). This is already handled by `quantize_embedding()` in embeddings-server. The document-indexer uses `emb_result.field_name` to write to the correct Solr field. **No change needed in the embeddings or indexer flow for field routing.**
+
+The **Solr schema** is what changes between modes (Ash's domain):
+- HNSW mode: `DenseVectorField` with `indexed="true" stored="false"`
+- Hybrid-rerank mode: regular stored field with `indexed="false" stored="true"`
+
+### Indexing Behavior Per Mode
+
+| Mode | What Happens at Index Time |
+|------|---------------------------|
+| `hnsw` | Vectors written to `embedding_v` (or `embedding_byte_v`). Solr builds HNSW index. |
+| `hybrid-rerank` | Same vectors written to same field names. Solr stores them without HNSW indexing. |
+
+**The document-indexer code does NOT need to change based on architecture mode.** The indexer always writes vectors to the field the embeddings server specifies. The difference is entirely in the Solr schema definition (stored vs. indexed). This is a clean separation of concerns.
+
+---
+
+## 5. Document Indexer Changes — `src/document-indexer/`
+
+### Current Vector Writing Flow
+
+```
+__main__.py:index_chunks()
+  → extract_pdf_text(path)
+  → chunk_text_with_pages(pages, chunk_size, overlap)
+  → for each batch:
+      → get_embeddings(chunks, host, port)          # calls embeddings-server
+      → build_chunk_doc(..., embedding=vector,
+                        embedding_field=emb_result.field_name)
+      → requests.post(solr_url, json=docs)           # writes to Solr
+```
+
+**`build_chunk_doc()`** (line 248-283): Constructs the Solr JSON document. The vector is written to `{embedding_field}_v` — e.g., `embedding_v` for float32/fp16, `embedding_byte_v` for int8. This field name comes from the embeddings server's `field_name` response field, which is set by `quantize_embedding()`.
+
+### Changes Needed for Hybrid-Rerank Mode
+
+**Answer: NONE on the document-indexer side.**
+
+The indexer is architecture-agnostic by design:
+1. It calls the embeddings server → gets vectors with `field_name`
+2. It writes to `{field_name}_v` in Solr
+3. Whether Solr indexes (HNSW) or just stores the field is determined by the **Solr schema**, not the indexer
+
+The only deployment-time change is the Solr schema configuration, which is Ash's responsibility.
+
+### Optional Enhancement: Informational Logging
+
+Could add a startup log line in the indexer showing which architecture mode is active:
+
+```python
+SEARCH_ARCHITECTURE = os.environ.get("SEARCH_ARCHITECTURE", "hnsw")
+logger.info("Search architecture: %s (vectors will be %s)",
+            SEARCH_ARCHITECTURE,
+            "HNSW-indexed" if SEARCH_ARCHITECTURE == "hnsw" else "stored-only for reranking")
+```
+
+This is purely informational — no behavioral change.
+
+---
+
+## 6. Implementation Plan (solr-search changes only)
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `config.py` | Add `search_architecture`, `vector_quantization`, `embedding_dimensions`, `rerank_candidates` fields |
+| `search_service.py` | Add `rerank_by_cosine_similarity()` function |
+| `main.py` | Add `/v1/capabilities` endpoint; modify `_search_hybrid()` and `_search_semantic()` to branch on architecture |
+| `main.py` | Add `SEARCH_ARCHITECTURE` to `PUBLIC_PATHS` for capabilities |
+
+### Branching Logic in Search
+
+```python
+def _search_hybrid(request, q, page, page_size, ...):
+    if settings.search_architecture == "hybrid-rerank":
+        return _search_hybrid_rerank(request, q, page, page_size, ...)
+    else:
+        return _search_hybrid_hnsw(request, q, page, page_size, ...)  # existing code
+```
+
+The `_search_hybrid_rerank()` function:
+1. Fetch query embedding (same as now)
+2. Run BM25 with extended `fl` (include `embedding_v`)
+3. Call `rerank_by_cosine_similarity(bm25_docs, query_vector)`
+4. Feed BM25 + reranked results into existing `reciprocal_rank_fusion()`
+5. Return in same response format
+
+### Testing Strategy
+
+- Unit tests for `rerank_by_cosine_similarity()` with known vectors
+- Mock-based integration tests for `_search_hybrid_rerank()` path
+- Parametrize existing search tests with `search_architecture` setting
+- Performance benchmark test for reranking (assert <50ms for 200×768D)
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Stored vectors increase Solr memory | Medium | int8 quantization reduces 4× vs fp32; only stored, no HNSW overhead |
+| Reranking quality vs true kNN | Low | RRF fusion compensates; BM25 pre-filter is strong for text search |
+| BM25 candidate set misses relevant docs | Medium | Use higher `RERANK_CANDIDATES` (200-500); log coverage metrics |
+| Config mismatch (architecture vs schema) | High | `/v1/capabilities` should probe Solr schema at startup to validate |
+| numpy dependency in solr-search | Low | numpy is lightweight; already used transitively via other deps |
+
+---
+
+## 8. Dependencies on Other Team Members
+
+| Who | What | Blocking? |
+|-----|------|-----------|
+| **Ash** (Schema) | Solr schema with stored-only vector fields for hybrid-rerank mode | ✅ Yes — without stored fields, reranking has no vectors to read |
+| **Devon** (UI) | Call `/v1/capabilities` at startup; adapt search mode selector | ❌ No — UI works with current modes; capabilities is additive |
+| **Brett** (Infra) | Docker compose config for `SEARCH_ARCHITECTURE` env var | ❌ No — defaults to `hnsw` (current behavior) |

--- a/.squad/analysis/hnsw-vs-hybrid-architecture.md
+++ b/.squad/analysis/hnsw-vs-hybrid-architecture.md
@@ -1,0 +1,596 @@
+# Architecture Analysis: HNSW vs Hybrid-Rerank Deployment Modes
+
+**Author:** Ripley (Lead)
+**Date:** 2025-07-25
+**Status:** Proposal
+**Requested by:** jmservera (Juanma)
+
+---
+
+## 1. Executive Summary
+
+The system currently requires an HNSW index for all vector search capabilities (semantic and hybrid modes). This index consumes 9–28 GB RAM for 9M page vectors depending on quantization. We propose a second deployment mode — **hybrid-rerank** — that eliminates the HNSW graph entirely, using BM25 as the primary retrieval stage with application-side vector reranking of top-N results.
+
+---
+
+## 2. Current Architecture — Search Flow Trace
+
+### 2.1 System Diagram (Current — HNSW Mode)
+
+```
+┌──────────────┐     ┌─────────────────┐     ┌─────────────────────────┐
+│  aithena-ui  │────▶│  solr-search    │────▶│  SolrCloud (3-node)     │
+│  (React 18)  │     │  (FastAPI)      │     │                         │
+│              │     │                 │     │  Collection: books       │
+│  MODE_OPTIONS│     │  /v1/search     │     │  ┌─────────────────────┐│
+│  - keyword   │     │  ?mode=X        │     │  │ Parent docs (books) ││
+│  - semantic  │     │                 │     │  │ - BM25 text index   ││
+│  - hybrid    │     │  ┌────────────┐ │     │  └─────────────────────┘│
+└──────────────┘     │  │ keyword:   │ │     │  ┌─────────────────────┐│
+                     │  │ edismax    │─┼────▶│  │ Chunk docs          ││
+                     │  │ BM25       │ │     │  │ - chunk_text_t      ││
+                     │  ├────────────┤ │     │  │ - embedding_v       ││
+                     │  │ semantic:  │ │     │  │   (knn_vector_768)  ││
+                     │  │ {!knn}     │─┼────▶│  │   HNSW cosine index ││
+                     │  ├────────────┤ │     │  │ - embedding_byte    ││
+                     │  │ hybrid:    │ │     │  │   (knn_vector_768   ││
+                     │  │ BM25 + kNN │ │     │  │    _byte) HNSW      ││
+                     │  │ → RRF      │ │     │  └─────────────────────┘│
+                     │  └────────────┘ │     └─────────────────────────┘
+                     │                 │
+                     │  ┌────────────┐ │     ┌─────────────────────────┐
+                     │  │ embedding  │ │     │  embeddings-server      │
+                     │  │ fetch      │─┼────▶│  (FastAPI)              │
+                     │  └────────────┘ │     │  multilingual-e5-base   │
+                     └─────────────────┘     │  768-dim, cosine sim    │
+                                             └─────────────────────────┘
+
+┌──────────────────┐     ┌─────────────────────────┐
+│ document-indexer  │────▶│  embeddings-server       │
+│ (RabbitMQ)       │     │  /v1/embeddings/          │
+│                  │     └─────────────────────────┘
+│ PDF → Tika → chunks    │
+│ chunks → embeddings    ├──▶ Solr: parent doc (metadata)
+│ chunks + vectors → Solr│    Solr: chunk docs (text + embedding_v)
+└──────────────────┘
+```
+
+### 2.2 Search Mode Implementation Details
+
+**File:** `src/solr-search/main.py` (lines 944–980) + `src/solr-search/search_service.py`
+
+| Mode | Entry Point | Solr Query | Embedding Required | Result Source |
+|------|-------------|------------|-------------------|---------------|
+| **keyword** | `_search_keyword()` L1002 | `defType=edismax`, BM25 on `_text_` | No | Parent docs (books) via `EXCLUDE_CHUNKS_FQ` |
+| **semantic** | `_search_semantic()` L1076 | `{!knn f=embedding_v topK=N}[vector]` | Yes | Chunk docs → deduplicated |
+| **hybrid** | `_search_hybrid()` L1144 | BM25 ∥ kNN in ThreadPoolExecutor → `reciprocal_rank_fusion()` | Yes | Fused via RRF (k=60) |
+
+**Key implementation details:**
+- **kNN query construction:** `build_knn_params()` in `search_service.py:287-312` — uses `{!knn}` local-parameter syntax
+- **RRF fusion:** `reciprocal_rank_fusion()` in `search_service.py:419-463` — application-side fusion of two ranked lists, score = Σ 1/(k + rank)
+- **Graceful degradation:** When embeddings are unavailable (502/503/504), semantic and hybrid degrade to keyword with `degraded: true` + message (L506-507, L1101-1115, L1189-1203)
+- **Chunk exclusion:** Keyword mode filters with `EXCLUDE_CHUNKS_FQ = "-parent_id_s:[* TO *]"` — kNN intentionally does NOT exclude chunks (embeddings live on chunks)
+- **Parallel execution:** Hybrid mode runs BM25 query and embedding fetch concurrently via `ThreadPoolExecutor(max_workers=2)` (L1181)
+
+### 2.3 Solr Schema — Vector Fields
+
+**File:** `src/solr/books/managed-schema.xml`
+
+```xml
+<!-- Field Types -->
+<fieldType name="knn_vector_768" class="solr.DenseVectorField"
+           vectorDimension="768" similarityFunction="cosine" knnAlgorithm="hnsw"/>
+<fieldType name="knn_vector_768_byte" class="solr.DenseVectorField"
+           vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine"
+           knnAlgorithm="hnsw" hnswMaxConnections="12"/>
+
+<!-- Fields -->
+<field name="embedding_v" type="knn_vector_768" indexed="true" stored="true"/>
+<field name="embedding_byte" type="knn_vector_768_byte" indexed="true" stored="true"/>
+<field name="book_embedding" type="knn_vector_768" indexed="true" stored="true"/>
+```
+
+Both `embedding_v` and `embedding_byte` have `indexed="true"`, which means HNSW graph is built. This is the RAM cost center.
+
+### 2.4 Configuration Touchpoints
+
+**File:** `src/solr-search/config.py`
+
+Relevant settings:
+- `knn_field` = `EMBEDDING_V` env var (default: `embedding_v`) — Solr field for kNN queries
+- `book_embedding_field` = `BOOK_EMBEDDING_FIELD` env var (default: `embedding_v`) — used by similar-books
+- `default_search_mode` = `DEFAULT_SEARCH_MODE` env var (default: `keyword`)
+- `embeddings_url` = `EMBEDDINGS_URL` env var
+- `rrf_k` = `RRF_K` env var (default: 60)
+
+---
+
+## 3. Proposed Architecture — Dual Deployment Modes
+
+### 3.1 System Diagram (Hybrid-Rerank Mode)
+
+```
+┌──────────────┐     ┌─────────────────┐     ┌─────────────────────────┐
+│  aithena-ui  │────▶│  solr-search    │────▶│  SolrCloud (3-node)     │
+│  (React 18)  │     │  (FastAPI)      │     │                         │
+│              │     │                 │     │  Collection: books       │
+│  MODE_OPTIONS│     │  /v1/search     │     │  ┌─────────────────────┐│
+│  - keyword   │     │  ?mode=X        │     │  │ Parent docs (books) ││
+│  - hybrid    │     │                 │     │  │ - BM25 text index   ││
+│  (semantic   │     │  ┌────────────┐ │     │  └─────────────────────┘│
+│   disabled)  │     │  │ keyword:   │ │     │  ┌─────────────────────┐│
+└──────────────┘     │  │ edismax    │─┼────▶│  │ Chunk docs          ││
+                     │  │ BM25       │ │     │  │ - chunk_text_t      ││
+                     │  ├────────────┤ │     │  │ - embedding_v       ││
+                     │  │ hybrid:    │ │     │  │   stored="true"     ││
+                     │  │ BM25 →     │ │     │  │   indexed="false"   ││
+                     │  │ fetch top-N│ │     │  │   ← NO HNSW graph!  ││
+                     │  │ vectors →  │ │     │  └─────────────────────┘│
+                     │  │ app-side   │ │     └─────────────────────────┘
+                     │  │ cosine sim │ │
+                     │  │ → rerank   │ │     ┌─────────────────────────┐
+                     │  └────────────┘ │     │  embeddings-server      │
+                     │  │ embedding  │ │     │  (still needed for      │
+                     │  │ fetch      │─┼────▶│   query embedding)      │
+                     │  └────────────┘ │     └─────────────────────────┘
+                     └─────────────────┘
+```
+
+### 3.2 How Hybrid-Rerank Works
+
+1. **BM25 retrieval:** Same edismax query as keyword mode, but fetch **more candidates** (e.g., top 100–200 chunks via `parent_id_s:[* TO *]` instead of excluding them)
+2. **Fetch stored vectors:** Request `embedding_v` in the `fl` (field list) for the top-N BM25 chunk results
+3. **Query embedding:** Get the query vector from embeddings-server (same as today)
+4. **Application-side cosine similarity:** Compute `cos(query_vec, doc_vec)` for each candidate
+5. **Rerank or RRF:** Either pure rerank by cosine score, or RRF fusion of BM25 rank + cosine rank
+6. **Return top-K:** Deduplicate by parent_id_s and return
+
+**Key insight:** Vectors are still stored in Solr (for retrieval), but `indexed="false"` means no HNSW graph is built. RAM savings: **9–28 GB freed**.
+
+---
+
+## 4. Configuration Design
+
+### 4.1 Environment Variable
+
+```
+SEARCH_ARCHITECTURE=hnsw|hybrid-rerank
+```
+
+Default: `hnsw` (backward compatible)
+
+**Why not auto-detect from schema?**
+- Auto-detection would require querying Solr's Schema API at startup to check if `embedding_v` is indexed
+- This creates a startup dependency and a fragile coupling to Solr schema internals
+- Explicit configuration is clearer, easier to debug, and follows the existing pattern (e.g., `VECTOR_QUANTIZATION`, `DEFAULT_SEARCH_MODE`)
+- Auto-detection could be added later as a convenience enhancement
+
+### 4.2 Startup Behavior
+
+On startup, `solr-search` should:
+1. Read `SEARCH_ARCHITECTURE` from environment
+2. Set `VALID_SEARCH_MODES` based on architecture:
+   - `hnsw`: `{"keyword", "semantic", "hybrid"}` (unchanged)
+   - `hybrid-rerank`: `{"keyword", "hybrid"}` (no standalone semantic)
+3. Log the active architecture mode at INFO level
+4. Adjust `DEFAULT_SEARCH_MODE` if it's incompatible (e.g., `semantic` in `hybrid-rerank` → fall back to `keyword` with WARNING)
+
+### 4.3 Configuration Matrix
+
+| Feature | HNSW Mode | Hybrid-Rerank Mode |
+|---------|-----------|-------------------|
+| **keyword search** | ✅ BM25 edismax | ✅ BM25 edismax (identical) |
+| **semantic search** | ✅ Solr `{!knn}` on HNSW | ❌ Not available |
+| **hybrid search** | ✅ BM25 ∥ kNN → RRF | ✅ BM25 → fetch vectors → app-side cosine → RRF |
+| **similar books** | ✅ kNN on stored vectors | ❌ Not available (no HNSW to search against) |
+| **embedding_v field** | `indexed="true" stored="true"` | `indexed="false" stored="true"` |
+| **HNSW RAM cost** | 9–28 GB (768-dim × 9M chunks) | **0 GB** |
+| **Embeddings server** | Required for semantic/hybrid | Required for hybrid (query embedding) |
+| **Facets in hybrid** | From BM25 leg | From BM25 leg (identical) |
+| **Highlights in hybrid** | From BM25 leg | From BM25 leg (identical) |
+| **Reranking latency** | N/A (HNSW handles it) | App-side: ~5-20ms for 200 vectors |
+
+---
+
+## 5. Impact Analysis by Layer
+
+### 5.1 Solr Schema (`src/solr/books/managed-schema.xml`)
+
+**Change:** Add a stored-only variant of the vector field type.
+
+```xml
+<!-- NEW: stored-only vector type — no HNSW index, no RAM cost -->
+<fieldType name="knn_vector_768_stored"
+           class="solr.DenseVectorField"
+           vectorDimension="768"
+           similarityFunction="cosine"
+           indexed="false"
+           stored="true"/>
+```
+
+**Option A — Dual field types, single schema:**
+- Define both `knn_vector_768` (HNSW) and `knn_vector_768_stored` (stored-only) field types
+- Use different field names: `embedding_v` (HNSW) vs `embedding_stored_v` (stored-only)
+- Indexer writes to the correct field based on `SEARCH_ARCHITECTURE`
+
+**Option B — Configurable schema via envsubst (RECOMMENDED):**
+- Use a single `embedding_v` field whose type switches between `knn_vector_768` and `knn_vector_768_stored` based on a build-time or init-time variable
+- Simpler: one field name, no indexer changes for field routing
+- Solr init script applies the appropriate schema variant
+
+**Recommendation:** Option B. Fewer moving parts, no indexer field-routing logic.
+
+### 5.2 Search API (`src/solr-search/`)
+
+#### 5.2.1 `config.py`
+
+Add new setting:
+```python
+search_architecture: str  # "hnsw" or "hybrid-rerank"
+```
+
+Read from `SEARCH_ARCHITECTURE` env var, default `"hnsw"`.
+
+#### 5.2.2 `search_service.py`
+
+Add new function for hybrid-rerank:
+
+```python
+def build_bm25_with_vectors_params(
+    query: str,
+    page: int,
+    candidate_limit: int,
+    sort_by: str,
+    sort_order: str,
+    facet_limit: int,
+    vector_field: str,
+    *,
+    sort: str | None = None,
+    filters: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build BM25 params that ALSO return stored vectors for top-N chunks."""
+    # Query chunks (not parents) so we get vectors
+    params = build_solr_params(query, 1, candidate_limit, sort_by, sort_order, facet_limit,
+                               sort=sort, filters=filters)
+    # Override fq to include chunks instead of excluding them
+    filter_queries = build_filter_queries(filters)
+    filter_queries.append("parent_id_s:[* TO *]")  # chunks only
+    params["fq"] = filter_queries
+    # Add vector field to fl
+    params["fl"] = ",".join(SOLR_FIELD_LIST + [vector_field])
+    params["rows"] = candidate_limit
+    return params
+
+
+def cosine_similarity(vec_a: list[float], vec_b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    norm_a = sum(a * a for a in vec_a) ** 0.5
+    norm_b = sum(b * b for b in vec_b) ** 0.5
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def rerank_by_similarity(
+    candidates: list[dict[str, Any]],
+    query_vector: list[float],
+    vector_field: str,
+    top_k: int,
+) -> list[dict[str, Any]]:
+    """Rerank BM25 candidates by cosine similarity to query vector."""
+    scored = []
+    for doc in candidates:
+        vec = doc.get(vector_field)
+        if vec:
+            sim = cosine_similarity(query_vector, vec)
+            scored.append((sim, doc))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [doc for _, doc in scored[:top_k]]
+```
+
+**Performance note:** For 200 candidates × 768 dimensions, cosine similarity is ~0.3ms in pure Python. If perf matters, use numpy: `np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))` — ~0.05ms for 200 vectors.
+
+#### 5.2.3 `main.py`
+
+**New `_search_hybrid_rerank()` function:**
+
+```python
+def _search_hybrid_rerank(
+    request, q, page, page_size, sort_by, sort_order, sort, filters,
+    *, collection=None,
+) -> dict[str, Any]:
+    """BM25 retrieval + application-side vector reranking."""
+    candidate_limit = max(page_size * 5, 100)  # over-fetch for reranking pool
+
+    # 1. BM25 on chunks (with vectors in fl)
+    chunk_params = build_bm25_with_vectors_params(...)
+
+    # 2. Concurrent: BM25 query + query embedding
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        bm25_future = pool.submit(query_solr, chunk_params, collection=collection)
+        emb_future = pool.submit(_fetch_embedding, q, collection=collection)
+
+        bm25_payload = bm25_future.result()
+        query_vector = emb_future.result()  # graceful degradation if fails
+
+    # 3. Extract BM25 chunk results with their stored vectors
+    chunk_docs = bm25_payload["response"]["docs"]
+
+    # 4. Compute cosine similarity for each chunk
+    for doc in chunk_docs:
+        vec = doc.get(settings.knn_field)
+        doc["_rerank_score"] = cosine_similarity(query_vector, vec) if vec else 0.0
+
+    # 5. RRF fusion of BM25 rank and cosine rank
+    bm25_ranked = chunk_docs  # already in BM25 order
+    cosine_ranked = sorted(chunk_docs, key=lambda d: d["_rerank_score"], reverse=True)
+    fused = reciprocal_rank_fusion(bm25_ranked, cosine_ranked, k=settings.rrf_k)
+
+    # 6. Deduplicate by parent_id_s, take top page_size
+    ...
+```
+
+**Mode routing change in `search()` endpoint:**
+
+```python
+if mode == "hybrid":
+    if settings.search_architecture == "hybrid-rerank":
+        response = _search_hybrid_rerank(...)
+    else:
+        response = _search_hybrid(...)
+```
+
+**Semantic mode guard:**
+
+```python
+if mode == "semantic" and settings.search_architecture == "hybrid-rerank":
+    raise HTTPException(
+        status_code=400,
+        detail="Semantic search requires HNSW mode. Current architecture: hybrid-rerank."
+    )
+```
+
+### 5.3 Embeddings Server (`src/embeddings-server/`)
+
+**No changes required.** The embeddings server generates vectors on demand for both modes:
+- HNSW mode: generates query vectors for kNN search
+- Hybrid-rerank mode: generates query vectors for application-side reranking
+
+### 5.4 Document Indexer (`src/document-indexer/`)
+
+**Minimal changes:**
+
+The indexer writes to `embedding_v` (or `embedding_byte` for int8 quantization) regardless of mode. The Solr schema determines whether the vector is indexed (HNSW) or just stored.
+
+- If using **Option B** (configurable schema), no indexer changes needed
+- If using **Option A** (dual fields), the indexer needs to know which field to write to via `EMBEDDING_FIELD` env var
+
+**Recommendation:** No indexer changes (Option B schema approach).
+
+### 5.5 Docker Compose
+
+```yaml
+solr-search:
+  environment:
+    - SEARCH_ARCHITECTURE=${SEARCH_ARCHITECTURE:-hnsw}
+
+# For hybrid-rerank deployments, add a compose override:
+# docker/compose.hybrid-rerank.yml
+```
+
+New override file `docker/compose.hybrid-rerank.yml`:
+```yaml
+services:
+  solr-search:
+    environment:
+      - SEARCH_ARCHITECTURE=hybrid-rerank
+      - DEFAULT_SEARCH_MODE=keyword
+```
+
+### 5.6 UI (`src/aithena-ui/`)
+
+#### 5.6.1 Capabilities Discovery
+
+The UI needs to know which search modes are available. Two approaches:
+
+**Option A — API capabilities endpoint (RECOMMENDED):**
+
+```
+GET /v1/capabilities
+{
+  "search_architecture": "hybrid-rerank",
+  "available_modes": ["keyword", "hybrid"],
+  "default_mode": "keyword",
+  "features": {
+    "similar_books": false,
+    "facets": true,
+    "semantic_search": false
+  }
+}
+```
+
+**Option B — Embedded in search response:**
+Already partially done — the `mode` field in search responses tells the UI what mode was used. But the UI needs to know *before* searching to populate the mode selector.
+
+**Recommendation:** Option A. Add `/v1/capabilities` endpoint. The UI fetches it once on load and conditionally renders mode options.
+
+#### 5.6.2 UI Changes
+
+In `src/aithena-ui/src/pages/SearchPage.tsx`:
+- `MODE_OPTIONS` should be filtered based on capabilities response
+- When `semantic` is unavailable, hide it from the mode selector
+- The "Similar Books" panel should be hidden/disabled when `similar_books: false`
+
+In `src/aithena-ui/src/hooks/search.ts`:
+- `SearchMode` type remains the same (superset)
+- Validation falls back to `keyword` if selected mode is unavailable
+
+---
+
+## 6. API Contract Proposal
+
+### 6.1 New Endpoint: `/v1/capabilities`
+
+```
+GET /v1/capabilities
+
+Response 200:
+{
+  "search_architecture": "hnsw" | "hybrid-rerank",
+  "available_modes": ["keyword", "semantic", "hybrid"] | ["keyword", "hybrid"],
+  "default_mode": "keyword" | "semantic" | "hybrid",
+  "features": {
+    "semantic_search": true | false,
+    "similar_books": true | false,
+    "vector_reranking": true | false,
+    "facets": true,
+    "highlights": true
+  },
+  "vector_config": {
+    "dimensions": 768,
+    "model": "multilingual-e5-base",
+    "quantization": "none" | "fp16" | "int8"
+  }
+}
+```
+
+**Authentication:** Public (no auth required) — same as `/health`.
+
+### 6.2 Search Endpoint Behavior Changes
+
+| `search_type` | HNSW Mode | Hybrid-Rerank Mode |
+|---------------|-----------|-------------------|
+| `keyword` | BM25 (unchanged) | BM25 (unchanged) |
+| `semantic` | Solr kNN (unchanged) | **400 error**: "Semantic search requires HNSW architecture" |
+| `hybrid` | BM25 + kNN → RRF (unchanged) | BM25 → vector rerank → RRF |
+
+### 6.3 Degradation Behavior in Hybrid-Rerank Mode
+
+If embeddings server is down in hybrid-rerank mode:
+- **hybrid** degrades to **keyword** with `degraded: true` (same as today)
+- This is consistent with existing degradation behavior (L506-507)
+
+### 6.4 Similar Books Endpoint
+
+| Endpoint | HNSW Mode | Hybrid-Rerank Mode |
+|----------|-----------|-------------------|
+| `/v1/books/{id}/similar` | kNN search (unchanged) | **501 error**: "Similar books requires HNSW architecture" |
+
+---
+
+## 7. Edge Cases and Risks
+
+### 7.1 Migration: Switching Modes Mid-Deployment
+
+**HNSW → Hybrid-Rerank:**
+1. Update Solr schema to change `embedding_v` from `indexed="true"` to `indexed="false"`
+2. **Requires full re-index** — Solr cannot drop an HNSW index without reindexing
+3. Set `SEARCH_ARCHITECTURE=hybrid-rerank`, restart `solr-search`
+4. Freed RAM is reclaimed after reindex completes
+
+**Hybrid-Rerank → HNSW:**
+1. Update Solr schema to change `embedding_v` to `indexed="true"`
+2. **Requires full re-index** — vectors are stored but HNSW graph needs to be built
+3. RAM consumption will spike during indexing
+4. Set `SEARCH_ARCHITECTURE=hnsw`, restart `solr-search`
+
+**Risk mitigation:** Document that mode switching requires scheduled maintenance with reindex.
+
+### 7.2 Reindexing Requirements
+
+| Scenario | Reindex Required? | Reason |
+|----------|-------------------|--------|
+| Initial deployment as hybrid-rerank | No (fresh index) | Schema configured from start |
+| HNSW → hybrid-rerank | **Yes** | Must rebuild without HNSW graph |
+| hybrid-rerank → HNSW | **Yes** | Must build HNSW graph from stored vectors |
+| Change quantization (within same mode) | **Yes** | Different field types |
+
+### 7.3 Quality: Recall Ceiling of BM25+Rerank vs Full kNN
+
+| Metric | Full kNN (HNSW) | BM25 + Rerank |
+|--------|----------------|---------------|
+| **Recall@10** | ~95%+ (HNSW approximate, configurable) | Bounded by BM25 recall in top-N |
+| **Semantic coverage** | Finds conceptually similar but lexically different docs | Only reranks docs already found by BM25 |
+| **Zero-overlap queries** | Handles them (vector-only) | **Misses entirely** — if no keyword match, no candidates to rerank |
+| **Multilingual cross-lingual** | Strong (embedding model handles) | Weak — BM25 is language-dependent |
+
+**The fundamental trade-off:** Reranking can only reorder what BM25 finds. If a relevant document shares no keywords with the query, it won't appear in the candidate pool. This is acceptable for cost-constrained deployments but should be clearly documented.
+
+**Mitigation:** Use a generous candidate pool (100–200) and edismax's flexible matching to maximize BM25 recall.
+
+### 7.4 Performance: Latency Trade-offs
+
+| Component | HNSW Mode | Hybrid-Rerank Mode |
+|-----------|-----------|-------------------|
+| BM25 query | ~10-50ms | ~10-50ms |
+| kNN query (HNSW) | ~5-20ms | N/A |
+| Embedding fetch | ~20-100ms | ~20-100ms |
+| Vector fetch from stored fields | N/A | ~5-15ms (200 × 768 floats) |
+| App-side cosine similarity | N/A | ~0.3ms (pure Python, 200 vectors) |
+| RRF fusion | <1ms | <1ms |
+| **Total hybrid** | **~35-170ms** | **~35-165ms** |
+
+Latencies are comparable. The vector fetch from stored fields replaces the kNN query. Network overhead of transferring 200 × 768 × 4 bytes ≈ 600 KB is the main delta.
+
+### 7.5 Disk Space
+
+Stored-only vectors still consume disk space (and Solr segment memory for stored field access). The saving is purely in HNSW graph RAM:
+- HNSW graph overhead: ~1.5–4× the raw vector size (due to neighbor lists)
+- Stored fields: raw vector size only
+
+---
+
+## 8. Recommended Implementation Order
+
+### Phase 1 — Foundation (1–2 sprints)
+1. **Add `SEARCH_ARCHITECTURE` config** — `config.py` + env var
+2. **Add `/v1/capabilities` endpoint** — read-only, returns architecture info
+3. **Add stored-only schema variant** — `knn_vector_768_stored` field type
+4. **Add cosine similarity helper** — `search_service.py`
+5. **Unit tests** for new helpers
+
+### Phase 2 — Search Path (1–2 sprints)
+6. **Implement `_search_hybrid_rerank()`** — BM25 + vector fetch + rerank
+7. **Mode routing** — switch hybrid implementation based on `SEARCH_ARCHITECTURE`
+8. **Guard semantic mode** — 400 error in hybrid-rerank mode
+9. **Guard similar-books** — 501 error in hybrid-rerank mode
+10. **Integration tests** with both modes
+
+### Phase 3 — UI + Docker (1 sprint)
+11. **UI capabilities hook** — fetch `/v1/capabilities`, filter mode options
+12. **Docker compose override** — `compose.hybrid-rerank.yml`
+13. **Documentation** — deployment guide, migration guide
+
+### Phase 4 — Validation (1 sprint)
+14. **A/B quality testing** — compare HNSW hybrid vs rerank hybrid on test queries
+15. **Performance benchmarks** — latency and throughput comparison
+16. **Memory profiling** — confirm RAM savings
+
+---
+
+## 9. Open Questions for Team Discussion
+
+1. **Should hybrid-rerank use pure cosine rerank or RRF fusion?** RRF preserves BM25 signal; pure rerank trusts vectors more. Recommend RRF (consistent with HNSW hybrid behavior).
+
+2. **Candidate pool size for reranking?** Too small = poor recall, too large = slow vector fetch. Recommend configurable via `RERANK_CANDIDATE_LIMIT` env var, default 200.
+
+3. **Should similar-books work in hybrid-rerank mode?** Could do BM25 on the source book's title/author → vector rerank. Lower quality than kNN but better than nothing. Defer to Phase 2.
+
+4. **Numpy dependency for cosine similarity?** Currently not in solr-search's deps. Pure Python is fast enough for 200 vectors. Add numpy only if profiling shows it's needed.
+
+5. **Schema management:** How do we handle the configurable schema? Options: (a) envsubst at Solr init time, (b) Solr Schema API call at startup, (c) two separate schema files. Recommend (a) — aligns with existing `VECTOR_QUANTIZATION` pattern.
+
+---
+
+## 10. Ownership Assignment (Recommendation)
+
+| Component | Owner | Rationale |
+|-----------|-------|-----------|
+| Schema variant + Solr init | **Ash** (Search Engineering) | Schema is Ash's domain |
+| `config.py` + capabilities endpoint | **Parker** (Backend) | Config and API changes |
+| `_search_hybrid_rerank()` | **Ash** (Search Engineering) | Search algorithm implementation |
+| UI capabilities integration | **Dallas** (Frontend) | UI mode selector changes |
+| Docker compose + docs | **Brett** (Infrastructure) | Deployment configuration |
+| Quality benchmarks | **Ash** + **Lambert** (Testing) | Search quality validation |
+| Architecture review | **Ripley** (Lead) | Decision arbitration |

--- a/.squad/analysis/hybrid-rerank-search-pipeline.md
+++ b/.squad/analysis/hybrid-rerank-search-pipeline.md
@@ -1,0 +1,370 @@
+# Hybrid-Rerank Search Pipeline Analysis
+
+**Author:** Ash (Search Engineer)  
+**Date:** 2025-07-23  
+**Status:** Analysis Complete
+
+---
+
+## 1. Current Solr Query Construction
+
+### 1.1 kNN Query Construction
+
+The kNN path is built in `search_service.py:build_knn_params()` (line 287):
+
+```python
+params = {
+    "q": f"{{!knn f={knn_field} topK={top_k}}}{vector_str}",
+    "rows": top_k,
+    "fl": ",".join(SOLR_FIELD_LIST),
+    "wt": "json",
+}
+```
+
+Key details:
+- **QParser:** Solr `{!knn}` local-parameter syntax
+- **Field:** `embedding_v` (768-dim, `knn_vector_768` type, HNSW cosine)
+- **topK:** Passed as `candidate_limit = max(page_size * 2, 20)` for hybrid; `page_size` for pure semantic
+- **Vector format:** JSON array string `[0.1,0.2,...]`
+- **No EXCLUDE_CHUNKS_FQ:** Chunks carry `parent_id_s`, so filtering them out would eliminate all kNN candidates (explicitly documented in code comments)
+- **Optional filter queries:** User facet filters (author, category, etc.) are passed as `fq` params via `build_filter_queries()`
+
+### 1.2 Keyword (BM25) Query Construction
+
+Built in `search_service.py:build_solr_params()` (line 115):
+
+- **QParser:** `edismax` with default field `_text_`
+- **Facets:** All six facet fields enabled (author, category, year, language, series, folder)
+- **Highlights:** Unified highlighter on `content` and `_text_` fields
+- **EXCLUDE_CHUNKS_FQ:** Always applied (`-parent_id_s:[* TO *]`) — returns parent (book-level) docs only
+- **Pagination:** Standard `start`/`rows` offset
+- **Post-search enrichment:** A second Solr query fetches matching chunk page ranges for keyword results (`build_chunk_page_params`)
+
+### 1.3 Hybrid Search (RRF Fusion)
+
+Implemented in `main.py:_search_hybrid()` (line 1144):
+
+1. **Two separate Solr queries** — NOT a single combined query:
+   - **BM25 leg:** `build_solr_params()` with `candidate_limit` rows (includes facets, highlights, EXCLUDE_CHUNKS_FQ)
+   - **kNN leg:** `build_knn_params()` with `candidate_limit` candidates (no facets, no highlights, targets chunks)
+
+2. **Concurrency:** BM25 query and embedding fetch run in parallel via `ThreadPoolExecutor(max_workers=2)`. The kNN Solr query runs *after* the embedding returns (sequential dependency).
+
+3. **RRF Fusion:** `reciprocal_rank_fusion()` merges the two result lists:
+   - Score formula: `Σ 1/(k + rank)` per list (1-based rank)
+   - Default k=60 (configurable via `RRF_K` env var)
+   - Documents in both lists score higher
+   - Facets sourced from BM25 leg; kNN results get empty highlights
+   - Final result truncated to `page_size`
+
+4. **Graceful degradation:** If embeddings service is down (502/503/504), hybrid falls back to keyword-only with `degraded=True`
+
+### 1.4 Solr Response Fields Returned
+
+Standard field list (`SOLR_FIELD_LIST`):
+```
+id, title_s, author_s, year_i, category_s, language_detected_s, language_s,
+series_s, file_path_s, folder_path_s, page_count_i, file_size_l,
+thumbnail_url_s, page_start_i, page_end_i, chunk_text_t, parent_id_s, score
+```
+
+Note: **`embedding_v` is NOT in the field list** — vectors are never returned in search responses today.
+
+### 1.5 Solr Transport
+
+All queries use `requests.post(url, data=params)` — form-encoded POST body. This avoids URI length limits with large vector payloads (>4KB).
+
+---
+
+## 2. Schema Changes for Hybrid-Rerank Mode
+
+### 2.1 Current Schema Vector Fields
+
+| Field | Type | Indexed | Stored | Usage |
+|-------|------|---------|--------|-------|
+| `embedding_v` | `knn_vector_768` (HNSW, cosine) | true | true | Primary chunk embedding (float32) |
+| `embedding_byte` | `knn_vector_768_byte` (HNSW, BYTE, cosine) | true | true | Int8 quantized chunk embedding |
+| `book_embedding` | `knn_vector_768` (HNSW, cosine) | true | true | Parent-level book embedding |
+
+### 2.2 Stored-Only Vector Field Option
+
+**Option A: `stored="true" indexed="false"` on DenseVectorField**
+
+In Solr 9.7, `solr.DenseVectorField` with `indexed="false"` **does not build an HNSW graph**. The field becomes a stored-only binary blob. This is the cleanest approach:
+
+```xml
+<fieldType name="knn_vector_768_stored"
+           class="solr.DenseVectorField"
+           vectorDimension="768"
+           similarityFunction="cosine"/>
+
+<field name="embedding_stored"
+       type="knn_vector_768_stored"
+       indexed="false"
+       stored="true"/>
+```
+
+**Caveat:** No `knnAlgorithm` attribute is needed (and should be omitted) since there's no index to build. Solr 9.7 accepts this configuration — the DenseVectorField class respects the `indexed` attribute. Verified in Solr source: `DenseVectorField.createField()` checks `indexed()` before building the HNSW codec data.
+
+**Option B: MultivalueFloat field (backup approach)**
+
+If DenseVectorField with `indexed="false"` causes issues in any Solr 9.x minor version:
+
+```xml
+<field name="embedding_stored"
+       type="pfloats"
+       indexed="false"
+       stored="true"
+       multiValued="true"/>
+```
+
+This stores the vector as a plain float array. Works universally but loses type safety and the vector is stored as individual float values rather than a compact binary blob.
+
+**Recommendation: Option A.** It's native, compact, and Solr 9.7-compatible.
+
+### 2.3 Storage Overhead Comparison
+
+| Mode | Field Config | Disk per 768-dim vector | RAM per vector | HNSW graph overhead |
+|------|-------------|------------------------|----------------|---------------------|
+| HNSW (current) | indexed=true, stored=true | ~3 KB stored + ~3 KB HNSW | ~3 KB (in heap for graph) + neighbors list | ~48 bytes × M neighbors per level |
+| Stored-only | indexed=false, stored=true | ~3 KB stored | 0 (no graph in RAM) | 0 |
+| HNSW + stored (dual) | Both fields | ~6 KB total | ~3 KB (HNSW only) | Same as HNSW |
+
+For 100K chunks:
+- **HNSW mode:** ~600 MB disk, ~300 MB heap for graph navigation
+- **Stored-only mode:** ~300 MB disk, ~0 MB heap for vectors (dramatic RAM savings)
+- **Dual-field mode:** ~600 MB disk, ~300 MB heap (same as HNSW-only since stored field adds disk but no heap)
+
+**Key insight:** The main savings of hybrid-rerank mode are in **RAM** (no HNSW graph in memory) and **indexing speed** (no graph construction). Disk savings are ~50% since the stored representation is similar size either way.
+
+---
+
+## 3. Query Construction for Hybrid-Rerank Mode
+
+### 3.1 Stage 1: BM25 Candidate Retrieval
+
+Reuse the existing keyword search path almost entirely:
+
+```python
+# Existing build_solr_params() works as-is
+# But request MORE candidates (recall pool)
+bm25_params = build_solr_params(
+    query=q, page=1, page_size=rerank_pool_size,  # e.g., 200
+    sort_by="score", sort_order="desc",
+    facet_limit=facet_limit, filters=filters,
+)
+```
+
+**Critical change:** `EXCLUDE_CHUNKS_FQ` should remain — BM25 returns parent (book) docs. But we need chunk-level vectors for reranking. Two sub-approaches:
+
+- **Approach A (book-level rerank):** Use `book_embedding` on parent docs for reranking. Simpler, but less precise since book-level embeddings are averaged over all chunks.
+- **Approach B (chunk-level rerank):** After BM25 returns parent IDs, fetch their chunk embeddings in a second query. More precise, but requires an additional Solr round-trip.
+
+**Recommendation: Approach A for v1** — rerank using `book_embedding` stored on parent docs. The existing `book_embedding` field already exists on parent documents.
+
+### 3.2 Stage 2: Vector Retrieval for Reranking
+
+To retrieve stored vectors efficiently:
+
+```python
+# Add embedding field to fl (field list) for rerank mode
+RERANK_FIELD_LIST = SOLR_FIELD_LIST + ["book_embedding"]
+
+# In build_solr_params, when mode is hybrid-rerank:
+params["fl"] = ",".join(RERANK_FIELD_LIST)
+```
+
+**Solr returns vectors as JSON arrays** when they're in the `fl` list and stored=true. For 768-dim float32 vectors, each result adds ~6 KB to the response payload. For a pool of 200 candidates, that's ~1.2 MB of vector data — acceptable.
+
+For chunk-level reranking (future Approach B):
+
+```python
+# Second query to fetch chunk embeddings for candidate parent IDs
+chunk_params = {
+    "q": "*:*",
+    "fq": [f"parent_id_s:({' OR '.join(parent_ids)})"],
+    "fl": "parent_id_s,embedding_stored",
+    "rows": len(parent_ids) * 3,  # ~3 chunks per book
+    "wt": "json",
+}
+```
+
+### 3.3 Stage 3: Application-Side Cosine Similarity
+
+```python
+import numpy as np
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    a_arr, b_arr = np.array(a), np.array(b)
+    return float(np.dot(a_arr, b_arr) / (np.linalg.norm(a_arr) * np.linalg.norm(b_arr)))
+```
+
+For 200 candidates × 768 dimensions, this takes <1ms with NumPy. Negligible latency.
+
+### 3.4 RRF Fusion for Hybrid-Rerank
+
+The existing `reciprocal_rank_fusion()` function can be reused directly:
+
+```python
+# BM25 results are already ranked by Solr score
+bm25_ranked = [...]  # from Stage 1
+
+# Reranked by cosine similarity
+vector_ranked = sorted(bm25_ranked, key=lambda d: d["cosine_sim"], reverse=True)
+
+# Fuse using existing RRF
+fused = reciprocal_rank_fusion(bm25_ranked, vector_ranked, k=settings.rrf_k)
+```
+
+**Key difference from current hybrid:** Both ranked lists come from the SAME candidate pool (BM25 top-N), just ranked differently. Current hybrid draws from two independent pools (BM25 books vs kNN chunks). This means hybrid-rerank fusion can never introduce documents that BM25 didn't find.
+
+---
+
+## 4. Solr Configuration
+
+### 4.1 Single Schema Supporting Both Modes
+
+**Yes — a single schema can support both modes.** Add the stored-only field alongside existing HNSW fields:
+
+```xml
+<!-- Existing HNSW fields (unchanged) -->
+<field name="embedding_v" type="knn_vector_768" indexed="true" stored="true"/>
+<field name="embedding_byte" type="knn_vector_768_byte" indexed="true" stored="true"/>
+<field name="book_embedding" type="knn_vector_768" indexed="true" stored="true"/>
+
+<!-- NEW: stored-only field for hybrid-rerank mode (no HNSW graph) -->
+<fieldType name="knn_vector_768_stored"
+           class="solr.DenseVectorField"
+           vectorDimension="768"
+           similarityFunction="cosine"/>
+<field name="embedding_rerank"
+       type="knn_vector_768_stored"
+       indexed="false"
+       stored="true"/>
+```
+
+The indexer chooses which fields to populate based on a `SEARCH_ARCHITECTURE` env var:
+- `hnsw`: Write to `embedding_v` (or `embedding_byte`) — current behavior
+- `hybrid-rerank`: Write to `embedding_rerank` (and `book_embedding` for parent-level rerank)
+- `both`: Write to both (for A/B testing between modes)
+
+**No separate schema variants needed.** Unpopulated DenseVectorFields have zero overhead.
+
+### 4.2 solrconfig.xml Changes
+
+**No changes required for v1.** The hybrid-rerank mode uses only standard `/select` queries (BM25 + field retrieval). No Solr-side reranking plugins needed.
+
+For future optimization, consider:
+
+```xml
+<!-- Optional: dedicated handler with larger maxBooleanClauses for chunk retrieval -->
+<requestHandler name="/rerank-vectors" class="solr.SearchHandler">
+  <lst name="defaults">
+    <str name="echoParams">explicit</str>
+    <str name="wt">json</str>
+    <int name="rows">600</int>
+  </lst>
+</requestHandler>
+```
+
+The existing LTR module (`solr.modules=ltr`) could enable Solr-side reranking in the future, but application-side reranking is simpler and more flexible for v1.
+
+### 4.3 Mode Selection Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Search API (mode parameter)                         │
+│                                                      │
+│  keyword ──────► BM25 (existing, unchanged)          │
+│  semantic ─────► kNN HNSW (existing, unchanged)      │
+│  hybrid ───────► BM25 + kNN + RRF (existing)         │
+│  hybrid-rerank ► BM25 + stored vectors + app cosine  │  ◄── NEW
+│                  + RRF                               │
+└──────────────────────────────────────────────────────┘
+```
+
+Add `"hybrid-rerank"` to `VALID_SEARCH_MODES` and implement `_search_hybrid_rerank()` as a new code path in `main.py`.
+
+---
+
+## 5. Quality Analysis
+
+### 5.1 BM25 Recall Estimation for Book Search
+
+For a library book search system with structured queries (author names, titles, topics):
+
+| Query Type | Estimated BM25 recall@100 | BM25 recall@200 | Notes |
+|------------|--------------------------|-----------------|-------|
+| Known-item (author + title) | 95–99% | 98–99% | BM25 excels at exact/near-exact matches |
+| Topic keyword ("machine learning") | 80–90% | 85–95% | Good if `_text_` covers content + metadata |
+| Conceptual ("books about grief") | 30–50% | 40–60% | BM25 misses semantic meaning |
+| Cross-lingual ("libros sobre IA" in EN corpus) | 5–15% | 10–20% | BM25 is language-bound |
+| Synonym-dependent ("automobile" vs "car") | 50–70% | 60–80% | Depends on synonym file quality |
+
+**Overall weighted estimate** (assuming 60% known-item/topic, 25% conceptual, 15% cross-lingual/synonym):
+- **recall@100:** ~65–75%
+- **recall@200:** ~72–82%
+
+### 5.2 What's Lost Without HNSW First-Stage Retrieval
+
+When BM25 is the sole first-stage retriever:
+
+1. **Semantic recall gap:** Documents that are semantically relevant but lack exact keyword overlap are completely invisible. The reranking stage can only reorder what BM25 found — it cannot resurrect missed documents.
+
+2. **Conceptual queries suffer most:** "Books that make you think about mortality" — BM25 won't find *The Death of Ivan Ilyich* unless the words "mortality" or "think" appear in the indexed text.
+
+3. **Cross-lingual recall is near-zero:** A Spanish query against English content (or vice versa) gets virtually no BM25 candidates. E5-base handles this natively via its multilingual training.
+
+4. **Diminishing returns of larger rerank pools:** Increasing from recall@100 to recall@200 yields modest gains (5–10%) because BM25's ranking tail contains increasingly irrelevant documents.
+
+### 5.3 Where Pure Semantic Beats BM25
+
+| Query Type | Semantic Advantage | Example |
+|------------|-------------------|---------|
+| **Conceptual queries** | High | "books about overcoming adversity" |
+| **Cross-lingual** | Very high | Spanish query → English books |
+| **Synonym/paraphrase** | Medium-high | "automobile repair" finds "car maintenance" |
+| **Typo tolerance** | Medium | "machien lerning" → machine learning |
+| **Vague/exploratory** | Medium | "something like Borges" |
+| **Known-item with exact terms** | Low (BM25 wins) | "Don Quixote Cervantes" |
+| **Metadata-specific** | Low (BM25 wins) | "published in 2020" |
+
+### 5.4 Recommendations for Mitigation
+
+To compensate for BM25's recall limitations in hybrid-rerank mode:
+
+1. **Expand BM25 candidate pool aggressively:** Use recall@200 or recall@300 to catch more potential matches.
+2. **Enrich the `_text_` copy field** with metadata concatenation (author + title + category + series) to boost known-item recall.
+3. **Invest in synonym files** for each language to close the synonym gap.
+4. **Add query expansion:** Before BM25 query, use the embedding to find related terms and append them (pseudo-relevance feedback).
+5. **Track quality metrics:** Measure nDCG@10 for both modes using the existing A/B comparison endpoint.
+
+---
+
+## 6. Implementation Roadmap
+
+### Phase 1: Schema (Ash)
+- Add `knn_vector_768_stored` field type and `embedding_rerank` field to managed-schema.xml
+- No existing fields modified
+
+### Phase 2: Indexer changes (Parker)
+- Add `SEARCH_ARCHITECTURE` env var logic
+- Write to `embedding_rerank` field when in hybrid-rerank mode
+
+### Phase 3: Query path (Parker, schema guidance from Ash)
+- Add `hybrid-rerank` search mode to `VALID_SEARCH_MODES`
+- Implement `_search_hybrid_rerank()` using existing BM25 path + stored vector retrieval + app-side cosine + RRF
+- Add `book_embedding` (or `embedding_rerank`) to `fl` for rerank queries
+
+### Phase 4: A/B comparison
+- Use existing comparison endpoint to measure HNSW hybrid vs hybrid-rerank quality
+- Success criteria: ≤5% nDCG@10 regression, ≥30% RAM reduction
+
+---
+
+## 7. Key Risks and Open Questions
+
+1. **DenseVectorField indexed=false in Solr 9.7:** Needs integration test. If it fails, fall back to Option B (pfloats field).
+2. **Book-level vs chunk-level reranking precision:** Book-level embeddings average over all chunks, potentially losing passage-level signal. Monitor quality metrics.
+3. **BM25 recall ceiling:** For conceptual/cross-lingual queries, no amount of reranking can fix a bad candidate set. Consider a "fallback to HNSW" mode for queries with low BM25 confidence.
+4. **Vector serialization format:** Verify Solr returns stored DenseVectorField values as JSON arrays (not binary) when included in `fl`. If binary, a deserialization step is needed.

--- a/.squad/analysis/ui-search-mode-configuration.md
+++ b/.squad/analysis/ui-search-mode-configuration.md
@@ -1,0 +1,313 @@
+# UI Search Mode Configuration — Analysis & Design Proposal
+
+**Author:** Dallas (Frontend Dev)  
+**Date:** 2025-07-23  
+**Status:** Proposal  
+**Requested by:** jmservera (Juanma)
+
+---
+
+## 1. Current UI Audit
+
+### 1.1 Search Mode Selector — Location & UI Pattern
+
+The search mode is rendered as a **segmented button group** (three buttons in a horizontal bar) in `SearchPage.tsx` (line 484–501). The buttons are wrapped in a `<div class="mode-selector">` with `role="group"` and each button uses `aria-pressed` for accessibility.
+
+```
+┌──────────────────────────────────────────────────┐
+│  [Keyword]  [Semantic]  [Hybrid]                 │
+│   ^^^^^^^^                                        │
+│   active (highlighted with --color-primary)       │
+└──────────────────────────────────────────────────┘
+```
+
+The three modes are defined as a static constant array:
+
+```tsx
+const MODE_OPTIONS: { value: SearchMode; labelId: string; titleId: string }[] = [
+  { value: 'keyword',  labelId: 'search.modeKeyword',  titleId: 'search.modeKeywordTitle'  },
+  { value: 'semantic', labelId: 'search.modeSemantic', titleId: 'search.modeSemanticTitle' },
+  { value: 'hybrid',   labelId: 'search.modeHybrid',   titleId: 'search.modeHybridTitle'   },
+];
+```
+
+**Default mode:** `keyword` (defined in `useSearchState.ts` line 46).
+
+### 1.2 How the UI Calls the Search API
+
+The search hook (`hooks/search.ts`) builds a request to `GET /v1/search?q=...&mode=...&limit=...&page=...&sort=...&fq_*=...`.
+
+Key observations:
+- The `mode` parameter is sent as a plain string: `keyword`, `semantic`, or `hybrid`.
+- On a 400 response for non-keyword modes, the UI shows a helpful fallback error: *"Semantic search is unavailable. Embeddings may not be indexed yet."* (line 116–122).
+- The search state is fully URL-driven (`useSearchState.ts`): mode is read from `?mode=` param, validated against `VALID_MODES`, and falls back to `keyword` if invalid.
+
+### 1.3 Existing "Available Modes" or Capabilities Concept
+
+**There is none.** The mode list is entirely hardcoded in the frontend. There is:
+- No `GET /api/capabilities` call
+- No feature flag system
+- No A/B testing framework
+- No environment-variable-driven mode filtering
+
+The only dynamic behavior is the 400-error fallback for semantic/hybrid when embeddings aren't indexed.
+
+### 1.4 Mode-Specific UI Elements
+
+| Element | Location | Mode-specific behavior |
+|---------|----------|----------------------|
+| **Mode selector buttons** | SearchPage header | Static 3-button group, no disabling |
+| **Mode badge** | Results count area | Colored pill showing active mode (keyword=gray, semantic=teal, hybrid=amber) |
+| **FacetPanel** | Left sidebar | Shows "Facets are only available in keyword mode" message when `mode === 'semantic'`; hidden facets for semantic mode |
+| **SimilarBooks** | Below results | Always uses vector similarity — independent of search mode |
+
+---
+
+## 2. Design Proposal for Hybrid-Rerank Mode
+
+### 2.1 Recommended Approach: Hide Unavailable + Capabilities API
+
+**Option (a) — Hide "Semantic" entirely** when the backend reports it's unavailable.
+
+**Rationale:**
+- Users don't need to know about HNSW vs rerank architecture
+- Showing a grayed-out option creates confusion ("why can't I use this?")
+- Simpler UX: users only see what works
+
+### 2.2 Text-Based Mockups
+
+#### HNSW Mode (current behavior, no changes)
+
+```
+┌─ Search ────────────────────────────────────────────────────┐
+│                                                              │
+│  [ 🔍 Search for books...                    ] [Search]      │
+│                                                              │
+│  [Keyword]  [Semantic]  [Hybrid]                             │
+│   ^^^^^^^^                                                    │
+│                                                              │
+│  42 results for "machine learning"  ● keyword                │
+│  Sort: Relevance ▾    Per page: 10 ▾                         │
+│                                                              │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐                     │
+│  │ Result 1 │ │ Result 2 │ │ Result 3 │                     │
+│  └──────────┘ └──────────┘ └──────────┘                     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+#### Hybrid-Rerank Mode (semantic hidden)
+
+```
+┌─ Search ────────────────────────────────────────────────────┐
+│                                                              │
+│  [ 🔍 Search for books...                    ] [Search]      │
+│                                                              │
+│  [Keyword]  [Hybrid]                                         │
+│              ^^^^^^^^                                         │
+│              (default in this mode)                           │
+│                                                              │
+│  42 results for "machine learning"  ● hybrid                 │
+│  Sort: Relevance ▾    Per page: 10 ▾                         │
+│                                                              │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐                     │
+│  │ Result 1 │ │ Result 2 │ │ Result 3 │                     │
+│  └──────────┘ └──────────┘ └──────────┘                     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 2.3 Architecture Indicator (Admin Only)
+
+Regular users should **not** see the architecture mode. Admin users can see it on the existing **Admin → Infrastructure** page as a new "Search Architecture" card:
+
+```
+┌─ Admin › Infrastructure ──────────────────────────┐
+│                                                    │
+│  ┌─────────────────────────────────┐               │
+│  │ 🔍 Search Architecture          │               │
+│  │                                  │               │
+│  │  Mode:    hybrid-rerank          │               │
+│  │  Modes:   keyword, hybrid        │               │
+│  │  HNSW:    not available          │               │
+│  └─────────────────────────────────┘               │
+│                                                    │
+│  (existing service cards below...)                 │
+└────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Capabilities API Integration
+
+### 3.1 Proposed API Contract
+
+```
+GET /api/capabilities
+→ 200 OK
+{
+  "search_modes": ["keyword", "hybrid"],
+  "default_mode": "hybrid",
+  "architecture": "hybrid-rerank",
+  "features": {
+    "hnsw_index": false,
+    "vector_reranking": true,
+    "facets": true,
+    "similar_books": false
+  }
+}
+```
+
+For HNSW mode:
+```json
+{
+  "search_modes": ["keyword", "semantic", "hybrid"],
+  "default_mode": "keyword",
+  "architecture": "hnsw",
+  "features": {
+    "hnsw_index": true,
+    "vector_reranking": false,
+    "facets": true,
+    "similar_books": true
+  }
+}
+```
+
+### 3.2 Frontend Integration Plan
+
+#### New: `useCapabilities` hook
+
+```tsx
+// hooks/useCapabilities.ts
+interface Capabilities {
+  searchModes: SearchMode[];
+  defaultMode: SearchMode;
+  architecture: string;
+  features: {
+    hnswIndex: boolean;
+    vectorReranking: boolean;
+    facets: boolean;
+    similarBooks: boolean;
+  };
+}
+
+function useCapabilities(): {
+  capabilities: Capabilities | null;
+  loading: boolean;
+  error: string | null;
+}
+```
+
+- Fetches `GET /api/capabilities` once at app startup
+- Caches in React context (`CapabilitiesContext`) so all components can access it
+- Refetches on visibility change (`document.visibilitychange`) to handle deployment switches
+- Returns sensible defaults while loading (all modes available = current behavior)
+
+#### New: `CapabilitiesContext`
+
+```tsx
+// contexts/CapabilitiesContext.tsx
+<CapabilitiesProvider>
+  {/* wraps entire app in App.tsx */}
+  <App />
+</CapabilitiesProvider>
+```
+
+#### Changes to Existing Components
+
+| File | Change |
+|------|--------|
+| `hooks/search.ts` | `SearchMode` type stays the same. No changes needed — the mode param is already a string. |
+| `hooks/useSearchState.ts` | `VALID_MODES` becomes dynamic: read from `CapabilitiesContext`. If URL has an invalid mode, fall back to `capabilities.defaultMode` instead of hardcoded `'keyword'`. |
+| `pages/SearchPage.tsx` | Filter `MODE_OPTIONS` array by `capabilities.searchModes`. Only render available modes. |
+| `Components/FacetPanel.tsx` | No change needed — already handles mode-specific behavior. |
+| `Components/SimilarBooks.tsx` | Check `capabilities.features.similarBooks` — hide the section if false (no HNSW = no kNN for similar books). |
+| `pages/AdminInfrastructurePage.tsx` | Add "Search Architecture" card using capabilities data. |
+
+### 3.3 Loading Strategy
+
+```
+App mounts
+  → CapabilitiesProvider fetches /api/capabilities
+  → While loading: render UI with all modes (optimistic, avoids flash)
+  → On success: filter to available modes
+  → On error: keep all modes (graceful degradation, let search API return 400s as today)
+```
+
+This is a **non-blocking** load — users can start typing immediately.
+
+---
+
+## 4. UX Considerations
+
+### 4.1 User-Centric Naming
+
+Most users don't care about HNSW vs rerank. The mode names should stay **user-friendly**:
+
+| Mode | HNSW label | Hybrid-rerank label | Tooltip (title) |
+|------|-----------|---------------------|-----------------|
+| keyword | Keyword | Keyword | Traditional keyword search |
+| semantic | Semantic | *(hidden)* | — |
+| hybrid | Hybrid | Hybrid | Combined keyword + AI-powered search |
+
+The hybrid tooltip can change subtly — "Combined keyword + semantic search" → "Combined keyword + AI-powered search" — but this is optional. The user-facing label stays "Hybrid" in both architectures.
+
+### 4.2 Default Mode
+
+**Recommendation:** Default to `hybrid` in hybrid-rerank mode, keep `keyword` default in HNSW mode.
+
+Rationale: In hybrid-rerank mode, hybrid is the "best" search experience (BM25 + vector reranking). In HNSW mode, keyword is the safest default (always works even if embeddings aren't indexed yet).
+
+The `defaultMode` field from the capabilities API drives this.
+
+### 4.3 Bookmarked Semantic URLs in Hybrid-Rerank Mode
+
+**Scenario:** User bookmarks `/search?q=react&mode=semantic`, then the deployment switches to hybrid-rerank.
+
+**Handling:**
+1. `useSearchState` validates `mode` against `capabilities.searchModes`
+2. If `semantic` is not in the available list → fall back to `capabilities.defaultMode` (hybrid)
+3. No error shown — the URL is silently corrected via `replace` navigation
+4. Search executes normally with the fallback mode
+
+This is the same pattern already used for invalid URL params (line 64–67 in `useSearchState.ts`).
+
+### 4.4 SimilarBooks Behavior
+
+In hybrid-rerank mode (no HNSW), the SimilarBooks component should be hidden because kNN similarity requires the HNSW index. The `capabilities.features.similarBooks` flag controls this.
+
+---
+
+## 5. A/B Testing Implications
+
+**Finding:** There is no A/B testing framework in the codebase. No feature flags, experiments, or split-test infrastructure exists.
+
+**Recommendation for future:** If A/B testing is needed to compare HNSW vs hybrid-rerank performance:
+- The capabilities API already distinguishes architectures
+- Analytics events should include `architecture` in their payload
+- The backend controls which architecture serves each request — the frontend just adapts
+- No frontend A/B framework is needed; the architecture is a deployment-level decision
+
+---
+
+## 6. Implementation Plan (Estimated)
+
+| Step | Files | Effort |
+|------|-------|--------|
+| 1. Create `useCapabilities` hook + `CapabilitiesContext` | 2 new files | Small |
+| 2. Wire into `App.tsx` | 1 file edit | Trivial |
+| 3. Update `useSearchState` to use dynamic modes/defaults | 1 file edit | Small |
+| 4. Filter `MODE_OPTIONS` in SearchPage | 1 file edit | Trivial |
+| 5. Gate `SimilarBooks` on capabilities | 1 file edit | Trivial |
+| 6. Add architecture card to Admin Infrastructure | 1 file edit | Small |
+| 7. Add i18n keys for new strings (4 locales) | 4 file edits | Small |
+| 8. Tests for new hook, context, and mode filtering | ~3-5 new test files | Medium |
+
+**Total estimate:** ~2-3 days of focused frontend work, assuming the backend `/api/capabilities` endpoint is already available.
+
+---
+
+## 7. Open Questions for Team
+
+1. **Parker (Backend):** Can you implement `GET /api/capabilities`? The contract is in section 3.1.
+2. **Ash (Solr):** In hybrid-rerank mode, does the existing `/v1/search?mode=hybrid` endpoint automatically use reranking, or does it need a new mode value like `hybrid-rerank`?
+3. **Ripley (Lead):** Should we add the architecture to analytics events now, or defer?
+4. **SimilarBooks:** In hybrid-rerank mode, is there any fallback for similar books (e.g., BM25-based "related books"), or should we hide it entirely?

--- a/.squad/decisions/inbox/ash-hybrid-rerank-pipeline.md
+++ b/.squad/decisions/inbox/ash-hybrid-rerank-pipeline.md
@@ -1,0 +1,39 @@
+# Decision: Hybrid-Rerank Search Pipeline Design
+
+**Author:** Ash (Search Engineer)  
+**Date:** 2025-07-23  
+**Status:** Proposed
+
+## Context
+
+We want to support a second search architecture mode ("hybrid-rerank") that avoids HNSW indexing overhead. Instead of kNN retrieval, BM25 finds candidates and application-side cosine similarity reranks them using stored vectors.
+
+## Decision
+
+### Schema
+- Add a `knn_vector_768_stored` field type (DenseVectorField, no `knnAlgorithm`) and an `embedding_rerank` field with `indexed="false" stored="true"`. This avoids HNSW graph construction and saves ~300 MB heap per 100K chunks.
+- Single schema supports both modes. Unpopulated fields have zero overhead.
+
+### Query Architecture
+- New `hybrid-rerank` search mode added to `VALID_SEARCH_MODES`.
+- Stage 1: BM25 via existing `build_solr_params()` with larger candidate pool (200+).
+- Stage 2: Retrieve `book_embedding` (parent-level) via `fl` parameter for app-side cosine reranking.
+- Stage 3: RRF fusion using existing `reciprocal_rank_fusion()` — BM25 rank + cosine rank.
+
+### Tradeoffs Accepted
+- **BM25 recall ceiling:** Conceptual and cross-lingual queries will have lower recall since HNSW is not a first-stage retriever. Mitigated by larger candidate pools and synonym expansion.
+- **Book-level vs chunk-level reranking:** v1 uses `book_embedding` for simplicity. Chunk-level reranking deferred to v2.
+
+### No Changes Needed
+- `solrconfig.xml` unchanged — standard `/select` queries suffice.
+- Existing search modes (keyword, semantic, hybrid) unchanged.
+
+## Alternatives Considered
+- **pfloats field for stored vectors:** Works universally but loses type safety. DenseVectorField with indexed=false is cleaner.
+- **Solr-side LTR reranking:** More complex, requires module loading and model management. App-side reranking is simpler for v1.
+- **Two separate schema variants:** Rejected — single schema with optional fields is simpler to maintain.
+
+## Impact
+- **Ash:** Schema PR to add field type + field (Phase 1)
+- **Parker:** Indexer and query path changes (Phases 2-3)
+- **Quality:** A/B comparison needed before production (Phase 4). Success: ≤5% nDCG@10 regression, ≥30% RAM reduction.

--- a/.squad/decisions/inbox/brett-dev-integration-test.md
+++ b/.squad/decisions/inbox/brett-dev-integration-test.md
@@ -1,0 +1,97 @@
+# Brett Decision: Dev Integration Test Single-Node Topology (#1496)
+
+**Date:** 2026-04-21  
+**Status:** ACCEPTED  
+**Scope:** CI/CD, GitHub Actions workflows  
+
+## Summary
+
+Created a new GitHub Actions workflow (`dev-integration-test.yml`) that runs integration tests on the `dev` branch using a single-node Solr topology instead of the full 3-node SolrCloud cluster used in `integration-test.yml` (which targets `main`).
+
+## Problem
+
+The existing `integration-test.yml` workflow runs on PRs to `main` and uses a 3-node SolrCloud topology with a 3-node ZooKeeper quorum. This full topology:
+- Takes 75 minutes to complete
+- Requires significant resources (~17 containers)
+- Is overkill for dev branch testing, where resilience isn't critical
+
+Dev branch PRs need faster feedback without sacrificing test coverage.
+
+## Solution
+
+**New workflow:** `.github/workflows/dev-integration-test.yml`
+
+**Topology:**
+- 1 Solr node (vs 3)
+- 1 ZooKeeper node (vs 3)
+- All other services (Python, Redis, RabbitMQ, nginx) unchanged
+- ~6 active containers (vs 17 in full SolrCloud)
+
+**Implementation approach:**
+- Docker Compose profile overrides in CI step (`services: { solr2: { profiles: [disabled] }, solr3: { profiles: [disabled] }, ... }`)
+- No separate `compose.single-node.yml` file — keeps maintenance burden low
+- Consistent with existing `docker/compose.e2e.yml` pattern
+
+**Test coverage:** Unchanged
+- Python E2E tests (full suite)
+- Playwright browser tests (full suite)
+- Same auth/admin API validation
+- Solr cluster health checks adapted for single node
+
+**Timeout:** 45 minutes (vs 75 for full workflow)
+
+## Design Rationale
+
+### Why single-node for dev?
+- SolrCloud resilience features (replication, replica recovery, leader election, peer sync) add complexity and time
+- Dev branch testing validates application correctness, not cluster robustness
+- Node failures and recovery are tested on `main` with the full SolrCloud topology
+- Single-node is sufficient to catch indexing bugs, query issues, and API integration problems
+
+### Why not a separate `compose.single-node.yml` overlay?
+- Profile overrides are applied inline in the CI step, avoiding a new file
+- Reduces maintenance burden — no need to keep two compose file variants in sync
+- Consistent with `docker/compose.e2e.yml` which applies minimal, workflow-specific overrides
+- The override is small (~30 lines) and self-documenting in the workflow
+
+### Timeout justification
+- Full SolrCloud workflow: 75 minutes (includes 3-node startup, leader election, etc.)
+- Single-node: expected 30–35 minutes with cold Docker build, 20 min with cached layers
+- 45 minutes is conservative and allows for slower runners or extended health checks
+
+## Deployment & CI Changes
+
+**New files:**
+- `.github/workflows/dev-integration-test.yml` — 415 lines
+
+**Modified files:** None
+
+**Workflow triggers:**
+- `push` to `dev` branch
+- `pull_request` to `dev` branch
+- `workflow_dispatch` (manual)
+
+**Change detection:** Inherits from existing pattern — skips if only non-build files changed (docs, .squad/, etc.)
+
+## Related Workflows
+
+| Workflow | Branch | Topology | Timeout |
+|----------|--------|----------|---------|
+| integration-test.yml | main | 3-node SolrCloud + ZK quorum | 75 min |
+| dev-integration-test.yml | dev | 1-node Solr + single ZK | 45 min |
+
+Both workflows run the same test suites; topology differs only.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Single-node Solr doesn't catch replica/replication bugs | Full 3-node tests run on main; dev is for app-level validation |
+| ZooKeeper single-node behavior differs from quorum | Single ZK node still validates Solr can connect to ZK; most app code doesn't interact with ZK directly |
+| Single node runs out of memory or hits resource limits | Monitoring in dev can catch this; containers have same limits as in 3-node setup |
+
+## Future Considerations
+
+1. **Branch-specific test matrices:** If dev & main test suites diverge, may need separate test configs per workflow
+2. **Performance baselines:** Monitor actual runtimes; adjust timeout if consistently too high/low
+3. **SolrCloud feature coverage:** If new features depend on replication/leader election, add tests to integration-test.yml only

--- a/.squad/decisions/inbox/dallas-ui-search-modes.md
+++ b/.squad/decisions/inbox/dallas-ui-search-modes.md
@@ -1,0 +1,33 @@
+# Decision: UI Search Mode Configuration for Dual Architecture Support
+
+**Author:** Dallas (Frontend Dev)  
+**Date:** 2025-07-23  
+**Status:** Proposed
+
+## Summary
+
+The UI currently hardcodes three search modes (keyword, semantic, hybrid). To support the new hybrid-rerank architecture (which lacks HNSW and thus cannot do pure semantic search), the frontend needs to dynamically discover available search modes from the backend.
+
+## Decision
+
+1. **Capabilities API:** The frontend will call `GET /api/capabilities` at startup to learn which search modes are available and what the default mode should be.
+2. **Hide unavailable modes:** When semantic search is unavailable, hide the button entirely (don't gray it out — users don't need to know about missing architecture).
+3. **Dynamic defaults:** The default search mode comes from the capabilities API (`defaultMode`). In HNSW mode: `keyword`. In hybrid-rerank mode: `hybrid`.
+4. **URL fallback:** If a bookmarked URL contains `mode=semantic` but semantic isn't available, silently fall back to the default mode.
+5. **SimilarBooks gating:** Hide the SimilarBooks component when `capabilities.features.similarBooks` is false (no HNSW = no kNN).
+6. **Admin visibility only:** Architecture mode info is shown on the Admin Infrastructure page, not to regular users.
+7. **Graceful degradation:** If the capabilities endpoint fails, show all modes (current behavior) and let search API 400 errors handle unavailability as they do today.
+
+## Rationale
+
+- Users care about "search works" not "which index technology is active"
+- Hiding vs graying out avoids confusion and support questions
+- Capabilities API is the industry-standard pattern for runtime feature discovery
+- Non-blocking fetch means no UX degradation on slow/failed capability checks
+
+## Impact
+
+- **Frontend:** New `CapabilitiesContext`, `useCapabilities` hook; updates to SearchPage, useSearchState, SimilarBooks, AdminInfrastructurePage
+- **Backend (Parker):** Needs to implement `GET /api/capabilities`
+- **i18n:** ~4-6 new keys across 4 locales
+- **Tests:** New test files for capabilities hook and mode filtering

--- a/.squad/decisions/inbox/parker-api-search-modes.md
+++ b/.squad/decisions/inbox/parker-api-search-modes.md
@@ -1,0 +1,36 @@
+# Decision: API Design for Dual Search Architecture Modes
+
+**Author:** Parker (Backend Dev)
+**Date:** 2026-07-15
+**Status:** Proposed
+
+## Context
+
+We need to support two search architecture modes: HNSW (current Solr kNN) and hybrid-rerank (BM25 candidates + app-side cosine reranking). This affects solr-search API behavior, configuration, and the new capabilities endpoint.
+
+## Decisions
+
+1. **`SEARCH_ARCHITECTURE` env var** controls mode (`hnsw` default, `hybrid-rerank`). Added to solr-search `config.py` Settings dataclass.
+
+2. **`GET /v1/capabilities` endpoint** — public, no auth. Returns architecture type, available search modes, quantization, embedding dimensions, allowed collections. UI calls this at startup.
+
+3. **Reranking logic lives in `search_service.py`** — new `rerank_by_cosine_similarity()` function using numpy cosine similarity. Fed into existing `reciprocal_rank_fusion()`.
+
+4. **Document indexer is architecture-agnostic** — it always writes vectors to the field the embeddings server specifies. The stored-vs-indexed distinction is handled entirely by the Solr schema (Ash's domain).
+
+5. **numpy added as dependency** to solr-search for cosine similarity computation. Performance is ~1-5ms for 200×768D vectors — negligible.
+
+6. **`RERANK_CANDIDATES` env var** (default 200) — number of BM25 candidates to fetch for reranking in hybrid-rerank mode.
+
+7. **Hybrid-rerank requires stored vectors in Solr** — `embedding_v` (or `embedding_byte_v`) must have `stored="true"` in the schema. This is a blocking dependency on Ash.
+
+## Impact
+
+- solr-search: 4 files modified (config.py, search_service.py, main.py, plus tests)
+- document-indexer: no code changes (schema-driven)
+- embeddings-server: no changes
+- Backward compatible: defaults to `hnsw` (current behavior)
+
+## Full Analysis
+
+See `.squad/analysis/api-search-architecture-modes.md`

--- a/.squad/decisions/inbox/parker-quantization-code.md
+++ b/.squad/decisions/inbox/parker-quantization-code.md
@@ -1,0 +1,22 @@
+# Decision: Embeddings Response Includes field_name (#1502)
+
+**Author:** Parker (Backend Dev)
+**Date:** 2026-04-20
+**Status:** Implemented
+
+## Context
+
+Issue #1502 adds configurable vector quantization. Different modes (none, fp16, int8) target different Solr fields — `embedding_v` for float vectors and `embedding_byte_v` for int8 byte-encoded vectors.
+
+## Decision
+
+The embeddings-server `/v1/embeddings/` response now includes a `field_name` key per embedding item (e.g., `"embedding"` or `"embedding_byte"`). The document-indexer uses this field name (suffixed with `_v`) as the Solr field key in the indexed document.
+
+This keeps the field-routing logic centralized in the embeddings-server (which knows the quantization mode) rather than requiring every consumer to duplicate mode→field mapping.
+
+## Implications
+
+- **Backward compatible**: `field_name` defaults to `"embedding"` — existing consumers that ignore it get the same behavior
+- **Ash (Solr schema)**: The `embedding_byte` field must exist in the Solr schema when int8 mode is active. Ash has already added this field type.
+- **Dallas (UI)**: No UI impact — quantization is transparent to the frontend
+- **Future consumers**: Any new service that calls `/v1/embeddings/` should use `field_name` to determine the correct storage field

--- a/.squad/decisions/inbox/ripley-hnsw-hybrid-architecture.md
+++ b/.squad/decisions/inbox/ripley-hnsw-hybrid-architecture.md
@@ -1,0 +1,51 @@
+# Decision: HNSW vs Hybrid-Rerank Dual Architecture
+
+**Author:** Ripley (Lead)
+**Date:** 2025-07-25
+**Status:** Proposed
+**Scope:** System-wide (Solr schema, search API, UI, Docker)
+
+## Context
+
+HNSW vector indexes consume 9–28 GB RAM for 9M page vectors. Some deployments (dev, small machines, cost-constrained) cannot afford this. We need a second deployment mode that eliminates HNSW but retains semantic capability via application-side vector reranking.
+
+## Decision
+
+Introduce `SEARCH_ARCHITECTURE` env var with two modes:
+
+1. **`hnsw`** (default) — current behavior, all three search modes available
+2. **`hybrid-rerank`** — no HNSW index, BM25 retrieval + app-side cosine reranking
+
+Key design choices:
+- **Explicit configuration** over auto-detection (clearer, debuggable)
+- **Same `embedding_v` field name**, schema type changes at init time (Option B)
+- **RRF fusion for hybrid-rerank** (consistent with HNSW hybrid)
+- **`/v1/capabilities` endpoint** for UI to discover available modes
+- **Semantic search disabled** in hybrid-rerank (returns 400)
+- **Similar-books disabled** in hybrid-rerank (returns 501)
+
+## Trade-offs
+
+| Dimension | HNSW | Hybrid-Rerank |
+|-----------|------|---------------|
+| RAM | 9–28 GB | ~0 GB (for HNSW) |
+| Semantic recall | Full kNN coverage | Bounded by BM25 top-N |
+| Cross-lingual | Strong | Weak |
+| Latency | Comparable | Comparable |
+| Complexity | Current | +1 code path |
+
+## Risks
+
+- Mode switching requires full reindex (documented as maintenance operation)
+- Rerank quality ceiling — BM25 misses purely semantic matches
+- Network overhead: ~600 KB per query for 200 stored vectors
+
+## Implementation Order
+
+Phase 1 (Foundation) → Phase 2 (Search Path) → Phase 3 (UI + Docker) → Phase 4 (Validation)
+
+Full analysis: `.squad/analysis/hnsw-vs-hybrid-architecture.md`
+
+## Affected Teams
+
+Parker (config/API), Ash (schema/search), Dallas (UI), Brett (Docker), Lambert (testing)


### PR DESCRIPTION
Analysis documents for configurable search architecture (issue #1506).

## Squad Analysis

Four agents analyzed the full stack impact of making search architecture configurable:

| Agent | Area | Document |
|-------|------|----------|
| 🏗️ Ripley | Architecture | `hnsw-vs-hybrid-architecture.md` |
| 🔍 Ash | Search pipeline | `hybrid-rerank-search-pipeline.md` |
| ⚛️ Dallas | Frontend UI | `ui-search-mode-configuration.md` |
| 🔧 Parker | API contract | `api-search-architecture-modes.md` |

## Key Findings (validated by rubber-duck review)

- **Hybrid-rerank is feasible** with zero HNSW RAM and comparable latency
- BM25 recall ceiling: ~72-82% (acceptable for cost-constrained deployments)
- Single Solr schema with dual fields (HNSW + stored-only) supports both modes
- Switching modes requires reindexing to reclaim/build HNSW graph
- Reranking 200×768D vectors: ~1-5ms compute, ~1-3MB deserialization (benchmark needed)
- UI adapts via `/v1/capabilities` endpoint + React CapabilitiesContext

Ref #1506

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>