### PR TITLE
fix: address release PR review comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,16 +161,6 @@ BUILD_DATE=1970-01-01T00:00:00Z
 # SOLR_TOPOLOGY=distributed
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Solr Deployment Topology (Single-Node vs Distributed)
-# ──────────────────────────────────────────────────────────────────────────────
-# Controls the number of Solr and ZooKeeper nodes started by docker compose.
-# Set by the installer via --topology or the interactive prompt.
-#
-# For detailed topology comparison, capacity planning, and migration paths,
-# see: docs/deployment-topologies.md
-# SOLR_TOPOLOGY=distributed
-
-# ──────────────────────────────────────────────────────────────────────────────
 # Solr Collection Topology
 # ──────────────────────────────────────────────────────────────────────────────
 # These control how the Solr "books" collection is created at first startup.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Frontend / Search API
 Aithena supports two SolrCloud deployment modes optimized for different scales:
 
 - **SolrCloud Distributed (default)**: 3-node Solr cluster + 3-node ZooKeeper ensemble. Recommended for production (>3K books, high availability required).
-- **Single-Node SolrCloud (planned)**: Single Solr node with embedded ZooKeeper. Ideal for development, testing, and small deployments (<3K books, 32 GB RAM available).
+- **Single-Node SolrCloud**: 1 Solr node + 1 ZooKeeper container via `docker/compose.single-node.yml`. Ideal for development, testing, and small deployments (<3K books, 32 GB RAM available).
 
 See [**Deployment Topologies Guide**](docs/deployment-topologies.md) for detailed architecture, capacity planning, formulas, and migration paths between topologies.
 

--- a/docs/deployment-topologies.md
+++ b/docs/deployment-topologies.md
@@ -7,7 +7,7 @@ This document describes the two supported Solr deployment architectures for Aith
 Aithena supports two fundamentally different Solr deployment topologies:
 
 1. **SolrCloud Distributed** (default in `docker-compose.yml`) — Three-node SolrCloud cluster with three-node ZooKeeper ensemble
-2. **Single-Node SolrCloud** (planned via overlay compose) — Single Solr node with embedded ZooKeeper for resource-constrained deployments. Note: This is SolrCloud in single-node mode, not a true standalone/core mode.
+2. **Single-Node SolrCloud** (via `docker/compose.single-node.yml` overlay) — 1 Solr node + 1 ZooKeeper container for resource-constrained deployments. Note: This is SolrCloud in single-node mode, not a true standalone/core mode.
 
 The choice depends on your scale, budget, operational complexity, and high-availability requirements.
 
@@ -129,20 +129,24 @@ If you start with single-node SolrCloud and outgrow it, migrating to distributed
 
 ---
 
-## 2. Single-Node SolrCloud Topology (Planned for v2.0+)
+## 2. Single-Node SolrCloud Topology
 
 ### Architecture
 
 ```
 ┌─────────────────────────────────────────────────┐
 │                                                 │
-│   Single Solr Node + Embedded ZooKeeper        │
+│   Single Solr Node + ZooKeeper Container        │
+│  ┌─────────────────────────────────────────┐  │
+│  │   zoo1 (standalone ZooKeeper)           │  │
+│  │   :2181                                 │  │
+│  └─────────────────────────────────────────┘  │
 │  ┌─────────────────────────────────────────┐  │
 │  │   solr (single-node SolrCloud)          │  │
-│  │   :8983 (with embedded ZK)              │  │
+│  │   :8983                                 │  │
 │  │                                         │  │
-│  │   • ZooKeeper embedded in Solr JVM      │  │
-│  │   • Single-shard, no replication        │  │
+│  │   • Connects to zoo1:2181               │  │
+│  │   • Single-shard, replicationFactor=1   │  │
 │  │   • 100% query and index traffic here   │  │
 │  │                                         │  │
 │  └─────────────────────────────────────────┘  │
@@ -152,8 +156,8 @@ If you start with single-node SolrCloud and outgrow it, migrating to distributed
 
 ### Configuration
 
-**Not yet in `docker-compose.yml`** — planned via overlay (`docker/compose.single-node.yml`).  
-**Environment variable:** `ZK_HOST=""` (or absent) — runs in single-node mode. Note: Requires the single-node compose overlay; base compose hardcodes 3-node ZK ensemble.
+Enabled via the single-node compose overlay (`docker/compose.single-node.yml`), which disables extra Solr/ZK nodes and sets `SOLR_EXPECTED_NODES=1`, `ZK_HOST=zoo1:2181`, and `replicationFactor=1`.  
+**Environment variable:** `SOLR_TOPOLOGY=single-node` — set by the installer or manually in `.env`.
 
 ### When to Use
 
@@ -297,7 +301,7 @@ If the single Solr node fails:
 | **Search Latency (cold, 75% cache)** | 500 ms–2 s | 500 ms–2 s |
 | **Index Scaling** | Add shards to grow | Re-optimize or migrate |
 | **Recommended Min Books** | 1,000+ | < 3,000 |
-| **Production Ready** | ✅ Yes (proven) | 🟡 Planned (not yet deployed) |
+| **Production Ready** | ✅ Yes (proven) | ✅ Yes (v2.1+) |
 
 ---
 
@@ -369,22 +373,24 @@ Are you starting a new deployment?
 
 The base `docker-compose.yml` is always **SolrCloud** (3 nodes + ZooKeeper).
 
-### Future: Environment-Based Selection (Planned)
+### Environment-Based Selection
 
-In a future release, selection will be configurable:
+Topology is configured via the `SOLR_TOPOLOGY` environment variable:
 
 ```bash
