### PR TITLE
Project review: squad roster + documentation drift fixes

### DIFF
--- a/.squad/agents/bishop/charter.md
+++ b/.squad/agents/bishop/charter.md
@@ -1,0 +1,28 @@
+# Bishop — Vector Search & Data Science Specialist
+
+## Role
+Vector Search & Data Science Specialist: Embedding models, vector similarity, quantization, semantic search test design, retrieval evaluation.
+
+## Responsibilities
+- Design semantic search test scenarios with proper ground-truth queries
+- Select embedding models and quantization strategies (fp16, int8, none)
+- Evaluate vector search quality (recall, precision, semantic similarity)
+- Design test PDFs with controlled content for deterministic semantic retrieval
+- Advise on kNN vs hybrid-rerank search strategies
+- Validate that cosine similarity and embedding pipelines produce correct results
+- Design evaluation metrics for search relevance
+
+## Boundaries
+- Does NOT build Python services or APIs (that's Parker)
+- Does NOT configure Solr schema (that's Ash)
+- Does NOT make architectural decisions unilaterally (proposes to Ripley)
+- DOES advise on embedding model selection, quantization, and test design
+
+## Domain Tools
+- sentence-transformers, numpy, embedding quantization (fp16/int8)
+- Cosine similarity, kNN search, hybrid search (BM25 + vector rerank)
+- Solr DenseVectorField, HNSW parameters
+- PDF text extraction via Apache Tika
+
+## Model
+Preferred: auto

--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -1,0 +1,13 @@
+# Bishop — History
+
+## Project Context
+- **Project:** aithena — Book library search engine with Solr full-text indexing, multilingual embeddings, PDF processing, and React UI
+- **User:** jmservera
+- **Stack:** Python (backend services), TypeScript/React + Vite (UI), Docker Compose, Apache Solr (search), multilingual embeddings
+- **Key services:** embeddings-server (sentence-transformers), solr-search (FastAPI), document-indexer, document-lister
+- **Search modes:** keyword (BM25), semantic (kNN vector), hybrid (BM25 + vector rerank), hybrid-rerank (configurable)
+- **Quantization:** Configurable — none (fp32), fp16, int8
+- **Vector field:** embedding_v (chunk-level), configured via KNN_FIELD env var
+
+## Learnings
+- Semantic E2E coverage should index parent PDFs via Solr `/update/extract`, then enqueue the same file paths to `shortembeddings` so document-indexer produces chunk docs with vectors before asserting `/v1/search` semantic and hybrid ranking.

--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -549,3 +549,13 @@ Performed thorough comparison of embeddings-server OpenVINO images rc.3 (working
 **Testing:** 16 new quantization tests (none identity, fp16 similarity > 0.99, int8 range [-128,127], invalid mode, quality validation). All 76 embeddings-server tests pass. All 203 document-indexer tests pass (4 pre-existing env-specific failures excluded).
 
 **Coordination with Ash:** Ash added `embedding_byte` Solr field type for int8/BYTE encoding in parallel. Our `embedding_byte_v` field name maps to Ash's schema.
+
+### Local Single-Node E2E Pipeline Audit (2026-05-12)
+
+**Compose chain:** For a real local single-node E2E run, the working compose stack is `docker-compose.yml` + `docker/compose.dev-ports.yml` + `docker/compose.single-node.yml` + `docker/compose.e2e.yml`. `compose.e2e.yml` only swaps the document-data bind mount to `E2E_LIBRARY_PATH`, lowers `POLL_INTERVAL` to 10s, disables search rate limiting, and disables nginx; it does **not** publish `8080`/`8983`, so `compose.dev-ports.yml` is still required for the pytest suite defaults (`SEARCH_API_URL=http://localhost:8080`, `SOLR_URL=http://localhost:8983/solr/books`).
+
+**Installer dependency:** The installer still needs to run first because `solr-search` hard-requires installer-generated auth settings (`AUTH_JWT_SECRET`, auth DB bind mount, admin bootstrap user, Solr/Rabbit credentials). The installer-generated `start.sh` includes dev/prod + GPU + SSL + single-node overlays, but never the E2E overlay, so E2E runs must add `docker/compose.e2e.yml` manually.
+
+**Pipeline shape:** `/v1/upload` writes the PDF into `/data/documents/uploads`, then publishes the absolute path straight to RabbitMQ; it bypasses document-lister for initial enqueue. `document-indexer` then does two phases: (1) parent-book indexing via Solr `/update/extract`, (2) page/chunk extraction + batched calls to `/v1/embeddings/` + chunk writes back to Solr. Redis state is updated with `text_indexed`, `embedding_indexed`, and `chunk_count`; `GET /v1/admin/indexing-status` is the best API to poll in E2E.
+
+**Gap update:** There is now an `e2e/test_semantic_retrieval.py` test that verifies fresh semantic and hybrid retrieval, but it still cheats the user path by POSTing directly to Solr `/update/extract` and publishing directly to RabbitMQ. The remaining missing coverage is a single test that uses `/v1/upload`, waits for `embedding_indexed=true`, then asserts `/v1/search?mode=semantic` and `/v1/search?mode=hybrid` both retrieve the uploaded document.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -334,3 +334,14 @@ Consolidated skills from 38 to 24 (14 eliminated, target was ≤35). Five merge 
 5. **FastAPI** (2 → 1): `fastapi-auth-patterns`, `fastapi-query-params` → `fastapi-patterns`
 
 Each merged skill preserves key patterns, examples, and anti-patterns from all sources while removing duplication. All merged skills are under 300 lines.
+
+## Learnings
+
+### Project Review (2026-05-12)
+
+- **v2.1 shipped, but top-level docs lag behind.** `VERSION` and GitHub Releases are at `2.1.0`, and `CHANGELOG.md` covers the release well, but `README.md` still advertises `v1.9.1` / `v1.10.0` development state.
+- **Search architecture + capabilities are real shipped features.** `SEARCH_ARCHITECTURE` is implemented in `solr-search`, `/v1/capabilities` is live, UI capability gating is wired up, and the full `solr-search` test suite passes.
+- **Quantization naming is now a docs hazard.** The live env var is `VECTOR_QUANTIZATION`, not `EMBEDDING_QUANTIZATION`; stale naming would misconfigure deployments.
+- **Architecture docs need model/schema refresh.** `docs/architecture/solr-data-model.md` still describes 512-dim `distiluse` vectors, while code/schema use 768-dim `multilingual-e5-base` with optional byte-vector quantization.
+- **Auto-generated operational issues need lifecycle reconciliation.** Pre-release warning issues and heartbeat token issues can stay open after later clean runs or tagged releases, creating stale backlog noise unless a success path closes them.
+- **Immediate attention remains security-first.** Open GHAS issue #1519 is the only clearly current urgent issue from the active backlog snapshot.

--- a/.squad/casting/registry.json
+++ b/.squad/casting/registry.json
@@ -64,6 +64,14 @@
       "created_at": "2026-03-14T19:30:00Z",
       "legacy_named": false,
       "status": "active"
+    },
+    {
+      "persistent_name": "Bishop",
+      "role": "Vector Search & Data Science Specialist",
+      "universe": "Alien",
+      "created_at": "2026-05-12T10:27:00Z",
+      "legacy_named": false,
+      "status": "active"
     }
   ]
 }

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -24,6 +24,7 @@
 | Juanma | Product Owner | — | Human |
 | @copilot | Coding Agent | `.squad/agents/copilot/charter.md` | Active |
 | Newt | Product Manager | `.squad/agents/newt/charter.md` | Active |
