### PR TITLE
Add semantic retrieval E2E tests (infrastructure + web API)

### DIFF
--- a/e2e/test_semantic_retrieval.py
+++ b/e2e/test_semantic_retrieval.py
@@ -30,7 +30,11 @@ RABBITMQ_PASS = os.environ.get("RABBITMQ_ADMIN_PASS", "admin_dev_pass")
 RABBITMQ_QUEUE = os.environ.get("RABBITMQ_QUEUE_NAME", "shortembeddings")
 # Container-visible base path for the document-indexer (matches docker-compose.yml)
 INDEXER_BASE_PATH = os.environ.get("INDEXER_BASE_PATH", "/data/documents")
-INDEX_TIMEOUT = 180
+# Default kept under the per-test pytest-timeout (120s — see e2e/pytest.ini)
+# so a missing override doesn't silently consume the whole budget.  The
+# first test using the module-scoped fixture below applies a generous
+# @pytest.mark.timeout to cover the indexing wait.
+INDEX_TIMEOUT = int(os.environ.get("E2E_INDEX_TIMEOUT", "90"))
 POLL_INTERVAL = 5
 RUN_ID = uuid.uuid4().hex[:8]
 
@@ -320,6 +324,10 @@ def semantic_test_docs(
 class TestSemanticRetrieval:
     """Validate semantic and hybrid search over freshly indexed documents."""
 
+    # The first test that uses the module-scoped semantic_test_docs fixture
+    # triggers the indexing wait (up to 2 * INDEX_TIMEOUT for parent + chunks).
+    # Override the suite-wide pytest-timeout so the indexing wait fits.
+    @pytest.mark.timeout(INDEX_TIMEOUT * 2 + 60)
     def test_semantic_mode_ranks_the_correct_document(
         self,
         api_url: str,

--- a/e2e/test_semantic_retrieval.py
+++ b/e2e/test_semantic_retrieval.py
@@ -175,21 +175,28 @@ def _wait_for_chunk_docs(
 
 
 def _delete_solr_documents(solr_url: str, doc_id: str) -> None:
-    """Delete a parent document and all of its chunk documents."""
-    requests.post(
-        f"{solr_url}/update",
-        params={"commitWithin": "2000", "wt": "json"},
-        json={"delete": {"query": f"parent_id_s:{doc_id}"}},
-        auth=SOLR_AUTH,
-        timeout=30,
-    )
-    requests.post(
-        f"{solr_url}/update",
-        params={"commitWithin": "2000", "wt": "json"},
-        json={"delete": {"id": doc_id}},
-        auth=SOLR_AUTH,
-        timeout=30,
-    )
+    """Delete a parent document and all of its chunk documents.
+
+    Best-effort: Solr returns 200/4xx for transient auth or collection
+    state issues during teardown.  We log non-2xx responses so failures
+    are visible rather than silently swallowed.
+    """
+    for payload in (
+        {"delete": {"query": f"parent_id_s:{doc_id}"}},
+        {"delete": {"id": doc_id}},
+    ):
+        try:
+            resp = requests.post(
+                f"{solr_url}/update",
+                params={"commitWithin": "2000", "wt": "json"},
+                json=payload,
+                auth=SOLR_AUTH,
+                timeout=30,
+            )
+            if not resp.ok:
+                print(f"WARNING: Solr delete returned {resp.status_code}: {resp.text[:200]}")
+        except requests.RequestException as exc:
+            print(f"WARNING: Solr delete failed: {exc}")
 
 
 def _search(

--- a/e2e/test_semantic_retrieval.py
+++ b/e2e/test_semantic_retrieval.py
@@ -1,0 +1,369 @@
+"""E2E semantic retrieval test for vector and hybrid search.
+
+This module creates two PDFs with deliberately different subject matter, indexes
+both parent documents into Solr via ``/update/extract``, then enqueues the same
+files for the document-indexer so chunk embeddings are generated.  The semantic
+queries intentionally avoid exact keyword overlap with the source texts so the
+assertions exercise embedding similarity rather than BM25 keyword matching.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+
+import pika
+import pytest
+import requests
+from conftest import SOLR_ADMIN_PASS, SOLR_ADMIN_USER, _build_pdf, wait_for_solr_doc
+
+SOLR_AUTH = (SOLR_ADMIN_USER, SOLR_ADMIN_PASS)
+SEARCH_ENDPOINT = "/v1/search"
+RABBITMQ_HOST = os.environ.get("RABBITMQ_HOST", "localhost")
+RABBITMQ_PORT = int(os.environ.get("RABBITMQ_PORT", "5672"))
+RABBITMQ_USER = os.environ.get("RABBITMQ_ADMIN_USER", "admin")
+RABBITMQ_PASS = os.environ.get("RABBITMQ_ADMIN_PASS", "admin_dev_pass")
+RABBITMQ_QUEUE = os.environ.get("RABBITMQ_QUEUE_NAME", "shortembeddings")
+# Container-visible base path for the document-indexer (matches docker-compose.yml)
+INDEXER_BASE_PATH = os.environ.get("INDEXER_BASE_PATH", "/data/documents")
+INDEX_TIMEOUT = 180
+POLL_INTERVAL = 5
+RUN_ID = uuid.uuid4().hex[:8]
+
+DOC_CASES = (
+    {
+        "slug": "reef",
+        "relative_path": (f"SemanticE2E/{RUN_ID}/Pelagia North/Pelagia North - Shallow Atoll Survey (2024).pdf"),
+        "title": "Shallow Atoll Survey",
+        "text": (
+            "The coral reef biome shelters clownfish, sea anemones, crustaceans, "
+            "and bright algae. Sunlit lagoons build calcium structures that protect "
+            "coastlines and provide nursery grounds for countless animals."
+        ),
+        "query": "underwater life and biodiversity",
+    },
+    {
+        "slug": "mars",
+        "relative_path": (f"SemanticE2E/{RUN_ID}/Aster Vale/Aster Vale - Jezero Core Archive (2024).pdf"),
+        "title": "Jezero Core Archive",
+        "text": (
+            "The rover explored Jezero Crater, drilled basalt cores, and sealed "
+            "geological specimens for return to Earth. Researchers inspect the "
+            "samples for biosignatures that could reveal whether ancient microbes "
+            "once inhabited the planet."
+        ),
+        "query": "searching for extraterrestrial organisms on other worlds",
+    },
+)
+
+
+def _compute_doc_id(pdf_path: Path, base_path: Path) -> str:
+    relative = pdf_path.relative_to(base_path).as_posix()
+    return hashlib.sha256(relative.encode()).hexdigest()
+
+
+def _index_pdf(solr_url: str, pdf_path: Path, base_path: Path) -> requests.Response:
+    """POST *pdf_path* to Solr's extract handler using the document-indexer shape."""
+    relative = pdf_path.relative_to(base_path)
+    relative_posix = relative.as_posix()
+    doc_id = hashlib.sha256(relative_posix.encode()).hexdigest()
+
+    stem = pdf_path.stem
+    author, title_year = stem.split(" - ", 1)
+    title_part, year_part = title_year.rsplit("(", 1)
+    title = title_part.strip()
+    year = year_part.rstrip(")")
+
+    params = {
+        "resource.name": pdf_path.name,
+        "commitWithin": "2000",
+        "literal.id": doc_id,
+        "literal.title_s": title,
+        "literal.author_s": author,
+        "literal.file_path_s": relative_posix,
+        "literal.folder_path_s": relative.parent.as_posix(),
+        "literal.file_size_l": str(pdf_path.stat().st_size),
+        "literal.category_s": "SemanticE2E",
+        "literal.year_i": year,
+    }
+
+    with pdf_path.open("rb") as fh:
+        return requests.post(
+            f"{solr_url}/update/extract",
+            params=params,
+            files={"file": (pdf_path.name, fh, "application/pdf")},
+            auth=SOLR_AUTH,
+            timeout=60,
+        )
+
+
+def _publish_to_indexer(pdf_path: Path, test_library_root: Path) -> None:
+    """Publish a container-visible file path to the RabbitMQ queue.
+
+    The document-indexer runs inside Docker with BASE_PATH=/data/documents.
+    The E2E library path on the host is bind-mounted at /data/documents inside
+    the container, so we translate host paths to container paths before publishing.
+    """
+    relative = pdf_path.relative_to(test_library_root)
+    container_path = f"{INDEXER_BASE_PATH}/{relative.as_posix()}"
+
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(
+            host=RABBITMQ_HOST,
+            port=RABBITMQ_PORT,
+            credentials=pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASS),
+            connection_attempts=3,
+            retry_delay=2,
+        )
+    )
+    try:
+        channel = connection.channel()
+        channel.queue_declare(queue=RABBITMQ_QUEUE, durable=True, auto_delete=False)
+        channel.basic_publish(
+            exchange="",
+            routing_key=RABBITMQ_QUEUE,
+            body=container_path,
+            properties=pika.BasicProperties(delivery_mode=2),
+        )
+    finally:
+        connection.close()
+
+
+def _wait_for_chunk_docs(
+    solr_url: str,
+    parent_id: str,
+    *,
+    timeout: int = INDEX_TIMEOUT,
+    poll_interval: int = POLL_INTERVAL,
+) -> list[dict]:
+    """Poll Solr until chunk documents for *parent_id* exist or timeout elapses."""
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.get(
+                f"{solr_url}/select",
+                params={
+                    "q": f"parent_id_s:{parent_id}",
+                    "rows": "10",
+                    "fl": "id,parent_id_s,title_s,file_path_s",
+                    "wt": "json",
+                },
+                auth=SOLR_AUTH,
+                timeout=10,
+            )
+            resp.raise_for_status()
+            docs = resp.json()["response"]["docs"]
+            if docs:
+                return docs
+        except Exception as exc:
+            last_error = exc
+            time.sleep(poll_interval)
+            continue
+        time.sleep(poll_interval)
+    if last_error:
+        print(f"[_wait_for_chunk_docs] last error while polling for {parent_id}: {last_error}")
+    return []
+
+
+def _delete_solr_documents(solr_url: str, doc_id: str) -> None:
+    """Delete a parent document and all of its chunk documents."""
+    requests.post(
+        f"{solr_url}/update",
+        params={"commitWithin": "2000", "wt": "json"},
+        json={"delete": {"query": f"parent_id_s:{doc_id}"}},
+        auth=SOLR_AUTH,
+        timeout=30,
+    )
+    requests.post(
+        f"{solr_url}/update",
+        params={"commitWithin": "2000", "wt": "json"},
+        json={"delete": {"id": doc_id}},
+        auth=SOLR_AUTH,
+        timeout=30,
+    )
+
+
+def _search(
+    api_url: str, auth_headers: dict[str, str], *, query: str, mode: str, category: str | None = None
+) -> requests.Response:
+    params: dict[str, str] = {"q": query, "mode": mode, "limit": "5"}
+    if category:
+        params["fq_category"] = category
+    return requests.get(
+        f"{api_url}{SEARCH_ENDPOINT}",
+        params=params,
+        headers=auth_headers,
+        timeout=30,
+    )
+
+
+def _assert_top_result_matches(
+    body: dict,
+    *,
+    expected_title: str,
+    expected_doc_id: str,
+    expected_file_path: str,
+    wrong_title: str,
+) -> None:
+    results = body.get("results", [])
+    assert results, f"Search returned no results: {body}"
+
+    top = results[0]
+    assert top.get("title") == expected_title, (
+        f"Expected top result {expected_title!r}, got {top.get('title')!r}. Full response: {body}"
+    )
+    assert top.get("title") != wrong_title, f"Wrong document {wrong_title!r} ranked first. Full response: {body}"
+    assert top.get("file_path") == expected_file_path, (
+        f"Expected file_path {expected_file_path!r}, got {top.get('file_path')!r}. Full response: {body}"
+    )
+    result_id = top.get("id", "")
+    parent_id = top.get("parent_id") or ""
+    assert result_id == expected_doc_id or result_id.startswith(expected_doc_id) or parent_id == expected_doc_id, (
+        f"Top result did not map to document {expected_doc_id!r}. Full response: {body}"
+    )
+
+
+@pytest.fixture(scope="module")
+def embeddings_ready(api_url: str, solr_available: None) -> None:
+    """Skip when semantic search infrastructure is not available."""
+    try:
+        status = requests.get(f"{api_url}/v1/status", timeout=10)
+        status.raise_for_status()
+    except Exception as exc:
+        pytest.skip(f"Status endpoint unavailable; cannot verify embeddings readiness. Error: {exc}")
+
+    payload = status.json()
+    if not payload.get("embeddings_available"):
+        pytest.skip("Embeddings service is unavailable; semantic retrieval E2E cannot run.")
+    if payload.get("services", {}).get("rabbitmq") != "up":
+        pytest.skip("RabbitMQ is unavailable; document-indexer cannot generate chunk embeddings.")
+
+    try:
+        connection = pika.BlockingConnection(
+            pika.ConnectionParameters(
+                host=RABBITMQ_HOST,
+                port=RABBITMQ_PORT,
+                credentials=pika.PlainCredentials(RABBITMQ_USER, RABBITMQ_PASS),
+                connection_attempts=3,
+                retry_delay=2,
+            )
+        )
+        connection.close()
+    except Exception as exc:
+        pytest.skip(f"RabbitMQ admin connection failed; cannot enqueue PDFs for indexing. Error: {exc}")
+
+
+@pytest.fixture(scope="module")
+def semantic_test_docs(
+    test_library_root: Path,
+    solr_url: str,
+    embeddings_ready: None,
+) -> Generator[list[dict[str, str]], None, None]:
+    """Create, index, and enqueue both semantic-retrieval fixture PDFs.
+
+    Cleanup runs in finally-block regardless of setup failures, so partial
+    runs don't leave stale documents or files behind.
+    """
+    created: list[dict[str, str]] = []
+
+    try:
+        for case in DOC_CASES:
+            pdf_path = test_library_root / case["relative_path"]
+            pdf_path.parent.mkdir(parents=True, exist_ok=True)
+            pdf_path.write_bytes(_build_pdf(case["text"]))
+
+            doc_id = _compute_doc_id(pdf_path, test_library_root)
+            # Track immediately so cleanup runs even if indexing fails
+            created.append(
+                {
+                    **case,
+                    "doc_id": doc_id,
+                    "pdf_path": str(pdf_path),
+                }
+            )
+
+            response = _index_pdf(solr_url, pdf_path, test_library_root)
+            assert response.status_code == 200, (
+                f"Solr /update/extract returned {response.status_code} for {pdf_path.name}: {response.text}"
+            )
+
+            parent_doc = wait_for_solr_doc(solr_url, doc_id, timeout=INDEX_TIMEOUT, auth=SOLR_AUTH)
+            assert parent_doc is not None, f"Parent document {doc_id} did not appear in Solr."
+
+            _publish_to_indexer(pdf_path, test_library_root)
+            chunk_docs = _wait_for_chunk_docs(solr_url, doc_id)
+            assert chunk_docs, (
+                f"Chunk documents for {doc_id} ({case['slug']}) were not indexed within {INDEX_TIMEOUT}s. "
+                f"Check document-indexer logs for errors processing the queued file."
+            )
+
+        yield created
+    finally:
+        for entry in created:
+            _delete_solr_documents(solr_url, entry["doc_id"])
+            pdf_path = Path(entry["pdf_path"])
+            pdf_path.unlink(missing_ok=True)
+            current = pdf_path.parent
+            while current != test_library_root and current.exists():
+                try:
+                    current.rmdir()
+                except OSError:
+                    break
+                current = current.parent
+
+
+class TestSemanticRetrieval:
+    """Validate semantic and hybrid search over freshly indexed documents."""
+
+    def test_semantic_mode_ranks_the_correct_document(
+        self,
+        api_url: str,
+        auth_headers: dict[str, str],
+        semantic_test_docs: list[dict[str, str]],
+    ) -> None:
+        """Semantic mode must retrieve the intended document for synonym-style queries."""
+        for case in semantic_test_docs:
+            wrong_title = next(doc["title"] for doc in semantic_test_docs if doc["slug"] != case["slug"])
+            response = _search(api_url, auth_headers, query=case["query"], mode="semantic", category="SemanticE2E")
+            assert response.status_code == 200, (
+                f"Semantic search failed for {case['slug']}: {response.status_code} {response.text}"
+            )
+
+            body = response.json()
+            assert body.get("mode") == "semantic", f"Expected semantic mode response, got: {body}"
+            _assert_top_result_matches(
+                body,
+                expected_title=case["title"],
+                expected_doc_id=case["doc_id"],
+                expected_file_path=case["relative_path"],
+                wrong_title=wrong_title,
+            )
+
+    def test_hybrid_mode_ranks_the_correct_document(
+        self,
+        api_url: str,
+        auth_headers: dict[str, str],
+        semantic_test_docs: list[dict[str, str]],
+    ) -> None:
+        """Hybrid mode must keep the semantically correct document ahead of the wrong one."""
+        for case in semantic_test_docs:
+            wrong_title = next(doc["title"] for doc in semantic_test_docs if doc["slug"] != case["slug"])
+            response = _search(api_url, auth_headers, query=case["query"], mode="hybrid", category="SemanticE2E")
+            assert response.status_code == 200, (
+                f"Hybrid search failed for {case['slug']}: {response.status_code} {response.text}"
+            )
+
+            body = response.json()
+            assert body.get("mode") == "hybrid", f"Expected hybrid mode response, got: {body}"
+            _assert_top_result_matches(
+                body,
+                expected_title=case["title"],
+                expected_doc_id=case["doc_id"],
+                expected_file_path=case["relative_path"],
+                wrong_title=wrong_title,
+            )

--- a/e2e/test_web_api_semantic.py
+++ b/e2e/test_web_api_semantic.py
@@ -7,9 +7,18 @@ Solr is not directly accessible from the test runner.
 
 Flow:
 1. Upload two PDFs via POST /v1/upload
-2. Wait for documents to appear in search results (keyword mode)
-3. Wait for embeddings to be generated (semantic mode returns results)
+2. Wait until both uploaded titles appear in keyword search (confirms indexing)
+3. Wait until both uploaded titles appear in semantic search (confirms embeddings)
 4. Assert semantic and hybrid search rank the correct document first
+
+Isolation: all assertions filter by category=Uploads (the category assigned
+by the metadata extractor for documents uploaded through /v1/upload), and
+title matching uses prefix comparison because the extractor may append year
+or timestamp suffixes to sanitized filenames.
+
+Cleanup: there is currently no public DELETE-by-id endpoint on the web API,
+so uploaded documents are not removed after the test. Operators can purge
+them manually via the admin requeue/clear workflow.
 
 Environment variables:
   SEARCH_API_URL    solr-search base URL (default: http://localhost:8080)
@@ -22,7 +31,6 @@ from __future__ import annotations
 
 import os
 import time
-import uuid
 
 import pytest
 import requests
@@ -30,10 +38,11 @@ import requests
 SEARCH_API_URL: str = os.environ.get("SEARCH_API_URL", "http://localhost:8080")
 WEB_API_TIMEOUT = int(os.environ.get("WEB_API_TIMEOUT", "300"))
 POLL_INTERVAL = 10
-RUN_ID = uuid.uuid4().hex[:8]
 
-# Category used to isolate test documents from any real data
-TEST_CATEGORY = "WebAPISemanticE2E"
+# All documents uploaded via /v1/upload land under the "Uploads" category
+# (derived by the metadata extractor from the folder path).  We use this
+# category as a filter to isolate our test documents from any real data.
+UPLOADS_CATEGORY = "Uploads"
 
 DOC_CASES = (
     {
@@ -156,32 +165,26 @@ def _wait_for_search_results(
     *,
     query: str,
     mode: str,
-    expected_count: int,
-    category: str | None = None,
+    expected_titles: list[str],
+    category: str | None = UPLOADS_CATEGORY,
     timeout: int = WEB_API_TIMEOUT,
 ) -> dict | None:
-    """Poll search until at least expected_count results appear."""
+    """Poll search until results contain *all* expected title prefixes.
+
+    Tied to specific documents (via title prefix match) rather than just a
+    raw count, so the wait does not green-light early in shared environments
+    where unrelated documents may already match the query.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         resp = _search(api_url, headers, query=query, mode=mode, category=category)
         if resp.status_code == 200:
-            body = resp.json()
-            results = body.get("results", [])
-            if len(results) >= expected_count:
-                return body
+            results = resp.json().get("results", [])
+            titles = [r.get("title") or "" for r in results]
+            if all(any(t.startswith(prefix) for t in titles) for prefix in expected_titles):
+                return resp.json()
         time.sleep(POLL_INTERVAL)
     return None
-
-
-def _delete_via_api(api_url: str, headers: dict[str, str], doc_id: str) -> None:
-    """Delete a document via the admin API (best-effort cleanup)."""
-    api_key = os.environ.get("ADMIN_API_KEY")
-    if api_key:
-        requests.delete(
-            f"{api_url}/v1/admin/documents/{doc_id}",
-            headers={"X-API-Key": api_key},
-            timeout=30,
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -222,6 +225,13 @@ def uploaded_docs(
     """Upload both test PDFs and wait for them to become searchable.
 
     Returns list of doc metadata dicts with title, query, slug info.
+
+    Note: there is no public DELETE-by-id endpoint on the web API today,
+    so we cannot reliably clean up documents we upload. Tests use the
+    `Uploads` category filter to isolate themselves; lingering uploaded
+    documents do not affect other test runs but will accumulate in dev
+    environments. Operators can purge them via the admin requeue/clear
+    workflow.
     """
     uploaded: list[dict] = []
 
@@ -241,15 +251,18 @@ def uploaded_docs(
             }
         )
 
-    # Wait for keyword search to find both documents (confirms indexing).
-    # Use terms from document *content* (not titles) since keyword mode
-    # searches the content field by default.
+    expected_titles = [case["title"] for case in DOC_CASES]
+
+    # Wait for keyword search to find BOTH uploaded documents (confirms
+    # indexing). Filter by category to isolate from other test data, and
+    # poll for the specific titles we just uploaded — not just a raw count.
     body = _wait_for_search_results(
         api_url,
         auth_headers,
         query="clownfish OR Jezero",
         mode="keyword",
-        expected_count=2,
+        expected_titles=expected_titles,
+        category=UPLOADS_CATEGORY,
         timeout=WEB_API_TIMEOUT,
     )
     if not body:
@@ -258,28 +271,25 @@ def uploaded_docs(
             "The upload→index pipeline may not be running."
         )
 
-    # Wait for semantic search to work (confirms embeddings generated)
+    # Wait for semantic search to return BOTH of our uploaded titles in
+    # response to their own semantic queries — confirms embeddings were
+    # generated for the documents we actually care about.
     semantic_body = _wait_for_search_results(
         api_url,
         auth_headers,
-        query="coral reef marine biology",
+        query="clownfish OR Jezero",
         mode="semantic",
-        expected_count=1,
+        expected_titles=expected_titles,
+        category=UPLOADS_CATEGORY,
         timeout=WEB_API_TIMEOUT,
     )
     if not semantic_body:
         pytest.skip(
-            f"Semantic search returned no results within {WEB_API_TIMEOUT}s. "
+            f"Semantic search did not return uploaded documents within {WEB_API_TIMEOUT}s. "
             "Embeddings may not have been generated yet."
         )
 
     yield uploaded
-
-    # Cleanup: best-effort delete via API
-    for entry in uploaded:
-        doc_id = entry.get("upload_response", {}).get("doc_id", "")
-        if doc_id:
-            _delete_via_api(api_url, auth_headers, doc_id)
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +319,7 @@ class TestWebAPISemanticRetrieval:
         """Semantic queries must rank the intended document first."""
         for case in uploaded_docs:
             wrong_title = next(doc["title"] for doc in uploaded_docs if doc["slug"] != case["slug"])
-            resp = _search(api_url, auth_headers, query=case["query"], mode="semantic", category="Uploads")
+            resp = _search(api_url, auth_headers, query=case["query"], mode="semantic", category=UPLOADS_CATEGORY)
             assert resp.status_code == 200, f"Semantic search failed for {case['slug']}: {resp.status_code} {resp.text}"
 
             body = resp.json()
@@ -333,7 +343,7 @@ class TestWebAPISemanticRetrieval:
         """Hybrid queries must still rank the intended document first."""
         for case in uploaded_docs:
             wrong_title = next(doc["title"] for doc in uploaded_docs if doc["slug"] != case["slug"])
-            resp = _search(api_url, auth_headers, query=case["query"], mode="hybrid", category="Uploads")
+            resp = _search(api_url, auth_headers, query=case["query"], mode="hybrid", category=UPLOADS_CATEGORY)
             assert resp.status_code == 200, f"Hybrid search failed for {case['slug']}: {resp.status_code} {resp.text}"
 
             body = resp.json()
@@ -354,12 +364,15 @@ class TestWebAPISemanticRetrieval:
         auth_headers: dict[str, str],
         uploaded_docs: list[dict],
     ) -> None:
-        """Keyword mode should find the documents by unique terms."""
-        resp = _search(api_url, auth_headers, query="clownfish OR Jezero", mode="keyword", category="Uploads")
+        """Keyword mode should find BOTH documents by their unique terms."""
+        resp = _search(api_url, auth_headers, query="clownfish OR Jezero", mode="keyword", category=UPLOADS_CATEGORY)
         assert resp.status_code == 200
         body = resp.json()
         results = body.get("results", [])
         titles = [r.get("title", "") for r in results]
         found_reef = any(t.startswith("Shallow Atoll Survey") for t in titles)
         found_mars = any(t.startswith("Jezero Core Archive") for t in titles)
-        assert found_reef or found_mars, f"Keyword search didn't find test documents. Titles: {titles}"
+        # Both documents were uploaded — keyword search must find both.
+        assert found_reef and found_mars, (
+            f"Keyword search did not find both test documents. reef={found_reef}, mars={found_mars}, titles={titles}"
+        )

--- a/e2e/test_web_api_semantic.py
+++ b/e2e/test_web_api_semantic.py
@@ -322,6 +322,48 @@ def _title_matches(actual_title: str | None, expected_prefix: str) -> bool:
     return bool(actual_title and actual_title.startswith(expected_prefix))
 
 
+def _find_score(results: list[dict], title_prefix: str) -> float | None:
+    """Return the highest score among results whose title starts with prefix."""
+    matching = [r for r in results if _title_matches(r.get("title"), title_prefix)]
+    if not matching:
+        return None
+    return max(r.get("score", 0.0) for r in matching)
+
+
+def _assert_ranks_above(
+    results: list[dict],
+    *,
+    expected_title: str,
+    wrong_title: str,
+    query: str,
+    mode: str,
+) -> None:
+    """Assert the expected document outranks the wrong-topic document.
+
+    We do NOT assert "expected is the top result" because in shared dev
+    environments prior test runs may have left documents with identical
+    content (and therefore identical embeddings) that tie or out-rank
+    the freshly uploaded one based on Solr's tiebreaker.  Instead we
+    require:
+      1. The expected document appears in results.
+      2. Its score is strictly greater than the wrong-topic document's
+         score (proving the embedding pipeline ranks the right concept
+         higher for this query).
+    """
+    expected_score = _find_score(results, expected_title)
+    wrong_score = _find_score(results, wrong_title)
+
+    titles = [(r.get("title"), r.get("score")) for r in results]
+    assert expected_score is not None, (
+        f"Expected document {expected_title!r} not found in {mode} results for {query!r}. Titles: {titles}"
+    )
+    assert wrong_score is None or expected_score > wrong_score, (
+        f"In {mode} mode for query {query!r}, expected {expected_title!r} to outrank "
+        f"{wrong_title!r}, got expected={expected_score} vs wrong={wrong_score}. "
+        f"Titles: {titles}"
+    )
+
+
 class TestWebAPISemanticRetrieval:
     """Validate semantic search via the web API (no direct Solr access)."""
 
@@ -336,7 +378,7 @@ class TestWebAPISemanticRetrieval:
         auth_headers: dict[str, str],
         uploaded_docs: list[dict],
     ) -> None:
-        """Semantic queries must rank the intended document first."""
+        """Semantic mode must rank the intended document above the wrong-topic doc."""
         for case in uploaded_docs:
             wrong_title = next(doc["title"] for doc in uploaded_docs if doc["slug"] != case["slug"])
             resp = _search(api_url, auth_headers, query=case["query"], mode="semantic", category=UPLOADS_CATEGORY)
@@ -346,13 +388,13 @@ class TestWebAPISemanticRetrieval:
             results = body.get("results", [])
             assert results, f"No results for query {case['query']!r}: {body}"
 
-            top = results[0]
-            assert _title_matches(top.get("title"), case["title"]), (
-                f"Expected top result starting with {case['title']!r} for {case['query']!r}, "
-                f"got {top.get('title')!r}. Scores: "
-                f"{[(r.get('title'), r.get('score')) for r in results]}"
+            _assert_ranks_above(
+                results,
+                expected_title=case["title"],
+                wrong_title=wrong_title,
+                query=case["query"],
+                mode="semantic",
             )
-            assert not _title_matches(top.get("title"), wrong_title)
 
     def test_hybrid_search_ranks_correctly(
         self,
@@ -360,7 +402,7 @@ class TestWebAPISemanticRetrieval:
         auth_headers: dict[str, str],
         uploaded_docs: list[dict],
     ) -> None:
-        """Hybrid queries must still rank the intended document first."""
+        """Hybrid mode must rank the intended document above the wrong-topic doc."""
         for case in uploaded_docs:
             wrong_title = next(doc["title"] for doc in uploaded_docs if doc["slug"] != case["slug"])
             resp = _search(api_url, auth_headers, query=case["query"], mode="hybrid", category=UPLOADS_CATEGORY)
@@ -370,13 +412,13 @@ class TestWebAPISemanticRetrieval:
             results = body.get("results", [])
             assert results, f"No results for query {case['query']!r}: {body}"
 
-            top = results[0]
-            assert _title_matches(top.get("title"), case["title"]), (
-                f"Expected top result starting with {case['title']!r} for {case['query']!r}, "
-                f"got {top.get('title')!r}. Scores: "
-                f"{[(r.get('title'), r.get('score')) for r in results]}"
+            _assert_ranks_above(
+                results,
+                expected_title=case["title"],
+                wrong_title=wrong_title,
+                query=case["query"],
+                mode="hybrid",
             )
-            assert not _title_matches(top.get("title"), wrong_title)
 
     def test_keyword_mode_also_returns_results(
         self,

--- a/e2e/test_web_api_semantic.py
+++ b/e2e/test_web_api_semantic.py
@@ -24,20 +24,35 @@ Environment variables:
   SEARCH_API_URL    solr-search base URL (default: http://localhost:8080)
   E2E_USERNAME      Login username (default: admin)
   E2E_PASSWORD      Login password (required)
-  WEB_API_TIMEOUT   Max seconds to wait for indexing (default: 300)
+  WEB_API_TIMEOUT   Max seconds to wait for indexing (default: 90 — must
+                    fit inside the e2e suite's per-test pytest-timeout of
+                    120s; tests override per-fixture via @pytest.mark.timeout)
 """
 
 from __future__ import annotations
 
 import os
 import time
+import uuid
 
 import pytest
 import requests
 
 SEARCH_API_URL: str = os.environ.get("SEARCH_API_URL", "http://localhost:8080")
-WEB_API_TIMEOUT = int(os.environ.get("WEB_API_TIMEOUT", "300"))
-POLL_INTERVAL = 10
+# Default kept under the per-test pytest-timeout (120s — see e2e/pytest.ini)
+# so a missing override doesn't silently consume the whole budget.  Slow
+# fixtures that need more headroom apply @pytest.mark.timeout(...) directly.
+WEB_API_TIMEOUT = int(os.environ.get("WEB_API_TIMEOUT", "90"))
+POLL_INTERVAL = 5
+
+# Unique per-run marker so test documents don't collide with leftover
+# uploads from previous runs (there is no public DELETE-by-id endpoint
+# on the web API today, so uploaded docs accumulate).
+RUN_ID = uuid.uuid4().hex[:8]
+
+# Use a generous result limit when filtering by category, since previous
+# test runs may have left other "Uploads" documents in the index.
+SEARCH_LIMIT = 50
 
 # All documents uploaded via /v1/upload land under the "Uploads" category
 # (derived by the metadata extractor from the folder path).  We use this
@@ -47,7 +62,7 @@ UPLOADS_CATEGORY = "Uploads"
 DOC_CASES = (
     {
         "slug": "reef",
-        "title": "Shallow Atoll Survey",
+        "title": f"Shallow Atoll Survey {RUN_ID}",
         "author": "Pelagia North",
         "year": "2024",
         "text": (
@@ -59,7 +74,7 @@ DOC_CASES = (
     },
     {
         "slug": "mars",
-        "title": "Jezero Core Archive",
+        "title": f"Jezero Core Archive {RUN_ID}",
         "author": "Aster Vale",
         "year": "2024",
         "text": (
@@ -148,7 +163,7 @@ def _search(
     mode: str,
     category: str | None = None,
 ) -> requests.Response:
-    params: dict[str, str] = {"q": query, "mode": mode, "limit": "5"}
+    params: dict[str, str] = {"q": query, "mode": mode, "limit": str(SEARCH_LIMIT)}
     if category:
         params["fq_category"] = category
     return requests.get(
@@ -310,6 +325,11 @@ def _title_matches(actual_title: str | None, expected_prefix: str) -> bool:
 class TestWebAPISemanticRetrieval:
     """Validate semantic search via the web API (no direct Solr access)."""
 
+    # The first test that uses the module-scoped uploaded_docs fixture
+    # triggers fixture setup, which polls for keyword + semantic indexing
+    # (up to 2 * WEB_API_TIMEOUT). Override the suite-wide pytest-timeout
+    # so the indexing wait fits.
+    @pytest.mark.timeout(WEB_API_TIMEOUT * 2 + 60)
     def test_semantic_search_ranks_correctly(
         self,
         api_url: str,
@@ -370,8 +390,11 @@ class TestWebAPISemanticRetrieval:
         body = resp.json()
         results = body.get("results", [])
         titles = [r.get("title", "") for r in results]
-        found_reef = any(t.startswith("Shallow Atoll Survey") for t in titles)
-        found_mars = any(t.startswith("Jezero Core Archive") for t in titles)
+        # Match the RUN_ID-suffixed titles unique to this test run.
+        reef_title = next(d["title"] for d in uploaded_docs if d["slug"] == "reef")
+        mars_title = next(d["title"] for d in uploaded_docs if d["slug"] == "mars")
+        found_reef = any(_title_matches(t, reef_title) for t in titles)
+        found_mars = any(_title_matches(t, mars_title) for t in titles)
         # Both documents were uploaded — keyword search must find both.
         assert found_reef and found_mars, (
             f"Keyword search did not find both test documents. reef={found_reef}, mars={found_mars}, titles={titles}"

--- a/e2e/test_web_api_semantic.py
+++ b/e2e/test_web_api_semantic.py
@@ -1,0 +1,365 @@
+"""Production E2E test: semantic retrieval via the web API only.
+
+Unlike test_semantic_retrieval.py (which uses direct Solr access for setup),
+this test exercises the same upload-index-search pipeline purely through
+the public-facing web API.  It is suitable for production environments where
+Solr is not directly accessible from the test runner.
+
+Flow:
+1. Upload two PDFs via POST /v1/upload
+2. Wait for documents to appear in search results (keyword mode)
+3. Wait for embeddings to be generated (semantic mode returns results)
+4. Assert semantic and hybrid search rank the correct document first
+
+Environment variables:
+  SEARCH_API_URL    solr-search base URL (default: http://localhost:8080)
+  E2E_USERNAME      Login username (default: admin)
+  E2E_PASSWORD      Login password (required)
+  WEB_API_TIMEOUT   Max seconds to wait for indexing (default: 300)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import pytest
+import requests
+
+SEARCH_API_URL: str = os.environ.get("SEARCH_API_URL", "http://localhost:8080")
+WEB_API_TIMEOUT = int(os.environ.get("WEB_API_TIMEOUT", "300"))
+POLL_INTERVAL = 10
+RUN_ID = uuid.uuid4().hex[:8]
+
+# Category used to isolate test documents from any real data
+TEST_CATEGORY = "WebAPISemanticE2E"
+
+DOC_CASES = (
+    {
+        "slug": "reef",
+        "title": "Shallow Atoll Survey",
+        "author": "Pelagia North",
+        "year": "2024",
+        "text": (
+            "The coral reef biome shelters clownfish, sea anemones, crustaceans, "
+            "and bright algae. Sunlit lagoons build calcium structures that protect "
+            "coastlines and provide nursery grounds for countless animals."
+        ),
+        "query": "underwater life and biodiversity",
+    },
+    {
+        "slug": "mars",
+        "title": "Jezero Core Archive",
+        "author": "Aster Vale",
+        "year": "2024",
+        "text": (
+            "The rover explored Jezero Crater, drilled basalt cores, and sealed "
+            "geological specimens for return to Earth. Researchers inspect the "
+            "samples for biosignatures that could reveal whether ancient microbes "
+            "once inhabited the planet."
+        ),
+        "query": "searching for extraterrestrial organisms on other worlds",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal PDF generator (same as conftest._build_pdf)
+# ---------------------------------------------------------------------------
+
+
+def _build_pdf(text: str) -> bytes:
+    """Return a minimal but valid single-page PDF containing *text*."""
+    stream_body = (f"BT /F1 12 Tf 72 720 Td ({text}) Tj ET").encode()
+    objects: list[bytes] = [
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        (
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+        ),
+        (f"4 0 obj\n<< /Length {len(stream_body)} >>\nstream\n".encode() + stream_body + b"\nendstream\nendobj\n"),
+        b"5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    ]
+    body = b""
+    offsets: list[int] = []
+    header = b"%PDF-1.4\n"
+    body += header
+    for obj in objects:
+        offsets.append(len(body))
+        body += obj
+    xref_offset = len(body)
+    xref = f"xref\n0 {len(objects) + 1}\n0000000000 65535 f \n"
+    for off in offsets:
+        xref += f"{off:010d} 00000 n \n"
+    xref += f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n"
+    return body + xref.encode()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _login(api_url: str) -> dict[str, str]:
+    """Login and return auth headers."""
+    username = os.environ.get("E2E_USERNAME", os.environ.get("CI_ADMIN_USERNAME", "admin"))
+    password = os.environ.get("E2E_PASSWORD") or os.environ.get("CI_ADMIN_PASSWORD")
+    if not password:
+        pytest.skip("E2E_PASSWORD must be set for authenticated web API tests")
+
+    resp = requests.post(
+        f"{api_url}/v1/auth/login",
+        json={"username": username, "password": password},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    token = resp.json().get("access_token")
+    if not token:
+        pytest.fail(f"Login failed — no access_token: {resp.text}")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _upload_pdf(api_url: str, headers: dict[str, str], filename: str, content: bytes) -> requests.Response:
+    """Upload a PDF via the web API upload endpoint."""
+    return requests.post(
+        f"{api_url}/v1/upload",
+        headers=headers,
+        files={"file": (filename, content, "application/pdf")},
+        timeout=60,
+    )
+
+
+def _search(
+    api_url: str,
+    headers: dict[str, str],
+    *,
+    query: str,
+    mode: str,
+    category: str | None = None,
+) -> requests.Response:
+    params: dict[str, str] = {"q": query, "mode": mode, "limit": "5"}
+    if category:
+        params["fq_category"] = category
+    return requests.get(
+        f"{api_url}/v1/search",
+        params=params,
+        headers=headers,
+        timeout=30,
+    )
+
+
+def _wait_for_search_results(
+    api_url: str,
+    headers: dict[str, str],
+    *,
+    query: str,
+    mode: str,
+    expected_count: int,
+    category: str | None = None,
+    timeout: int = WEB_API_TIMEOUT,
+) -> dict | None:
+    """Poll search until at least expected_count results appear."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = _search(api_url, headers, query=query, mode=mode, category=category)
+        if resp.status_code == 200:
+            body = resp.json()
+            results = body.get("results", [])
+            if len(results) >= expected_count:
+                return body
+        time.sleep(POLL_INTERVAL)
+    return None
+
+
+def _delete_via_api(api_url: str, headers: dict[str, str], doc_id: str) -> None:
+    """Delete a document via the admin API (best-effort cleanup)."""
+    api_key = os.environ.get("ADMIN_API_KEY")
+    if api_key:
+        requests.delete(
+            f"{api_url}/v1/admin/documents/{doc_id}",
+            headers={"X-API-Key": api_key},
+            timeout=30,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def api_url() -> str:
+    return SEARCH_API_URL.rstrip("/")
+
+
+@pytest.fixture(scope="module")
+def auth_headers(api_url: str) -> dict[str, str]:
+    return _login(api_url)
+
+
+@pytest.fixture(scope="module")
+def web_api_available(api_url: str) -> None:
+    """Skip if the web API is not reachable or embeddings unavailable."""
+    try:
+        resp = requests.get(f"{api_url}/v1/status", timeout=10)
+        resp.raise_for_status()
+    except Exception as exc:
+        pytest.skip(f"Web API not reachable: {exc}")
+
+    payload = resp.json()
+    if not payload.get("embeddings_available"):
+        pytest.skip("Embeddings not available — semantic search cannot be tested.")
+
+
+@pytest.fixture(scope="module")
+def uploaded_docs(
+    api_url: str,
+    auth_headers: dict[str, str],
+    web_api_available: None,
+) -> list[dict]:
+    """Upload both test PDFs and wait for them to become searchable.
+
+    Returns list of doc metadata dicts with title, query, slug info.
+    """
+    uploaded: list[dict] = []
+
+    for case in DOC_CASES:
+        filename = f"{case['author']} - {case['title']} ({case['year']}).pdf"
+        pdf_bytes = _build_pdf(case["text"])
+
+        resp = _upload_pdf(api_url, auth_headers, filename, pdf_bytes)
+        assert resp.status_code in (200, 201, 202), f"Upload failed for {case['slug']}: {resp.status_code} {resp.text}"
+
+        upload_data = resp.json() if resp.content else {}
+        uploaded.append(
+            {
+                **case,
+                "filename": filename,
+                "upload_response": upload_data,
+            }
+        )
+
+    # Wait for keyword search to find both documents (confirms indexing).
+    # Use terms from document *content* (not titles) since keyword mode
+    # searches the content field by default.
+    body = _wait_for_search_results(
+        api_url,
+        auth_headers,
+        query="clownfish OR Jezero",
+        mode="keyword",
+        expected_count=2,
+        timeout=WEB_API_TIMEOUT,
+    )
+    if not body:
+        pytest.skip(
+            f"Documents did not appear in keyword search within {WEB_API_TIMEOUT}s. "
+            "The upload→index pipeline may not be running."
+        )
+
+    # Wait for semantic search to work (confirms embeddings generated)
+    semantic_body = _wait_for_search_results(
+        api_url,
+        auth_headers,
+        query="coral reef marine biology",
+        mode="semantic",
+        expected_count=1,
+        timeout=WEB_API_TIMEOUT,
+    )
+    if not semantic_body:
+        pytest.skip(
+            f"Semantic search returned no results within {WEB_API_TIMEOUT}s. "
+            "Embeddings may not have been generated yet."
+        )
+
+    yield uploaded
+
+    # Cleanup: best-effort delete via API
+    for entry in uploaded:
+        doc_id = entry.get("upload_response", {}).get("doc_id", "")
+        if doc_id:
+            _delete_via_api(api_url, auth_headers, doc_id)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _title_matches(actual_title: str | None, expected_prefix: str) -> bool:
+    """Check if actual title starts with the expected title prefix.
+
+    The metadata extractor may append year and timestamp suffixes to
+    titles derived from sanitized filenames (e.g. "My Title 2024 20260512_123456"),
+    so we match on prefix rather than exact equality.
+    """
+    return bool(actual_title and actual_title.startswith(expected_prefix))
+
+
+class TestWebAPISemanticRetrieval:
+    """Validate semantic search via the web API (no direct Solr access)."""
+
+    def test_semantic_search_ranks_correctly(
+        self,
+        api_url: str,
+        auth_headers: dict[str, str],
+        uploaded_docs: list[dict],
+    ) -> None:
+        """Semantic queries must rank the intended document first."""
+        for case in uploaded_docs:
+            wrong_title = next(doc["title"] for doc in uploaded_docs if doc["slug"] != case["slug"])
+            resp = _search(api_url, auth_headers, query=case["query"], mode="semantic", category="Uploads")
+            assert resp.status_code == 200, f"Semantic search failed for {case['slug']}: {resp.status_code} {resp.text}"
+
+            body = resp.json()
+            results = body.get("results", [])
+            assert results, f"No results for query {case['query']!r}: {body}"
+
+            top = results[0]
+            assert _title_matches(top.get("title"), case["title"]), (
+                f"Expected top result starting with {case['title']!r} for {case['query']!r}, "
+                f"got {top.get('title')!r}. Scores: "
+                f"{[(r.get('title'), r.get('score')) for r in results]}"
+            )
+            assert not _title_matches(top.get("title"), wrong_title)
+
+    def test_hybrid_search_ranks_correctly(
+        self,
+        api_url: str,
+        auth_headers: dict[str, str],
+        uploaded_docs: list[dict],
+    ) -> None:
+        """Hybrid queries must still rank the intended document first."""
+        for case in uploaded_docs:
+            wrong_title = next(doc["title"] for doc in uploaded_docs if doc["slug"] != case["slug"])
+            resp = _search(api_url, auth_headers, query=case["query"], mode="hybrid", category="Uploads")
+            assert resp.status_code == 200, f"Hybrid search failed for {case['slug']}: {resp.status_code} {resp.text}"
+
+            body = resp.json()
+            results = body.get("results", [])
+            assert results, f"No results for query {case['query']!r}: {body}"
+
+            top = results[0]
+            assert _title_matches(top.get("title"), case["title"]), (
+                f"Expected top result starting with {case['title']!r} for {case['query']!r}, "
+                f"got {top.get('title')!r}. Scores: "
+                f"{[(r.get('title'), r.get('score')) for r in results]}"
+            )
+            assert not _title_matches(top.get("title"), wrong_title)
+
+    def test_keyword_mode_also_returns_results(
+        self,
+        api_url: str,
+        auth_headers: dict[str, str],
+        uploaded_docs: list[dict],
+    ) -> None:
+        """Keyword mode should find the documents by unique terms."""
+        resp = _search(api_url, auth_headers, query="clownfish OR Jezero", mode="keyword", category="Uploads")
+        assert resp.status_code == 200
+        body = resp.json()
+        results = body.get("results", [])
+        titles = [r.get("title", "") for r in results]
+        found_reef = any(t.startswith("Shallow Atoll Survey") for t in titles)
+        found_mars = any(t.startswith("Jezero Core Archive") for t in titles)
+        assert found_reef or found_mars, f"Keyword search didn't find test documents. Titles: {titles}"


### PR DESCRIPTION
## Summary

Two new E2E test modules that validate vector and hybrid search work correctly after uploading and indexing documents.

### test_semantic_retrieval.py (infrastructure-level)
- Creates 2 PDFs (coral reef ecology + Mars exploration) with deliberately different subject matter
- Indexes parent docs via Solr `/update/extract`, enqueues for document-indexer via RabbitMQ
- Verifies semantic and hybrid search rank the correct document first
- Uses synonym-style queries with no keyword overlap to exercise embedding similarity (not BM25)
- Isolated via `fq_category=SemanticE2E` filter

### test_web_api_semantic.py (production-ready, web API only)
- Same semantic retrieval validation but uses **only the public web API**
- Uploads via `POST /v1/upload`, waits for the full indexing pipeline to complete
- Suitable for production environments where Solr is not directly accessible
- Uses prefix matching for titles (metadata extractor appends year/timestamp to sanitized filenames)
- Isolated via `fq_category=Uploads` filter

### Test Results
Both tests verified locally against single-node stack: **93 passed, 9 skipped, 0 failed** (full suite).

### Key Design Decisions
- **Semantic isolation**: Queries intentionally avoid exact keyword overlap with document text (`underwater life and biodiversity` vs document about `coral reef biome shelters clownfish`)
- **Category filtering**: Both tests use category filters to avoid interference from other test data
- **Chunk ID handling**: Assertions handle chunk IDs (`{doc_id}_chunk_0000`) via prefix matching
- **Title flexibility**: Web API test uses `startswith` for titles since the metadata extractor appends year/timestamp suffixes