### PR TITLE
fix(docker): complete Phase 1a prod overlay volume migration

### DIFF
--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -749,18 +749,8 @@ volumes:
   thumbnail-data:
 
   rabbitmq-data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/rabbitmq-data"
 
   redis-data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/redis"
   document-data:
     driver: local
     driver_opts:


### PR DESCRIPTION
## Summary
Completes Phase 1a volume migration by removing driver_opts blocks from `rabbitmq-data` and `redis-data` volumes in the production overlay configuration.

## Context
PR #1612 converted Redis and RabbitMQ to Docker-managed volumes in the base `docker-compose.yml`, but `docker/compose.prod.yml` still had the old bind mount driver_opts blocks. When the prod overlay is used, these override the base declarations, breaking the volume migration in production.

## Changes
- Removed `driver_opts` blocks from `rabbitmq-data` volume in `docker/compose.prod.yml`
- Removed `driver_opts` blocks from `redis-data` volume in `docker/compose.prod.yml`
- Both volumes now use simple declarations to match base file format

## Testing
- ✅ YAML syntax validation passed
- ✅ Pre-commit hooks passed
- ✅ No service code changes (config-only)

## Related
Closes #1613
Related to PR #1612 (Phase 1a base volume migration)
Milestone: v2.2.0

Working as Parker (Backend Dev)