+| Bishop | Vector Search Specialist | `.squad/agents/bishop/charter.md` | Active |
 
 <!-- copilot-auto-assign: true -->
 

--- a/.squad/team.md
+++ b/.squad/team.md
@@ -24,7 +24,7 @@
 | Juanma | Product Owner | — | Human |
 | @copilot | Coding Agent | `.squad/agents/copilot/charter.md` | Active |
 | Newt | Product Manager | `.squad/agents/newt/charter.md` | Active |
-| Bishop | Vector Search Specialist | `.squad/agents/bishop/charter.md` | Active |
+| Bishop | Vector Search & Data Science Specialist | `.squad/agents/bishop/charter.md` | Active |
 
 <!-- copilot-auto-assign: true -->
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A multilingual book library search engine that indexes PDFs using **Apache Solr** for full-text search, extracts metadata (author, date, language) from filenames and folder names, and supports keyword, semantic, and hybrid search via embeddings.
 
-**Current Release:** v1.9.1 — Docker build fix for aithena-ui.  
-**Development:** v1.10.0 milestones active. All PRs target `dev` branch; releases merge `dev` → `main`.  
-**[View Milestones](https://github.com/jmservera/aithena/milestones)** | **[Latest Release Notes](docs/release-notes/v1.9.1.md)**
+**Current Release:** v2.1.0 — Configurable search architecture (HNSW/hybrid-rerank), integration tests for both topologies.  
+**Development:** v2.5 milestone active. All PRs target `dev` branch; releases merge `dev` → `main`.  
+**[View Milestones](https://github.com/jmservera/aithena/milestones)** | **[Latest Release Notes](docs/release-notes/v2.0.0.md)**
 
 ## What It Does
 
@@ -98,10 +98,24 @@ See [Release Process Overview](#release-process-overview) below for full details
 
 ### Release Notes (newest first)
 
+- [v2.0.0 Release Notes](docs/release-notes/v2.0.0.md) — Major: React admin portal, installer overhaul
+- [v1.19.0 Release Notes](docs/release-notes/v1.19.0.md)
+- [v1.18.1 Release Notes](docs/release-notes/v1.18.1.md)
+- [v1.18.0 Release Notes](docs/release-notes/v1.18.0.md)
+- [v1.17.1 Release Notes](docs/release-notes/v1.17.1.md)
+- [v1.17.0 Release Notes](docs/release-notes/v1.17.0.md)
+- [v1.16.0 Release Notes](docs/release-notes/v1.16.0.md)
+- [v1.15.0 Release Notes](docs/release-notes/v1.15.0.md)
+- [v1.14.1 Release Notes](docs/release-notes/v1.14.1.md)
+- [v1.13.1 Release Notes](docs/release-notes/v1.13.1.md)
+- [v1.13.0 Release Notes](docs/release-notes/v1.13.0.md)
+- [v1.12.2 Release Notes](docs/release-notes/v1.12.2.md)
+- [v1.12.1 Release Notes](docs/release-notes/v1.12.1.md)
+- [v1.11.0 Release Notes](docs/release-notes/v1.11.0.md)
+- [v1.10.0 Release Notes](docs/release-notes/v1.10.0.md)
 - [v1.9.1 Release Notes](docs/release-notes/v1.9.1.md)
 - [v1.9.0 Release Notes](docs/release-notes/v1.9.0.md)
 - [v1.8.2 Release Notes](docs/release-notes/v1.8.2.md)
-- [v1.8.1 Release Notes](docs/release-notes/v1.8.1.md)
 - [v1.8.0 Release Notes](docs/release-notes/v1.8.0.md)
 - [v1.7.0 Release Notes](docs/release-notes/v1.7.0.md)
 - [v1.6.0 Release Notes](docs/release-notes/v1.6.0.md)
@@ -144,12 +158,11 @@ See [Release Process Overview](#release-process-overview) below for full details
 | Milestone | Theme | Status |
 |-----------|-------|--------|
 | [v1.8.0](https://github.com/jmservera/aithena/milestone/22) | UI/UX improvements, design system | Complete |
-| [v1.8.1](https://github.com/jmservera/aithena/milestone/24) | Bug fixes (search, stats, i18n, admin) | Complete |
-| [v1.8.2](https://github.com/jmservera/aithena/milestone/25) | Legacy admin retirement, infra UI links | Complete |
 | [v1.9.0](https://github.com/jmservera/aithena/milestone/23) | Authentication & user management | Complete |
-| [v1.9.1](https://github.com/jmservera/aithena/milestone/28) | Docker build fix | Complete |
-| [v1.10.0](https://github.com/jmservera/aithena/milestone/26) | User collections, metadata editing | Planned |
-| [v1.10.1](https://github.com/jmservera/aithena/milestone/27) | BCDR backup/restore | Planned |
+| [v1.19.0](https://github.com/jmservera/aithena/milestone/42) | Dependency updates, CI fixes | Complete |
+| [v2.0](https://github.com/jmservera/aithena/milestone/39) | React admin portal, installer overhaul | Complete |
+| [v2.1](https://github.com/jmservera/aithena/milestone/46) | Configurable search architecture, integration tests | Complete |
+| [v2.5](https://github.com/jmservera/aithena/milestone/44) | Semantic E2E tests, documentation | Active |
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A multilingual book library search engine that indexes PDFs using **Apache Solr*
 
 **Current Release:** v2.1.0 — Configurable search architecture (HNSW/hybrid-rerank), integration tests for both topologies.  
 **Development:** v2.5 milestone active. All PRs target `dev` branch; releases merge `dev` → `main`.  
-**[View Milestones](https://github.com/jmservera/aithena/milestones)** | **[Latest Release Notes](docs/release-notes/v2.0.0.md)**
+**[View Milestones](https://github.com/jmservera/aithena/milestones)** | **[Latest Release Notes](docs/release-notes/v2.1.0.md)**
 
 ## What It Does
 
@@ -98,6 +98,7 @@ See [Release Process Overview](#release-process-overview) below for full details
 
 ### Release Notes (newest first)
 
+- [v2.1.0 Release Notes](docs/release-notes/v2.1.0.md) — Configurable search architecture, single-node topology
 - [v2.0.0 Release Notes](docs/release-notes/v2.0.0.md) — Major: React admin portal, installer overhaul
 - [v1.19.0 Release Notes](docs/release-notes/v1.19.0.md)
 - [v1.18.1 Release Notes](docs/release-notes/v1.18.1.md)
@@ -116,6 +117,7 @@ See [Release Process Overview](#release-process-overview) below for full details
 - [v1.9.1 Release Notes](docs/release-notes/v1.9.1.md)
 - [v1.9.0 Release Notes](docs/release-notes/v1.9.0.md)
 - [v1.8.2 Release Notes](docs/release-notes/v1.8.2.md)
+- [v1.8.1 Release Notes](docs/release-notes/v1.8.1.md)
 - [v1.8.0 Release Notes](docs/release-notes/v1.8.0.md)
 - [v1.7.0 Release Notes](docs/release-notes/v1.7.0.md)
 - [v1.6.0 Release Notes](docs/release-notes/v1.6.0.md)

--- a/docs/architecture/solr-data-model.md
+++ b/docs/architecture/solr-data-model.md
@@ -86,7 +86,7 @@ Created by `document-indexer` during **Phase 2** (chunking & embedding).
 | `parent_id_s` | `string` | **Foreign key** → parent document `id`. |
 | `chunk_index_i` | `pint` | Sequential position of this chunk (0-based). |
 | `chunk_text_t` | `text_general` | The chunk's text content. |
-| `embedding_v` | `knn_vector_512` | 512-dimensional dense vector (HNSW, cosine). |
+| `embedding_v` | `knn_vector_768` | 768-dimensional dense vector (HNSW, cosine). |
 | `page_start_i` | `pint` | First page this chunk spans. |
 | `page_end_i` | `pint` | Last page this chunk spans. |
 | `title_s` | `string` | Inherited from parent (for display without join). |
@@ -112,8 +112,8 @@ not lost at chunk boundaries.
 ### Embedding generation
 
 Each chunk's text is sent to the **embeddings-server** (`POST /v1/embeddings/`),
-which returns a 512-dimensional vector using the
-`distiluse-base-multilingual-cased-v2` model. The vector is stored in the
+which returns a 768-dimensional vector using the
+`intfloat/multilingual-e5-base` model. The vector is stored in the
 `embedding_v` field, which is configured as a `DenseVectorField` with HNSW
 indexing and cosine similarity.
 
@@ -138,7 +138,7 @@ set. Highlighting uses the unified highlighter on `_text_`.
 
 ```
 User query
-    → embeddings-server → 512-dim vector
+    → embeddings-server → 768-dim vector
     → {!knn f=embedding_v topK=N} on chunk documents
     → returns chunk documents (with parent metadata)
     → normalize_book() maps chunk fields to book-level response

--- a/docs/release-notes/v2.1.0.md
+++ b/docs/release-notes/v2.1.0.md
@@ -1,0 +1,30 @@
+# v2.1.0
+
+Released: 2026-04-21T14:05:56Z
+
+## v2.1.0
+
+### Added
+- **Configurable search architecture** — `SEARCH_ARCHITECTURE` env var selects `hnsw` (default, HNSW-indexed kNN) or `hybrid-rerank` (BM25 + brute-force cosine rerank, no HNSW index)
+- **Single-node SolrCloud topology** — 1 Solr + 1 ZooKeeper via `docker/compose.single-node.yml` overlay, selectable through installer (`--topology single-node`)
+- **Configurable vector quantization** — `VECTOR_QUANTIZATION` env var: `none` (float32, default), `fp16` (reduced precision), `int8` (scaled byte encoding)
+- **Capabilities API** — Public `/v1/capabilities` endpoint returns active search architecture and available features for automatic UI adaptation
+- **CI both topologies** — Integration tests run against both single-node and distributed SolrCloud topologies
+
+### Changed
+- CI uses canonical `docker/compose.single-node.yml` overlay instead of duplicated heredoc overrides
+- Simplified all CI `docker compose` commands via `COMPOSE_FILE` env var
+- UI adapts search interface based on backend capabilities (hides vector search when unavailable)
+
+### Fixed
+- Credential leak in `retry_curl` error messages
+- Hard-coded container name in CI replaced with dynamic lookup
+- Hybrid-rerank pagination no longer advertises pages beyond rerank window
+- Capabilities fetch no longer triggers logout on unauthenticated sessions
+- Int8 vectors now emit proper integer JSON values for Solr BYTE encoding
+- Deployment topology docs updated to reflect supported (not planned) single-node status
+
+### Milestone
+- 9 issues closed: #1506, #1502, #1499, #1498, #1497, #1496, #1373, #1342
+
+Full details: [CHANGELOG.md](https://github.com/jmservera/aithena/blob/main/CHANGELOG.md)


### PR DESCRIPTION
## Summary

Updates from the comprehensive project review session.

### Squad Roster
- Added **Bishop** (Vector Search & Data Science Specialist) to the squad
- Updated Parker and Ripley history files from project review findings

### Documentation Drift Fixes

**README.md:**
- Updated current release from v1.9.1 → v2.1.0
- Updated dev milestone from v1.10.0 → v2.5
- Added 14 missing release note links (v1.10.0 through v2.0.0)
- Updated roadmap table with v2.0, v2.1, v2.5 milestones
- Removed stale v1.10.0/v1.10.1 planned entries

**docs/architecture/solr-data-model.md:**
- Fixed embedding dimensions: 512 → 768 (after migration to `intfloat/multilingual-e5-base`)
- Fixed Solr field type: `knn_vector_512` → `knn_vector_768`
- Updated model name from `distiluse-base-multilingual-cased-v2` to `intfloat/multilingual-e5-base`

### Related
- Filed #1544 for solr-init inline heredoc bug (replicationFactor not capped to EXPECTED_NODES)
- See PR #1543 for the new semantic E2E tests