### PR TITLE
feat: configurable search architecture (HNSW vs hybrid-rerank)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,20 @@ BUILD_DATE=1970-01-01T00:00:00Z
 # BOOK_EMBEDDING_FIELD=embedding_byte_v
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Search Architecture — controls how vector search works
+# ──────────────────────────────────────────────────────────────────────────────
+# Values: hnsw (default), hybrid-rerank
+#
+# hnsw: Full kNN vector search via Solr HNSW index. All three search modes
+#       (keyword, semantic, hybrid) available. Requires RAM for HNSW graph.
+#
+# hybrid-rerank: NO HNSW index, zero vector RAM overhead. BM25 finds candidates,
+#       stored vectors are fetched from Solr, cosine similarity computed in Python,
+#       results fused via RRF. Only keyword and hybrid modes available.
+#       Trades recall for memory savings — ideal for 32GB deployments at scale.
+# SEARCH_ARCHITECTURE=hnsw
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Solr Version (9 or 10) — controls CLI syntax and schema parameter names.
 # See docs/migration/solr-compat-layer.md for migration details.
 # ──────────────────────────────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,9 @@ BUILD_DATE=1970-01-01T00:00:00Z
 #       stored vectors are fetched from Solr, cosine similarity computed in Python,
 #       results fused via RRF. Only keyword and hybrid modes available.
 #       Trades recall for memory savings — ideal for 32GB deployments at scale.
+#
+# Note: The installer does not persist this setting. If you change it, add
+# SEARCH_ARCHITECTURE to your .env file manually.
 # SEARCH_ARCHITECTURE=hnsw
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/aithena-ui/src/__tests__/SearchPage.test.tsx
+++ b/src/aithena-ui/src/__tests__/SearchPage.test.tsx
@@ -8,6 +8,17 @@ import { IntlWrapper } from './test-intl-wrapper';
 import { ToastProvider } from '../contexts/ToastContext';
 import { AuthContext, AuthContextValue } from '../contexts/AuthContext';
 
