### PR TITLE
chore(squad): reskill retro — link batch-merge skills, bump e2e-auth-reuse

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -369,3 +369,19 @@ Batched 16 low/medium-risk Dependabot PRs into a single PR (#1584), merged to de
 - **Review threads from code scanning**: Each push triggers new code-scanning review threads that must be resolved before merge. The zizmor + CodeQL version comment issues were legitimate — the dependabot commit had stale inline version annotations.
 - **Strict mode + rulesets = must merge base**: When "require up to date" is in a ruleset, must `git merge origin/dev` into the branch and push before merging. Cannot bypass with --admin.
 - **Pre-existing test failures**: document-indexer has 4 failing metadata tests on dev — not caused by dependency bumps, predates this sweep.
+
+### Reskill Retrospective (2026-05-31, Consolidation Pass)
+
+**Status:** ✅ Complete
+
+Consolidated learnings from Ralph 3-round sweep (E2E 429 fix #1588, 4 Docker base bumps, 17-bump batch sweep PR #1608):
+
+1. **Skills:** Bumped `e2e-auth-reuse` from undocumented to **medium confidence** (successful CI validation + production code path in use). Cross-linked `dependabot-batch-merge` (low, tactical) ↔ `dependabot-batch-sweep` (high, strategic) to clarify scope. Warned in both skills about manifest-conflict gotcha that silently reverts bumps when using `--theirs`.
+
+2. **Agent Histories:** Verified that Parker, Lambert, and Brett all have "Local-Test-First Directive (2026-05-31, Round 2)" properly appended — Juanma's requirement that all squad agents test locally before pushing (using available docker + playwright) is now cross-documented.
+
+3. **Decisions:** No contradictions found in `.squad/decisions.md`. All three new items from this session ("Dependabot Batch Sweep 2026-05-31", "E2E Auth Token Reuse Pattern", "Always Test Locally Before Pushing") are clearly documented and non-overlapping.
+
+4. **Skills Created/Merged:** NO new skills created. The worktree batching pattern is already covered in `dependabot-batch-sweep`; local-test-first is a directive (not a skill), captured in decisions.md. Focused on quality over quantity — only 28 skills total, down from 38 in prior consolidation.
+
+5. **Key Pattern Captured:** The manifest-conflict gotcha (`git checkout --theirs` silently reverts prior bumps during multi-branch merges) is now flagged at skill level with explicit cross-reference. This pattern recurred in PR #1608 despite being documented in Parker's history — reinforces that escalating low-confidence patterns to skills + cross-linking prevents re-discovery.

--- a/.squad/skills/dependabot-batch-merge/SKILL.md
+++ b/.squad/skills/dependabot-batch-merge/SKILL.md
@@ -108,6 +108,7 @@ Run local verify: 1094 backend + 841 UI tests pass."
 
 ## Related Skills
 
+- `dependabot-batch-sweep` — The high-level strategy for batching multiple dependabot PRs. This skill focuses on tactical manifest-conflict handling during the merge phase of that workflow.
 - `git-workflows` — worktrees, 3-way merges, rebase strategies
 - `python-dependency-management` — uv lock regeneration, pyproject.toml semantics
 - `npm-dependency-management` — npm ci, package-lock.json regeneration

--- a/.squad/skills/dependabot-batch-sweep/SKILL.md
+++ b/.squad/skills/dependabot-batch-sweep/SKILL.md
@@ -82,3 +82,4 @@ Commit the regenerated lockfile separately with a clear message.
 - **Each push triggers new code-scanning review threads** — resolve all before merge attempt
 - **Pre-commit hooks run tests during cherry-pick --continue** — may modify lockfiles (reset with `git checkout --`)
 - **npm lockfiles auto-merge cleanly** more often than uv.lock; Python lockfiles almost always need regeneration
+- **⚠️ CRITICAL: `--ours`/`--theirs` on manifest files silently reverts earlier bumps** — See `.squad/skills/dependabot-batch-merge` for tactical conflict-resolution patterns. Never resolve conflicts on package.json / pyproject.toml with blanket `--theirs`; manually reconcile all distinct version specs instead.

--- a/.squad/skills/e2e-auth-reuse/SKILL.md
+++ b/.squad/skills/e2e-auth-reuse/SKILL.md
@@ -3,6 +3,18 @@
 ## Skill ID
 `e2e-auth-reuse`
 
+## Confidence
+**Medium** — Successfully implemented in PR #1588, validated in CI, and confirmed to resolve chronic rate-limit failures (#1583).
+
+## Last Confirmed
+2026-05-31 — PR #1588 merged, CI runs show `[setup] reusing E2E_API_TOKEN from environment (skipping login)` pattern working at scale (28 passed, 22 skipped, 0 failures in ci_e2e_tests workflow run 26717457605).
+
+## Evidence
+- **Issue #1583:** Chronic 429 rate-limit failures in E2E workflows (root cause: back-to-back `/v1/auth/login` calls from same IP)
+- **PR #1588:** Implementation of token-reuse pattern + single-retry defense-in-depth
+- **Files:** `e2e/playwright/global-setup.ts` (lines 71-142) — production code showing pattern in use
+- **CI Validation:** Multiple workflow runs passing with `E2E_API_TOKEN` env var present; fallback path (password login) tested locally and working when env var absent
+
 ## Context
 E2E tests in CI often need authenticated sessions. When the CI workflow mints an auth token (e.g., via curl), downstream test runners should consume that token via environment variable instead of re-authenticating. This avoids rate-limit races and speeds up test setup.
 
@@ -104,3 +116,7 @@ See `e2e/playwright/global-setup.ts` (lines 71-142) for the full implementation 
 
 ## Discovered
 2026-05-31 by Parker (Backend Dev) while fixing CI E2E failures
+
+## Related
+- Pattern complements `.squad/skills/playwright-e2e-aithena` (test infrastructure)
+- Enables "Always Test Locally Before Pushing" directive (`.squad/decisions.md`)


### PR DESCRIPTION
Ripley's reskill consolidation pass after Ralph's 3-round sweep on 2026-05-31.

## What changed
- **`.squad/skills/dependabot-batch-merge` ↔ `dependabot-batch-sweep`**: cross-linked with explicit scope notes; both now carry a ⚠️ warning about `git checkout --theirs` silently reverting prior bumps (the bug Copilot reviewer caught on PR #1608).
- **`.squad/skills/e2e-auth-reuse`**: bumped undocumented → medium confidence after PR #1588 validation (CI run 26717457605 logs the reuse path).
- **`.squad/agents/ripley/history.md`**: appended consolidation paragraph under Learnings.

## What was skipped (deliberately)
- No new skills created — worktree batching, GraphQL thread resolution, and local-test-first directive are already captured in existing skills or decisions.
- No agent history edits (verified Parker/Lambert/Brett already have the local-test directive).
- No decisions consolidation file — three new entries are non-overlapping.

Closes the implicit 'reskill' request from Juanma ('team, take a nap and reskill').

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>