### PR TITLE
fix(solr-init): cap replicationFactor to EXPECTED_NODES (#1544)

### DIFF
--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -103,6 +103,8 @@
 
 <!-- Append learnings below this line -->
 
+- **2026-05-24 (#1544):** Inline Solr init replicationFactor handling in docker-compose.yml must mirror docker/solr-init.sh by clamping SOLR_REPLICATION_FACTOR to EXPECTED_NODES, not merely warning.
+
 ### Thumbnail Serving Bug (#1137, 2026-03-25)
 
 **Root cause (triple):** nginx alias pointed to `/data/documents/` instead of `/data/thumbnails/`, nginx container was missing the `thumbnail-data` volume mount, and the search API returned bare relative paths without the `/thumbnails/` prefix — causing the browser to hit the SPA catch-all.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -817,8 +817,9 @@ services:
             exit 1
           fi
 
-          if [ "$$REPLICATION_FACTOR" -gt 3 ]; then
-            echo "WARNING: SOLR_REPLICATION_FACTOR=$$REPLICATION_FACTOR exceeds the default 3-node topology. Ensure you have enough Solr nodes." >&2
+          if [ "$$REPLICATION_FACTOR" -gt "$$EXPECTED_NODES" ]; then
+            echo "WARNING: SOLR_REPLICATION_FACTOR=$$REPLICATION_FACTOR exceeds available nodes ($$EXPECTED_NODES). Forcing replicationFactor=$$EXPECTED_NODES." >&2
+            REPLICATION_FACTOR="$$EXPECTED_NODES"
           fi
 
           # --- books collection (multilingual-e5-base, 768D) ---


### PR DESCRIPTION
Closes #1544

Milestone: v2.2.0

Mirrors the existing safety in `docker/solr-init.sh` (lines 112-115) inside the inline heredoc entrypoint in `docker-compose.yml`. When `SOLR_REPLICATION_FACTOR` (e.g. stale .env value of 3) exceeds `EXPECTED_NODES` on the single-node overlay, the value is now clamped instead of merely warned, preventing the 0-active-replica RED state and the cascading add-conf-overlay 404.

### Verification
- `docker compose config -q` passes with required AUTH_JWT_SECRET/AUTH_DB_DIR env supplied
- `.squad/scripts/verify.sh` passes
- Manually: with single-node overlay + `SOLR_REPLICATION_FACTOR=3` env, collection CREATE no longer requests >1 replica.

— Parker