+vi.mock('../contexts/CapabilitiesContext', () => ({
+  useCapabilities: () => ({
+    searchModes: ['keyword', 'semantic', 'hybrid'],
+    architecture: 'hnsw',
+    vectorDimensions: 768,
+    similarBooks: true,
+    loading: false,
+  }),
+  CapabilitiesProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 const mockAuthValue: AuthContextValue = {
   user: { id: 1, username: 'testuser', role: 'user' },
   token: 'test-token',

--- a/src/aithena-ui/src/contexts/CapabilitiesContext.tsx
+++ b/src/aithena-ui/src/contexts/CapabilitiesContext.tsx
@@ -42,6 +42,7 @@ export function CapabilitiesProvider({ children }: { children: ReactNode }) {
       try {
         const resp = await apiFetch(buildApiUrl('/v1/capabilities'), {
           skipAuth: true,
+          skipUnauthorizedHandler: true,
         });
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();

--- a/src/aithena-ui/src/contexts/CapabilitiesContext.tsx
+++ b/src/aithena-ui/src/contexts/CapabilitiesContext.tsx
@@ -1,0 +1,77 @@
+/**
+ * CapabilitiesContext — fetch and cache backend search capabilities.
+ *
+ * Calls GET /v1/capabilities at startup and exposes the result to the
+ * component tree.  Components use `useCapabilities()` to read:
+ * - which search modes are available
+ * - the search architecture (hnsw vs hybrid-rerank)
+ * - whether similar books is available
+ *
+ * If the endpoint is unavailable, assumes HNSW with all modes (graceful fallback).
+ */
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+import { apiFetch, buildApiUrl } from '../api';
+import type { SearchMode } from '../hooks/search';
+
+export interface Capabilities {
+  searchModes: SearchMode[];
+  architecture: string;
+  vectorDimensions: number;
+  similarBooks: boolean;
+  loading: boolean;
+}
+
+const DEFAULT_CAPABILITIES: Capabilities = {
+  searchModes: ['keyword', 'semantic', 'hybrid'],
+  architecture: 'hnsw',
+  vectorDimensions: 768,
+  similarBooks: true,
+  loading: true,
+};
+
+const CapabilitiesContext = createContext<Capabilities>(DEFAULT_CAPABILITIES);
+
+export function CapabilitiesProvider({ children }: { children: ReactNode }) {
+  const [caps, setCaps] = useState<Capabilities>(DEFAULT_CAPABILITIES);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchCapabilities() {
+      try {
+        const resp = await apiFetch(buildApiUrl('/v1/capabilities'), {
+          skipAuth: true,
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (!cancelled) {
+          setCaps({
+            searchModes: data.search_modes ?? ['keyword', 'semantic', 'hybrid'],
+            architecture: data.architecture ?? 'hnsw',
+            vectorDimensions: data.vector_dimensions ?? 768,
+            similarBooks: data.similar_books ?? true,
+            loading: false,
+          });
+        }
+      } catch {
+        // Graceful fallback: assume HNSW with all modes
+        if (!cancelled) {
+          setCaps({ ...DEFAULT_CAPABILITIES, loading: false });
+        }
+      }
+    }
+
+    fetchCapabilities();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return <CapabilitiesContext.Provider value={caps}>{children}</CapabilitiesContext.Provider>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useCapabilities(): Capabilities {
+  return useContext(CapabilitiesContext);
+}

--- a/src/aithena-ui/src/main.tsx
+++ b/src/aithena-ui/src/main.tsx
@@ -6,6 +6,7 @@ import './normal.css';
 import App from './App.tsx';
 import { RouteErrorBoundary } from './Components/ErrorBoundary';
 import { AuthProvider } from './contexts/AuthContext';
+import { CapabilitiesProvider } from './contexts/CapabilitiesContext';
 import { I18nProvider } from './contexts/I18nContext';
 import { ToastProvider } from './contexts/ToastContext';
 
@@ -29,11 +30,13 @@ async function bootstrap() {
       <I18nProvider>
         <BrowserRouter>
           <AuthProvider>
-            <ToastProvider>
-              <RouteErrorBoundary>
-                <App />
-              </RouteErrorBoundary>
-            </ToastProvider>
+            <CapabilitiesProvider>
+              <ToastProvider>
+                <RouteErrorBoundary>
+                  <App />
+                </RouteErrorBoundary>
+              </ToastProvider>
+            </CapabilitiesProvider>
           </AuthProvider>
         </BrowserRouter>
       </I18nProvider>

--- a/src/aithena-ui/src/pages/SearchPage.tsx
+++ b/src/aithena-ui/src/pages/SearchPage.tsx
@@ -196,7 +196,7 @@ function SearchResultsSection({
         )}
       </section>
 
-      {focusedBookId && capabilities.similarBooks && (
+      {focusedBookId && !capabilities.loading && capabilities.similarBooks && (
         <SimilarBooks documentId={focusedBookId} onSelectBook={onSelectSimilarBook} />
       )}
 

--- a/src/aithena-ui/src/pages/SearchPage.tsx
+++ b/src/aithena-ui/src/pages/SearchPage.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -27,6 +28,7 @@ import { useSearch, BookResult, SearchMode } from '../hooks/search';
 import { onRenderCallback } from '../utils/profiler';
 import { useToast } from '../contexts/ToastContext';
 import { useAuth } from '../contexts/AuthContext';
+import { useCapabilities } from '../contexts/CapabilitiesContext';
 import BatchSelectionToolbar from '../Components/BatchSelectionToolbar';
 import BatchEditPanel from '../Components/BatchEditPanel';
 
@@ -129,6 +131,7 @@ function SearchResultsSection({
   onSaveToCollection,
 }: SearchResultsSectionProps) {
   const intl = useIntl();
+  const capabilities = useCapabilities();
   const totalPages = Math.ceil(total / limit);
   const resultsHeadingId = `${resultsRegionId}-heading`;
 
@@ -193,7 +196,7 @@ function SearchResultsSection({
         )}
       </section>
 
-      {focusedBookId && (
+      {focusedBookId && capabilities.similarBooks && (
         <SimilarBooks documentId={focusedBookId} onSelectBook={onSelectSimilarBook} />
       )}
 
@@ -238,6 +241,13 @@ function SearchPage() {
 
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
+  const capabilities = useCapabilities();
+
+  // Filter mode options based on backend capabilities
+  const availableModeOptions = useMemo(
+    () => MODE_OPTIONS.filter((opt) => capabilities.searchModes.includes(opt.value)),
+    [capabilities.searchModes]
+  );
 
   const [selectionMode, setSelectionMode] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
@@ -486,7 +496,7 @@ function SearchPage() {
             role="group"
             aria-label={intl.formatMessage({ id: 'search.modeGroupLabel' })}
           >
-            {MODE_OPTIONS.map((option) => (
+            {availableModeOptions.map((option) => (
               <button
                 key={option.value}
                 type="button"

--- a/src/solr-search/config.py
+++ b/src/solr-search/config.py
@@ -94,6 +94,7 @@ class Settings:
     collection_embeddings_urls: tuple[tuple[str, str], ...]
     comparison_baseline_collection: str
     comparison_candidate_collection: str
+    search_architecture: str = "hnsw"
     docker_host: str = ""
     rabbitmq_management_path_prefix: str = "/admin/rabbitmq"
     log_tail_max: int = 5000
@@ -197,6 +198,7 @@ settings = Settings(
     comparison_baseline_collection=os.environ.get("COMPARISON_BASELINE_COLLECTION", "books"),
     comparison_candidate_collection=os.environ.get("COMPARISON_CANDIDATE_COLLECTION", "books"),
     docker_host=os.environ.get("DOCKER_HOST", "unix:///var/run/docker.sock"),
+    search_architecture=os.environ.get("SEARCH_ARCHITECTURE", "hnsw"),
     rabbitmq_management_path_prefix=os.environ.get("RABBITMQ_MANAGEMENT_PATH_PREFIX", "/admin/rabbitmq"),
     log_tail_max=int(os.environ.get("LOG_TAIL_MAX", "5000")),
     ascii_folding=os.environ.get("SOLR_ASCII_FOLDING", "true").lower() == "true",

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -157,6 +157,13 @@ _MODES_BY_ARCHITECTURE: dict[str, frozenset[str]] = {
 VALID_SEARCH_MODES: frozenset[str] = _MODES_BY_ARCHITECTURE.get(
     settings.search_architecture, _MODES_BY_ARCHITECTURE["hnsw"]
 )
+
+# Effective default search mode — falls back to "keyword" if configured default
+# is not available in the current architecture.
+EFFECTIVE_DEFAULT_SEARCH_MODE: str = (
+    settings.default_search_mode if settings.default_search_mode in VALID_SEARCH_MODES else "keyword"
+)
+
 EMBEDDINGS_DEGRADED_MESSAGE = "Embeddings unavailable — showing keyword results"
 
 SHA256_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
@@ -172,11 +179,12 @@ async def lifespan(_app: FastAPI):
             f"Invalid SEARCH_ARCHITECTURE={settings.search_architecture!r}. "
             f"Must be one of: {', '.join(sorted(_VALID_ARCHITECTURES))}"
         )
-    if settings.default_search_mode not in VALID_SEARCH_MODES:
+    if settings.default_search_mode != EFFECTIVE_DEFAULT_SEARCH_MODE:
         logger.warning(
-            "DEFAULT_SEARCH_MODE=%r is not available in %s architecture; falling back to 'keyword'",
+            "DEFAULT_SEARCH_MODE=%r is not available in %s architecture; using %r",
             settings.default_search_mode,
             settings.search_architecture,
+            EFFECTIVE_DEFAULT_SEARCH_MODE,
         )
     if settings.auth_jwt_secret in _INSECURE_JWT_SECRETS:
         logger.warning(
@@ -940,7 +948,7 @@ def search(
     fq_series: str | None = Query(None),
     fq_folder: str | None = Query(None),
     mode: str = Query(
-        settings.default_search_mode,
+        EFFECTIVE_DEFAULT_SEARCH_MODE,
         description="Search mode: keyword (BM25), semantic (Solr kNN), or hybrid (RRF fusion).",
         enum=list(VALID_SEARCH_MODES),
     ),
@@ -1352,6 +1360,8 @@ def _search_hybrid_rerank(
             sort,
             filters,
             collection=collection,
+            requested_mode="hybrid",
+            message="Non-relevance sort; vector reranking skipped",
         )
 
     candidate_limit = min(_RERANK_CANDIDATE_LIMIT, max(page_size * 10, 50))
@@ -1396,6 +1406,7 @@ def _search_hybrid_rerank(
     kw_response = kw_payload.get("response", {})
     kw_highlighting = kw_payload.get("highlighting", {})
     kw_docs = kw_response.get("docs", [])
+    bm25_total = kw_response.get("numFound", 0)
 
     if not kw_docs:
         return {
@@ -1404,7 +1415,7 @@ def _search_hybrid_rerank(
             "architecture": "hybrid-rerank",
             "sort": {"by": "score", "order": "desc"},
             "degraded": False,
-            **build_pagination(0, 1, page_size),
+            **build_pagination(0, page, page_size),
             "results": [],
             "facets": parse_facet_counts(kw_payload),
         }
@@ -1432,7 +1443,7 @@ def _search_hybrid_rerank(
             "sort": {"by": "score", "order": "desc"},
             "degraded": True,
             "message": "No vector embeddings available for reranking — showing keyword results",
-            **build_pagination(len(kw_results), 1, page_size),
+            **build_pagination(bm25_total, page, page_size),
             "results": kw_results[:page_size],
             "facets": parse_facet_counts(kw_payload),
         }
@@ -1449,7 +1460,9 @@ def _search_hybrid_rerank(
             entry["score"] = sim_score
             sem_results.append(entry)
 
-    fused = reciprocal_rank_fusion(kw_results, sem_results, k=settings.rrf_k)[:page_size]
+    fused = reciprocal_rank_fusion(kw_results, sem_results, k=settings.rrf_k)
+    start = (page - 1) * page_size
+    page_results = fused[start : start + page_size]
 
     return {
         "query": q,
@@ -1457,8 +1470,8 @@ def _search_hybrid_rerank(
         "architecture": "hybrid-rerank",
         "sort": {"by": "score", "order": "desc"},
         "degraded": False,
-        **build_pagination(len(fused), 1, page_size),
-        "results": fused,
+        **build_pagination(bm25_total, page, page_size),
+        "results": page_results,
         "facets": parse_facet_counts(kw_payload),
     }
 
@@ -1567,7 +1580,7 @@ def search_compare(
     fq_series: str | None = Query(None),
     fq_folder: str | None = Query(None),
     mode: str = Query(
-        settings.default_search_mode,
+        EFFECTIVE_DEFAULT_SEARCH_MODE,
         description="Search mode: keyword, semantic, or hybrid.",
     ),
     _rate_limit: None = Depends(check_search_rate_limit),

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -22,6 +22,11 @@ from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, U
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
+from rerank_service import (
+    build_chunk_vector_params,
+    cosine_rerank,
+    extract_grouped_vectors,
+)
 
 import redis as redis_lib
 from admin_auth import require_admin_auth
@@ -141,7 +146,17 @@ T = TypeVar("T")
 SortBy = Literal["score", "title", "author", "year", "category", "language"]
 SortOrder = Literal["asc", "desc"]
 
-VALID_SEARCH_MODES: frozenset[str] = frozenset({"keyword", "semantic", "hybrid"})
+_VALID_ARCHITECTURES = frozenset({"hnsw", "hybrid-rerank"})
+
+# Search modes available per architecture
+_MODES_BY_ARCHITECTURE: dict[str, frozenset[str]] = {
+    "hnsw": frozenset({"keyword", "semantic", "hybrid"}),
+    "hybrid-rerank": frozenset({"keyword", "hybrid"}),
+}
+
+VALID_SEARCH_MODES: frozenset[str] = _MODES_BY_ARCHITECTURE.get(
+    settings.search_architecture, _MODES_BY_ARCHITECTURE["hnsw"]
+)
 EMBEDDINGS_DEGRADED_MESSAGE = "Embeddings unavailable — showing keyword results"
 
 SHA256_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
@@ -152,6 +167,17 @@ _INSECURE_JWT_SECRETS = frozenset({"development-only-change-me", "", "changeme",
 
 @contextlib.asynccontextmanager
 async def lifespan(_app: FastAPI):
+    if settings.search_architecture not in _VALID_ARCHITECTURES:
+        raise ValueError(
+            f"Invalid SEARCH_ARCHITECTURE={settings.search_architecture!r}. "
+            f"Must be one of: {', '.join(sorted(_VALID_ARCHITECTURES))}"
+        )
+    if settings.default_search_mode not in VALID_SEARCH_MODES:
+        logger.warning(
+            "DEFAULT_SEARCH_MODE=%r is not available in %s architecture; falling back to 'keyword'",
+            settings.default_search_mode,
+            settings.search_architecture,
+        )
     if settings.auth_jwt_secret in _INSECURE_JWT_SECRETS:
         logger.warning(
             "AUTH_JWT_SECRET is using an insecure default value. "
@@ -710,6 +736,22 @@ def version() -> dict[str, str]:
     }
 
 
+@app.get("/v1/capabilities", include_in_schema=False, name="capabilities_v1")
+@app.get("/capabilities")
+def capabilities() -> dict[str, Any]:
+    """Return the search capabilities of this deployment.
+
+    The frontend uses this to dynamically show/hide search modes and
+    features based on the configured search architecture.
+    """
+    return {
+        "search_modes": sorted(VALID_SEARCH_MODES),
+        "architecture": settings.search_architecture,
+        "vector_dimensions": 768,
+        "similar_books": settings.search_architecture == "hnsw",
+    }
+
+
 @app.post("/v1/auth/login/", include_in_schema=False, name="auth_login_v1_slash")
 @app.post("/v1/auth/login", name="auth_login_v1")
 def auth_login(credentials: LoginRequest, request: Request, response: Response) -> dict[str, Any]:
@@ -925,7 +967,11 @@ def search(
     if mode not in VALID_SEARCH_MODES:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid search mode: {mode!r}. Must be one of: keyword, semantic, hybrid.",
+            detail=(
+                f"Invalid search mode: {mode!r}. "
+                f"Available modes for {settings.search_architecture} architecture: "
+                f"{', '.join(sorted(VALID_SEARCH_MODES))}."
+            ),
         )
 
     resolved_page_size = resolve_page_size(limit, page_size)
@@ -1153,6 +1199,26 @@ def _search_hybrid(
     *,
     collection: str | None = None,
 ) -> dict[str, Any]:
+    """Execute hybrid search — delegates to HNSW or rerank based on architecture."""
+    if settings.search_architecture == "hybrid-rerank":
+        return _search_hybrid_rerank(
+            request, q, page, page_size, sort_by, sort_order, sort, filters, collection=collection
+        )
+    return _search_hybrid_hnsw(request, q, page, page_size, sort_by, sort_order, sort, filters, collection=collection)
+
+
+def _search_hybrid_hnsw(
+    request: Request,
+    q: str,
+    page: int,
+    page_size: int,
+    sort_by: str,
+    sort_order: str,
+    sort: str | None,
+    filters: dict[str, str],
+    *,
+    collection: str | None = None,
+) -> dict[str, Any]:
     """Execute BM25 and kNN searches in parallel, then fuse with RRF.
 
     Facets and highlights are sourced from the BM25 (keyword) leg.
@@ -1236,6 +1302,159 @@ def _search_hybrid(
     return {
         "query": q,
         "mode": "hybrid",
+        "sort": {"by": "score", "order": "desc"},
+        "degraded": False,
+        **build_pagination(len(fused), 1, page_size),
+        "results": fused,
+        "facets": parse_facet_counts(kw_payload),
+    }
+
+
+_RERANK_CANDIDATE_LIMIT = 200  # BM25 candidates to rerank
+
+
+def _search_hybrid_rerank(
+    request: Request,
+    q: str,
+    page: int,
+    page_size: int,
+    sort_by: str,
+    sort_order: str,
+    sort: str | None,
+    filters: dict[str, str],
+    *,
+    collection: str | None = None,
+) -> dict[str, Any]:
+    """Hybrid search without HNSW: BM25 → fetch stored vectors → cosine rerank → RRF.
+
+    1. BM25 query returns top-N parent docs (books)
+    2. Fetch first-chunk embeddings for those books from Solr
+    3. Compute cosine similarity between query embedding and chunk vectors
+    4. RRF fusion of BM25 rank and vector similarity rank
+    5. Return top page_size results
+
+    For non-relevance sorts (title, year, etc.), vector reranking is skipped
+    and the search falls back to pure keyword mode.
+    """
+    if not q.strip():
+        raise HTTPException(status_code=400, detail="Query cannot be empty for hybrid search")
+
+    # Non-relevance sorts bypass vector reranking
+    effective_sort = sort_by if sort is None else sort.split()[0] if sort else sort_by
+    if effective_sort != "score":
+        return _search_keyword(
+            request,
+            q,
+            page,
+            page_size,
+            sort_by,
+            sort_order,
+            sort,
+            filters,
+            collection=collection,
+        )
+
+    candidate_limit = min(_RERANK_CANDIDATE_LIMIT, max(page_size * 10, 50))
+
+    kw_params = build_params_or_400(
+        query=q,
+        page=1,
+        page_size=candidate_limit,
+        sort_by="score",
+        sort_order="desc",
+        sort=None,
+        filters=filters,
+        facet_limit=settings.facet_limit,
+    )
+
+    # Run BM25 query and embedding fetch concurrently
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        kw_future = pool.submit(query_solr, kw_params, collection=collection)
+        emb_future = pool.submit(_fetch_embedding, q, collection=collection)
+
+        kw_payload = kw_future.result()
+        try:
+            query_vector = emb_future.result()
+        except HTTPException as exc:
+            if _should_degrade_to_keyword(exc):
+                return _search_keyword(
+                    request,
+                    q,
+                    page,
+                    page_size,
+                    sort_by,
+                    sort_order,
+                    sort,
+                    filters,
+                    degraded=True,
+                    message=EMBEDDINGS_DEGRADED_MESSAGE,
+                    requested_mode="hybrid",
+                    collection=collection,
+                )
+            raise
+
+    kw_response = kw_payload.get("response", {})
+    kw_highlighting = kw_payload.get("highlighting", {})
+    kw_docs = kw_response.get("docs", [])
+
+    if not kw_docs:
+        return {
+            "query": q,
+            "mode": "hybrid",
+            "architecture": "hybrid-rerank",
+            "sort": {"by": "score", "order": "desc"},
+            "degraded": False,
+            **build_pagination(0, 1, page_size),
+            "results": [],
+            "facets": parse_facet_counts(kw_payload),
+        }
+
+    # Normalize BM25 results
+    kw_results = [
+        normalize_book(doc, kw_highlighting, build_document_url(request, doc.get("file_path_s"))) for doc in kw_docs
+    ]
+    parent_ids = [r["id"] for r in kw_results]
+
+    # Fetch first-chunk embeddings for BM25 candidates
+    vec_params = build_chunk_vector_params(parent_ids, settings.knn_field)
+    vec_payload = query_solr(vec_params, collection=collection)
+    parent_vectors = extract_grouped_vectors(vec_payload, settings.knn_field)
+
+    # Build rerank candidates (only books that have vectors)
+    doc_vectors = [(pid, parent_vectors[pid]) for pid in parent_ids if pid in parent_vectors]
+
+    if not doc_vectors:
+        # No vectors available — fall back to BM25-only results
+        return {
+            "query": q,
+            "mode": "hybrid",
+            "architecture": "hybrid-rerank",
+            "sort": {"by": "score", "order": "desc"},
+            "degraded": True,
+            "message": "No vector embeddings available for reranking — showing keyword results",
+            **build_pagination(len(kw_results), 1, page_size),
+            "results": kw_results[:page_size],
+            "facets": parse_facet_counts(kw_payload),
+        }
+
+    # Cosine rerank and RRF fusion
+    reranked = cosine_rerank(query_vector, doc_vectors)
+
+    # Build semantic-like results from rerank scores
+    result_map = {r["id"]: r for r in kw_results}
+    sem_results = []
+    for doc_id, sim_score in reranked:
+        if doc_id in result_map:
+            entry = dict(result_map[doc_id])
+            entry["score"] = sim_score
+            sem_results.append(entry)
+
+    fused = reciprocal_rank_fusion(kw_results, sem_results, k=settings.rrf_k)[:page_size]
+
+    return {
+        "query": q,
+        "mode": "hybrid",
+        "architecture": "hybrid-rerank",
         "sort": {"by": "score", "order": "desc"},
         "degraded": False,
         **build_pagination(len(fused), 1, page_size),
@@ -1363,7 +1582,11 @@ def search_compare(
     if mode not in VALID_SEARCH_MODES:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid search mode: {mode!r}. Must be one of: keyword, semantic, hybrid.",
+            detail=(
+                f"Invalid search mode: {mode!r}. "
+                f"Available modes for {settings.search_architecture} architecture: "
+                f"{', '.join(sorted(VALID_SEARCH_MODES))}."
+            ),
         )
 
     resolved_page_size = resolve_page_size(limit, page_size)
@@ -1484,7 +1707,15 @@ def similar_books(
     chunk documents (not parent book docs), so we fetch the vector from the
     book's first chunk, run kNN against all other chunks, then deduplicate
     by parent book.
+
+    Requires HNSW architecture — returns 501 in hybrid-rerank mode.
     """
+    if settings.search_architecture != "hnsw":
+        raise HTTPException(
+            status_code=501,
+            detail="Similar books requires HNSW search architecture. "
+            f"Current architecture: {settings.search_architecture}",
+        )
     embedding_field = settings.book_embedding_field
 
     # If document_id looks like a chunk ID, resolve to parent.

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -243,6 +243,9 @@ PUBLIC_PATHS: frozenset[str] = frozenset(
         "/v1/auth/validate/",
         "/v1/metrics",
         "/v1/metrics/",
+        "/v1/capabilities",
+        "/v1/capabilities/",
+        "/capabilities",
         "/docs",
         "/redoc",
         "/openapi.json",
@@ -1461,6 +1464,8 @@ def _search_hybrid_rerank(
             sem_results.append(entry)
 
     fused = reciprocal_rank_fusion(kw_results, sem_results, k=settings.rrf_k)
+    # Cap pagination to the rerank window — pages beyond it would be empty
+    rerank_total = min(bm25_total, candidate_limit)
     start = (page - 1) * page_size
     page_results = fused[start : start + page_size]
 
@@ -1470,7 +1475,7 @@ def _search_hybrid_rerank(
         "architecture": "hybrid-rerank",
         "sort": {"by": "score", "order": "desc"},
         "degraded": False,
-        **build_pagination(bm25_total, page, page_size),
+        **build_pagination(rerank_total, page, page_size),
         "results": page_results,
         "facets": parse_facet_counts(kw_payload),
     }

--- a/src/solr-search/pyproject.toml
+++ b/src/solr-search/pyproject.toml
@@ -27,10 +27,10 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=search_service --cov=main --cov=auth --cov=admin_auth --cov=config --cov=metrics --cov=correlation --cov=logging_config --cov=reset_password --cov=password_policy --cov=collections_service --cov=collections_models --cov=backup_service --cov=utils --cov=solr_compat --cov-report=term-missing --cov-report=html -ra"
+addopts = "--cov=search_service --cov=main --cov=auth --cov=admin_auth --cov=config --cov=metrics --cov=correlation --cov=logging_config --cov=reset_password --cov=password_policy --cov=collections_service --cov=collections_models --cov=backup_service --cov=utils --cov=solr_compat --cov=rerank_service --cov-report=term-missing --cov-report=html -ra"
 
 [tool.coverage.run]
-source = ["search_service", "main", "auth", "admin_auth", "config", "metrics", "correlation", "logging_config", "reset_password", "password_policy", "collections_service", "collections_models", "backup_service", "utils", "solr_compat"]
+source = ["search_service", "main", "auth", "admin_auth", "config", "metrics", "correlation", "logging_config", "reset_password", "password_policy", "collections_service", "collections_models", "backup_service", "utils", "solr_compat", "rerank_service"]
 omit = ["tests/*", "__pycache__/*"]
 
 [tool.coverage.report]

--- a/src/solr-search/rerank_service.py
+++ b/src/solr-search/rerank_service.py
@@ -20,7 +20,12 @@ def _norm(v: list[float]) -> float:
 
 
 def cosine_similarity(a: list[float], b: list[float]) -> float:
-    """Compute cosine similarity between two vectors."""
+    """Compute cosine similarity between two vectors.
+
+    Returns 0.0 if vectors differ in length or either is zero-norm.
+    """
+    if len(a) != len(b):
+        return 0.0
     norm_a = _norm(a)
     norm_b = _norm(b)
     if norm_a == 0.0 or norm_b == 0.0:
@@ -41,9 +46,20 @@ def cosine_rerank(
     Returns:
         List of (doc_id, similarity_score) sorted by descending similarity.
     """
+    query_norm = _norm(query_vector)
+    if query_norm == 0.0:
+        return [(doc_id, 0.0) for doc_id, _ in doc_vectors]
+
     scored = []
     for doc_id, vec in doc_vectors:
-        score = cosine_similarity(query_vector, vec)
+        if len(vec) != len(query_vector):
+            scored.append((doc_id, 0.0))
+            continue
+        doc_norm = _norm(vec)
+        if doc_norm == 0.0:
+            scored.append((doc_id, 0.0))
+            continue
+        score = _dot(query_vector, vec) / (query_norm * doc_norm)
         scored.append((doc_id, score))
     scored.sort(key=lambda x: x[1], reverse=True)
     return scored

--- a/src/solr-search/rerank_service.py
+++ b/src/solr-search/rerank_service.py
@@ -1,0 +1,94 @@
+"""App-side cosine reranking for hybrid-rerank search architecture.
+
+When SEARCH_ARCHITECTURE=hybrid-rerank, there is no HNSW index. Instead,
+BM25 retrieves candidate documents, stored vectors are fetched from Solr,
+and this module computes cosine similarity for RRF fusion.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def _dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b, strict=True))
+
+
+def _norm(v: list[float]) -> float:
+    return math.sqrt(sum(x * x for x in v))
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    norm_a = _norm(a)
+    norm_b = _norm(b)
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return _dot(a, b) / (norm_a * norm_b)
+
+
+def cosine_rerank(
+    query_vector: list[float],
+    doc_vectors: list[tuple[str, list[float]]],
+) -> list[tuple[str, float]]:
+    """Rank documents by cosine similarity to the query vector.
+
+    Args:
+        query_vector: The query embedding.
+        doc_vectors: List of (doc_id, embedding) pairs.
+
+    Returns:
+        List of (doc_id, similarity_score) sorted by descending similarity.
+    """
+    scored = []
+    for doc_id, vec in doc_vectors:
+        score = cosine_similarity(query_vector, vec)
+        scored.append((doc_id, score))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return scored
+
+
+def build_chunk_vector_params(
+    parent_ids: list[str],
+    embedding_field: str,
+) -> dict[str, Any]:
+    """Build Solr params to fetch the first chunk embedding for each parent book.
+
+    Uses Solr grouping to get one chunk per parent, sorted by chunk_index
+    so we always get the first chunk's embedding as the representative vector.
+    """
+    from search_service import solr_escape
+
+    id_filter = " OR ".join('"' + solr_escape(pid) + '"' for pid in parent_ids)
+    return {
+        "q": f"parent_id_s:({id_filter})",
+        "fl": f"parent_id_s,{embedding_field}",
+        "rows": len(parent_ids),
+        "sort": "chunk_index_i asc",
+        "group": "true",
+        "group.field": "parent_id_s",
+        "group.limit": "1",
+        "group.sort": "chunk_index_i asc",
+        "wt": "json",
+    }
+
+
+def extract_grouped_vectors(
+    solr_response: dict[str, Any],
+    embedding_field: str,
+) -> dict[str, list[float]]:
+    """Extract parent_id → embedding from a grouped Solr response.
+
+    Returns a dict mapping parent_id to the first chunk's embedding vector.
+    """
+    vectors: dict[str, list[float]] = {}
+    grouped = solr_response.get("grouped", {}).get("parent_id_s", {})
+    for group in grouped.get("groups", []):
+        parent_id = group.get("groupValue")
+        docs = group.get("doclist", {}).get("docs", [])
+        if parent_id and docs:
+            vec = docs[0].get(embedding_field)
+            if vec and isinstance(vec, list):
+                vectors[parent_id] = vec
+    return vectors

--- a/src/solr-search/tests/test_rerank_service.py
+++ b/src/solr-search/tests/test_rerank_service.py
@@ -1,0 +1,137 @@
+"""Tests for the rerank_service module."""
+
+from __future__ import annotations
+
+import pytest
+from rerank_service import (
+    build_chunk_vector_params,
+    cosine_rerank,
+    cosine_similarity,
+    extract_grouped_vectors,
+)
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self):
+        v = [1.0, 2.0, 3.0]
+        assert cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors(self):
+        a = [1.0, 0.0]
+        b = [0.0, 1.0]
+        assert cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_opposite_vectors(self):
+        a = [1.0, 0.0]
+        b = [-1.0, 0.0]
+        assert cosine_similarity(a, b) == pytest.approx(-1.0)
+
+    def test_zero_vector(self):
+        a = [0.0, 0.0]
+        b = [1.0, 2.0]
+        assert cosine_similarity(a, b) == 0.0
+
+    def test_both_zero(self):
+        assert cosine_similarity([0.0], [0.0]) == 0.0
+
+
+class TestCosineRerank:
+    def test_ranks_by_similarity(self):
+        query = [1.0, 0.0, 0.0]
+        docs = [
+            ("doc_far", [0.0, 1.0, 0.0]),
+            ("doc_close", [0.9, 0.1, 0.0]),
+            ("doc_exact", [1.0, 0.0, 0.0]),
+        ]
+        result = cosine_rerank(query, docs)
+        ids = [doc_id for doc_id, _ in result]
+        assert ids[0] == "doc_exact"
+        assert ids[1] == "doc_close"
+        assert ids[2] == "doc_far"
+
+    def test_empty_docs(self):
+        assert cosine_rerank([1.0, 0.0], []) == []
+
+    def test_single_doc(self):
+        result = cosine_rerank([1.0], [("only", [1.0])])
+        assert len(result) == 1
+        assert result[0][0] == "only"
+        assert result[0][1] == pytest.approx(1.0)
+
+
+class TestBuildChunkVectorParams:
+    def test_basic(self):
+        params = build_chunk_vector_params(["book1", "book2"], "embedding_v")
+        assert "parent_id_s" in params["q"]
+        assert "book1" in params["q"]
+        assert "book2" in params["q"]
+        assert params["fl"] == "parent_id_s,embedding_v"
+        assert params["group"] == "true"
+        assert params["group.field"] == "parent_id_s"
+        assert params["group.limit"] == "1"
+        assert params["rows"] == 2
+
+    def test_single_parent(self):
+        params = build_chunk_vector_params(["single"], "embedding_byte_v")
+        assert params["fl"] == "parent_id_s,embedding_byte_v"
+        assert params["rows"] == 1
+
+
+class TestExtractGroupedVectors:
+    def test_extracts_vectors(self):
+        response = {
+            "grouped": {
+                "parent_id_s": {
+                    "groups": [
+                        {
+                            "groupValue": "book1",
+                            "doclist": {"docs": [{"parent_id_s": "book1", "embedding_v": [0.1, 0.2, 0.3]}]},
+                        },
+                        {
+                            "groupValue": "book2",
+                            "doclist": {"docs": [{"parent_id_s": "book2", "embedding_v": [0.4, 0.5, 0.6]}]},
+                        },
+                    ]
+                }
+            }
+        }
+        result = extract_grouped_vectors(response, "embedding_v")
+        assert "book1" in result
+        assert "book2" in result
+        assert result["book1"] == [0.1, 0.2, 0.3]
+
+    def test_skips_missing_vectors(self):
+        response = {
+            "grouped": {
+                "parent_id_s": {
+                    "groups": [
+                        {
+                            "groupValue": "book1",
+                            "doclist": {"docs": [{"parent_id_s": "book1"}]},
+                        },
+                    ]
+                }
+            }
+        }
+        result = extract_grouped_vectors(response, "embedding_v")
+        assert result == {}
+
+    def test_empty_response(self):
+        result = extract_grouped_vectors({}, "embedding_v")
+        assert result == {}
+
+    def test_skips_null_group_value(self):
+        response = {
+            "grouped": {
+                "parent_id_s": {
+                    "groups": [
+                        {
+                            "groupValue": None,
+                            "doclist": {"docs": [{"embedding_v": [0.1]}]},
+                        },
+                    ]
+                }
+            }
+        }
+        result = extract_grouped_vectors(response, "embedding_v")
+        assert result == {}

--- a/src/solr-search/tests/test_search_architecture.py
+++ b/src/solr-search/tests/test_search_architecture.py
@@ -266,18 +266,18 @@ def test_search_hybrid_rerank_no_results(mock_embedding: MagicMock, mock_solr: M
 
 def test_similar_books_blocked_in_hybrid_rerank():
     """Similar books should return 501 when architecture is hybrid-rerank."""
-    from config import settings
+    import main as main_module
 
+    client = get_client()
     with patch.object(
-        type(settings),
+        type(main_module.settings),
         "search_architecture",
-        new_callable=lambda: property(lambda self: "hybrid-rerank"),
+        new_callable=property,
+        fget=lambda self: "hybrid-rerank",
     ):
-        # Can't easily patch frozen dataclass, so test the logic directly
-
-        # The function checks settings.search_architecture at call time
-        # Since settings is a frozen dataclass, we'll verify through the endpoint
-        pass
+        resp = client.get("/v1/books/some-doc-id/similar")
+        assert resp.status_code == 501
+        assert "hybrid-rerank" in resp.json()["detail"]
 
 
 @patch("main.query_solr")
@@ -287,3 +287,16 @@ def test_similar_books_works_in_hnsw(mock_solr: MagicMock):
 
     # Settings default is "hnsw", so similar_books should NOT return 501
     assert settings.search_architecture == "hnsw"
+
+    # Mock Solr to return a document with a vector
+    mock_solr.return_value = {
+        "response": {
+            "numFound": 1,
+            "docs": [{"id": "chunk1", "parent_id_s": "doc1", "chunk_embedding": [0.1] * 768}],
+        }
+    }
+
+    client = get_client()
+    resp = client.get("/v1/books/some-doc-id/similar")
+    # Should not be 501 — may be 200 or 404 depending on Solr mock, but NOT 501
+    assert resp.status_code != 501

--- a/src/solr-search/tests/test_search_architecture.py
+++ b/src/solr-search/tests/test_search_architecture.py
@@ -1,0 +1,289 @@
+"""Tests for configurable search architecture (HNSW vs hybrid-rerank).
+
+Tests the /v1/capabilities endpoint, mode gating, hybrid-rerank search path,
+and similar_books gating.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from tests.auth_helpers import create_authenticated_client  # noqa: E402
+
+
+def get_client() -> TestClient:
+    return create_authenticated_client()
+
+
+# -- /v1/capabilities tests --
+
+
+def test_capabilities_endpoint_returns_search_modes():
+    client = get_client()
+    resp = client.get("/v1/capabilities")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "search_modes" in data
+    assert "architecture" in data
+    assert "vector_dimensions" in data
+    assert data["vector_dimensions"] == 768
+    assert isinstance(data["search_modes"], list)
+    assert "keyword" in data["search_modes"]
+
+
+def test_capabilities_hnsw_mode():
+    """Default architecture is hnsw — semantic should be available."""
+    client = get_client()
+    resp = client.get("/v1/capabilities")
+    data = resp.json()
+    assert data["architecture"] == "hnsw"
+    assert "semantic" in data["search_modes"]
+    assert "hybrid" in data["search_modes"]
+    assert data["similar_books"] is True
+
+
+# -- Mode gating tests --
+
+
+def test_semantic_mode_allowed_in_hnsw():
+    """In HNSW mode, semantic search should be accepted (not 400)."""
+    from main import VALID_SEARCH_MODES
+
+    assert "semantic" in VALID_SEARCH_MODES
+
+
+# -- Search endpoint mode validation --
+
+
+@patch("main.requests.post")
+def test_search_invalid_mode_returns_400_with_architecture(mock_post: MagicMock):
+    client = get_client()
+    resp = client.get("/v1/search", params={"q": "test", "mode": "invalid_mode"})
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "architecture" in detail
+
+
+# -- Hybrid-rerank search path tests --
+
+
+@patch("main.query_solr")
+@patch("main._fetch_embedding")
+def test_search_hybrid_rerank_path(mock_embedding: MagicMock, mock_solr: MagicMock):
+    """Test hybrid search delegates to rerank path when architecture is hybrid-rerank."""
+    from main import _search_hybrid_rerank
+
+    # Mock BM25 response with 2 books
+    bm25_response = {
+        "response": {
+            "numFound": 2,
+            "docs": [
+                {
+                    "id": "book1",
+                    "title_s": "Test Book 1",
+                    "score": 10.0,
+                    "file_path_s": "test1.pdf",
+                },
+                {
+                    "id": "book2",
+                    "title_s": "Test Book 2",
+                    "score": 8.0,
+                    "file_path_s": "test2.pdf",
+                },
+            ],
+        },
+        "highlighting": {},
+        "facet_counts": {"facet_fields": {}},
+    }
+
+    # Mock grouped vector response
+    grouped_response = {
+        "grouped": {
+            "parent_id_s": {
+                "groups": [
+                    {
+                        "groupValue": "book1",
+                        "doclist": {"docs": [{"parent_id_s": "book1", "embedding_v": [0.9, 0.1, 0.0]}]},
+                    },
+                    {
+                        "groupValue": "book2",
+                        "doclist": {"docs": [{"parent_id_s": "book2", "embedding_v": [0.1, 0.9, 0.0]}]},
+                    },
+                ]
+            }
+        }
+    }
+
+    mock_embedding.return_value = [1.0, 0.0, 0.0]  # query vector
+    mock_solr.side_effect = [bm25_response, grouped_response]
+
+    mock_request = MagicMock()
+    mock_request.url_for.return_value = "http://test/doc/123"
+
+    result = _search_hybrid_rerank(
+        mock_request,
+        "test query",
+        1,
+        10,
+        "score",
+        "desc",
+        None,
+        {},
+    )
+
+    assert result["mode"] == "hybrid"
+    assert result["architecture"] == "hybrid-rerank"
+    assert len(result["results"]) == 2
+    # book1 should rank higher (more similar to query)
+    assert result["results"][0]["id"] == "book1"
+
+
+@patch("main.query_solr")
+@patch("main._fetch_embedding")
+def test_search_hybrid_rerank_no_vectors_degrades(mock_embedding: MagicMock, mock_solr: MagicMock):
+    """When no vectors are available, hybrid-rerank should degrade gracefully."""
+    from main import _search_hybrid_rerank
+
+    bm25_response = {
+        "response": {
+            "numFound": 1,
+            "docs": [
+                {"id": "book1", "title_s": "Test Book", "score": 10.0, "file_path_s": "test.pdf"},
+            ],
+        },
+        "highlighting": {},
+        "facet_counts": {"facet_fields": {}},
+    }
+
+    # Empty grouped response (no vectors)
+    grouped_response = {"grouped": {"parent_id_s": {"groups": []}}}
+
+    mock_embedding.return_value = [1.0, 0.0]
+    mock_solr.side_effect = [bm25_response, grouped_response]
+
+    mock_request = MagicMock()
+    mock_request.url_for.return_value = "http://test/doc/123"
+
+    result = _search_hybrid_rerank(
+        mock_request,
+        "test query",
+        1,
+        10,
+        "score",
+        "desc",
+        None,
+        {},
+    )
+
+    assert result["degraded"] is True
+    assert "No vector embeddings" in result["message"]
+
+
+@patch("main.query_solr")
+@patch("main._fetch_embedding")
+def test_search_hybrid_rerank_empty_query_raises_400(mock_embedding: MagicMock, mock_solr: MagicMock):
+    """Empty query in hybrid-rerank should return 400."""
+    import pytest
+    from fastapi import HTTPException
+
+    from main import _search_hybrid_rerank
+
+    mock_request = MagicMock()
+    with pytest.raises(HTTPException) as exc_info:
+        _search_hybrid_rerank(
+            mock_request,
+            "   ",
+            1,
+            10,
+            "score",
+            "desc",
+            None,
+            {},
+        )
+    assert exc_info.value.status_code == 400
+
+
+@patch("main._search_keyword")
+def test_search_hybrid_rerank_non_relevance_sort_uses_keyword(mock_keyword: MagicMock):
+    """Non-relevance sorts should bypass reranking and use keyword search."""
+    from main import _search_hybrid_rerank
+
+    mock_keyword.return_value = {"results": [], "mode": "keyword"}
+    mock_request = MagicMock()
+
+    _search_hybrid_rerank(
+        mock_request,
+        "test",
+        1,
+        10,
+        "title",
+        "asc",
+        None,
+        {},
+    )
+    mock_keyword.assert_called_once()
+
+
+@patch("main.query_solr")
+@patch("main._fetch_embedding")
+def test_search_hybrid_rerank_no_results(mock_embedding: MagicMock, mock_solr: MagicMock):
+    """Empty BM25 results should return empty response."""
+    from main import _search_hybrid_rerank
+
+    bm25_response = {
+        "response": {"numFound": 0, "docs": []},
+        "highlighting": {},
+        "facet_counts": {"facet_fields": {}},
+    }
+
+    mock_embedding.return_value = [1.0, 0.0]
+    mock_solr.return_value = bm25_response
+
+    mock_request = MagicMock()
+    result = _search_hybrid_rerank(
+        mock_request,
+        "nonexistent",
+        1,
+        10,
+        "score",
+        "desc",
+        None,
+        {},
+    )
+
+    assert result["results"] == []
+    assert result["architecture"] == "hybrid-rerank"
+
+
+# -- Similar books gating tests --
+
+
+def test_similar_books_blocked_in_hybrid_rerank():
+    """Similar books should return 501 when architecture is hybrid-rerank."""
+    from config import settings
+
+    with patch.object(
+        type(settings),
+        "search_architecture",
+        new_callable=lambda: property(lambda self: "hybrid-rerank"),
+    ):
+        # Can't easily patch frozen dataclass, so test the logic directly
+
+        # The function checks settings.search_architecture at call time
+        # Since settings is a frozen dataclass, we'll verify through the endpoint
+        pass
+
+
+@patch("main.query_solr")
+def test_similar_books_works_in_hnsw(mock_solr: MagicMock):
+    """In HNSW mode, similar books should work (not 501)."""
+    from config import settings
+
+    # Settings default is "hnsw", so similar_books should NOT return 501
+    assert settings.search_architecture == "hnsw"


### PR DESCRIPTION
## Summary

Adds `SEARCH_ARCHITECTURE` configuration to support Solr deployments with or without HNSW vector index.

### Two modes:
- **`hnsw`** (default): Existing behavior — keyword, semantic, and hybrid search via Solr kNN
- **`hybrid-rerank`**: No HNSW index needed — BM25 keyword search + cosine rerank using stored chunk vectors. Only keyword + hybrid modes available.

### Backend changes
- New `rerank_service.py` — pure-Python cosine similarity (no numpy dependency)
- `/v1/capabilities` endpoint for frontend feature discovery
- Split `_search_hybrid` into `_search_hybrid_hnsw` and `_search_hybrid_rerank`
- Dynamic search mode validation per architecture
- `similar_books` endpoint gated (returns 501 in hybrid-rerank mode)
- Startup validation for architecture setting

### Frontend changes
- `CapabilitiesContext` fetches `/v1/capabilities` at startup
- Search mode buttons dynamically filtered by backend capabilities
- SimilarBooks component gated on `capabilities.similarBooks`
- Graceful fallback to HNSW defaults when capabilities unavailable

### Tests
- 25 new tests (14 rerank_service + 11 search_architecture)
- 1094 total tests passing, 89.07% coverage (threshold: 88%)
- 841 frontend tests passing, lint clean

Closes #1506