-# Deploy SolrCloud (current default)
+# Deploy SolrCloud (default)
 SOLR_TOPOLOGY=distributed docker compose up -d
 
-# Deploy single-node SolrCloud (planned)
+# Deploy single-node SolrCloud
 SOLR_TOPOLOGY=single-node docker compose up -d
 ```
 
+The installer sets this variable and generates the appropriate `start.sh` with the correct compose overlay chain.
+
 **Implementation status:**
-- 🟡 Design being finalized (topology selection framework TBD)
-- ⏳ Single-Node Compose override in development
-- ⏳ Automated topology detection in initialization scripts
+- ✅ Single-Node Compose overlay (`docker/compose.single-node.yml`)
+- ✅ Installer topology selection (`--topology` flag or interactive prompt)
+- ✅ CI integration tests for both topologies
 - ⏳ Migration helper scripts (distributed ↔ single-node)
 
 ---

--- a/src/embeddings-server/main.py
+++ b/src/embeddings-server/main.py
@@ -197,7 +197,7 @@ async def embeddings(sentences: EmbeddingsInput):
             validate_quantization_quality(original, quantized)
         result.data.append(
             EmbeddingsOutput.EmbeddingsList(
-                embedding=[float(x) for x in quantized],
+                embedding=[int(x) if quantized.dtype == np.int8 else float(x) for x in quantized],
                 field_name=field_name,
             )
         )

--- a/src/embeddings-server/main.py
+++ b/src/embeddings-server/main.py
@@ -121,7 +121,7 @@ class EmbeddingsOutput(BaseModel):
         """The list of embeddings."""
 
         object: str = "embedding"
-        embedding: list[float] = []
+        embedding: list[int | float] = []
         field_name: str = "embedding"
 
     class Usage(BaseModel):

--- a/src/embeddings-server/tests/test_embeddings_server.py
+++ b/src/embeddings-server/tests/test_embeddings_server.py
@@ -410,3 +410,38 @@ class TestStartupFailure:
             for key in list(sys.modules):
                 if key in ("main", "config"):
                     del sys.modules[key]
+
+
+# ---------------------------------------------------------------------------
+# Int8 quantization — JSON integer serialization
+# ---------------------------------------------------------------------------
+
+
+class TestInt8Serialization:
+    """Verify int8 quantization emits JSON integers (not floats) from the endpoint."""
+
+    def test_int8_embeddings_are_integers(self):
+        """When VECTOR_QUANTIZATION=int8, embedding values should be ints in JSON."""
+        client, _, _, _ = _fresh_import(extra_env={"VECTOR_QUANTIZATION": "int8"})
+        response = client.post(
+            "/v1/embeddings/",
+            json={"input": ["test sentence"]},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        embedding = data["data"][0]["embedding"]
+        for val in embedding:
+            assert isinstance(val, int), f"Expected int, got {type(val).__name__}: {val}"
+
+    def test_none_embeddings_are_floats(self):
+        """When VECTOR_QUANTIZATION=none, embedding values should be floats."""
+        client, _, _, _ = _fresh_import(extra_env={"VECTOR_QUANTIZATION": "none"})
+        response = client.post(
+            "/v1/embeddings/",
+            json={"input": ["test sentence"]},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        embedding = data["data"][0]["embedding"]
+        for val in embedding:
+            assert isinstance(val, float), f"Expected float, got {type(val).__name__}: {val}"


### PR DESCRIPTION
Fixes from review comments on PR #1513 (release v2.1.0):

- **README.md**: Updated single-node topology from 'planned' to supported (it's already implemented via `docker/compose.single-node.yml`)
- **embeddings-server/main.py**: Use `int(x)` for int8 vectors to emit proper integer JSON values for Solr BYTE encoding
- **.env.example**: Removed duplicate 'Solr Deployment Topology' block

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>