### PR TITLE
fix(docker): convert redis/rabbitmq to docker-managed volumes (#1578 phase 1a)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -844,18 +844,8 @@ volumes:
   thumbnail-data:
 
   rabbitmq-data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/rabbitmq-data"
 
   redis-data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/redis"
   document-data:
     driver: local
     driver_opts:


### PR DESCRIPTION
## Summary

Converts Redis and RabbitMQ volumes from bind mounts to Docker-managed named volumes as part of Phase 1a of #1578 (installer wizard).

## Context

This PR implements the smallest, lowest-risk volume conversion step to validate the clean-install approach approved by @jmservera on 2026-05-31. Phase 1a removes hard-coded `/source/volumes/` paths for Redis and RabbitMQ internal state, making the stack more portable and aligning with Docker best practices.

**Design decision reference (Section 3):**
- **Decision #3**: No migration path — v2.2.0 requires a clean install
- **Decision #4**: Volume conversion is not treated as a breaking migration due to clean-install policy

## Changes

- **redis-data**: removed bind mount to `/source/volumes/redis` → now Docker-managed
- **rabbitmq-data**: removed bind mount to `/source/volumes/rabbitmq-data` → now Docker-managed

Both volumes are now declared as simple named volumes. Docker will create and manage them automatically when the stack starts.

## Migration Impact

⚠️ Per the approved design decision #3, v2.2.0 requires a **fresh installation**. 

Existing deployments with data in `/source/volumes/redis` or `/source/volumes/rabbitmq-data` must back up that data manually before upgrading if they wish to preserve it. This clean-install policy eliminates the need for automated migration scripts.

## Validation

- ✅ `docker compose config` validates cleanly
- ✅ `.squad/scripts/verify.sh` passes (no service code changes detected)
- ✅ Pre-commit checks passed

## Next Steps

Phase 1b will convert the remaining volumes (ZooKeeper, Solr, SSL certbot paths) in a subsequent PR.

## References

- Issue: #1578
- Design doc: `.squad/decisions/inbox/parker-1578-installer-wizard-design.md` (Section 3)
- Quick summary: `installer/DESIGN-1578.md`

Closes #1578 (partial - Phase 1a only)
Working as Parker (Backend Dev)