### PR TITLE
fix(docker): Complete Phase 1c volume migration for compose.prod.yml

### DIFF
--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -752,94 +752,19 @@ volumes:
 
   redis-data:
   document-data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "${BOOKS_PATH:-/data/booklibrary}"
   collections-db:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "${COLLECTIONS_DB_DIR:-/source/volumes/collections-db}"
   solr-data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/solr-data"
   solr-data2:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/solr-data2"
   solr-data3:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/solr-data3"
   zoo-data1_logs:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data1/logs"
   zoo-data1_data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data1/data"
   zoo-data1_datalog:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data1/datalog"
   zoo-data2_logs:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data2/logs"
   zoo-data2_data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data2/data"
   zoo-data2_datalog:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data2/datalog"
   zoo-data3_logs:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data3/logs"
   zoo-data3_data:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data3/data"
   zoo-data3_datalog:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-data3/datalog"
   zoo-backup:
-    driver: local
-    driver_opts:
-      type: "none"
-      o: "bind"
-      device: "/source/volumes/zoo-backup"
 networks:
   default:

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -5028,24 +5028,81 @@ v2.0.0 publishes **5 container images** (down from 6 in v1.x):
 
 v2.2.0 is a **maintenance release** with no breaking changes. Key changes affecting operators:
 
-1. **Prod overlay volume migration complete (#1613)** — `docker/compose.prod.yml` now uses Docker-managed volumes for `rabbitmq-data` and `redis-data`, matching the base compose file.
+1. **Prod overlay volume migration complete (Phase 1c, #1616)** — `docker/compose.prod.yml` now uses Docker-managed volumes for all infrastructure volumes (document-data, collections-db, solr-data*, zoo-data*, zoo-backup), completing the migration started in PR #1612 (Redis/RabbitMQ) and PR #1614 (Solr/ZooKeeper).
 2. **Solr-init replication factor cap (#1544)** — Single-node deployments with a stale `SOLR_REPLICATION_FACTOR` value higher than 1 will no longer produce a RED collection on startup.
 3. **Wizard-style containerized installer (#1578)** — New two-command install path for first-time deployments. Existing deployments are unaffected; re-running the installer is optional.
 
 **Breaking Changes:** None.
 
-### Prod Overlay Volume Config
+### Prod Overlay Volume Config (Phase 1c Complete)
 
-If you use `docker/compose.prod.yml`, pull the updated file as part of your upgrade. The `rabbitmq-data` and `redis-data` volume declarations no longer carry `driver_opts` bind-mount stubs. After updating:
+**Phase 1c** (issue #1616): `docker/compose.prod.yml` now uses Docker-managed volumes for **all** infrastructure volumes, completing the migration started in PR #1612 (Redis/RabbitMQ) and PR #1614 (Solr/ZooKeeper/SSL):
 
-```bash
-# Validate the merged config
-docker compose -f docker-compose.yml -f docker/compose.prod.yml config | grep -A5 -B2 "rabbitmq-data\|redis-data"
-```
+- **document-data** (previously bound to `${BOOKS_PATH:-/data/booklibrary}`)
+- **collections-db** (previously bound to `${COLLECTIONS_DB_DIR:-/source/volumes/collections-db}`)
+- **solr-data, solr-data2, solr-data3** (previously bound to `/source/volumes/solr-data*`)
+- **zoo-data{1,2,3}_{logs,data,datalog}** (previously bound to `/source/volumes/zoo-data*/`)
+- **zoo-backup** (previously bound to `/source/volumes/zoo-backup`)
 
-Expected output: volume declarations with no `driver: local` + `driver_opts` block for those two volumes.
+All volumes are now declared as simple named volumes. Docker will create and manage them automatically when the stack starts.
 
-> **Note:** This only affects the prod overlay. The base `docker-compose.yml` was already correct.
+**If you use `docker/compose.prod.yml`:**
+
+1. Pull the updated compose file:
+   ```bash
+   git pull origin main
+   ```
+
+2. Validate the merged config:
+   ```bash
+   docker compose -f docker-compose.yml -f docker/compose.prod.yml config | grep -A2 "document-data:"
+   ```
+   
+   Expected output: `document-data:` with no `driver_opts` block.
+
+**Migration for existing deployments:**
+
+⚠️ **Important:** This change affects data persistence. If you have existing data in bind-mounted directories (e.g., `/data/booklibrary`, `/source/volumes/*`), you must migrate it manually:
+
+**Option A: Preserve existing data (recommended for production)**
+
+1. Back up your data before upgrading:
+   ```bash
+   # Example: back up document library
+   sudo tar czf ~/document-data-backup-$(date +%Y%m%d).tar.gz /data/booklibrary
+   
+   # Back up Solr indexes
+   sudo tar czf ~/solr-data-backup-$(date +%Y%m%d).tar.gz /source/volumes/solr-data*
+   
+   # Back up ZooKeeper data
+   sudo tar czf ~/zoo-data-backup-$(date +%Y%m%d).tar.gz /source/volumes/zoo-data*
+   ```
+
+2. After upgrading and starting the stack with the new compose files, Docker will create empty volumes. Stop the services and restore data:
+   ```bash
+   docker compose down
+   
+   # Find the volume mount point
+   docker volume inspect aithena_document-data | jq -r '.[0].Mountpoint'
+   # Example output: /var/lib/docker/volumes/aithena_document-data/_data
+   
+   # Copy your data to the Docker volume
+   sudo rsync -av /data/booklibrary/ $(docker volume inspect aithena_document-data -f '{{.Mountpoint}}')
+   sudo rsync -av /source/volumes/solr-data/ $(docker volume inspect aithena_solr-data -f '{{.Mountpoint}}')
+   # Repeat for other volumes as needed
+   
+   docker compose up -d
+   ```
+
+**Option B: Fresh install (acceptable for dev/test environments)**
+
+Simply pull the new compose file and start the stack. All volumes will be created empty. You can then upload documents through the admin UI or place them in the Docker volume location.
+
+**Clean install on a fresh system:**
+
+No action required. Docker will automatically create all volumes when you start the stack for the first time.
+
+> **Note:** The base `docker-compose.yml` already uses Docker-managed volumes for `document-data`. This change only affects the `docker/compose.prod.yml` overlay which previously overrode it with a bind mount.
 
 ### Single-Node Solr Deployments
 

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -2,7 +2,7 @@
 
 This manual covers deployment, configuration, monitoring, and troubleshooting for Aithena. If you are looking for end-user instructions, start with the [User Manual](user-manual.md). For the latest release features, see the [latest changelog](../CHANGELOG.md).
 
-**v1.15.0 / v1.16.0 / v1.17.0 / v1.18.0 / v1.19.0 / v2.0.0 / v2.2.0 operator note:** v1.15.0 includes admin portal enhancements (sidebar navigation, per-service log viewer, Solr SSO passthrough), critical bug fixes (document indexer OOM on large PDFs, thumbnail write failures), build-time dependency installation, and volume permission hardening. v1.16.0 adds search UI bug fixes, similar-books endpoint fix, admin dashboard pagination, nginx thumbnail routing fix, RabbitMQ deprecation warning fix, CI smoke test timeout fix, and a new pre-release container workflow. v1.17.0 introduces GPU acceleration for embeddings (opt-in via environment variables), security dependency updates (`requests`, `picomatch`), and comprehensive GPU documentation. v1.18.0 adds folder path facets for hierarchical search filtering, a comprehensive backup and disaster recovery system, stress-testing infrastructure, PDF embedded viewer fix, collections UI consistency fix, and CI/CD hardening. v1.18.1 patches the Solr auth role assignment to align with Solr 9.7 defaults and fixes the installer when run from the repo root. v1.19.0 adds configurable Solr topology (shards and replication factor), suppresses deprecation warnings from Solr 9.7 Security Manager and RabbitMQ 4.x, and includes 38+ dependency updates. **v2.0.0 is a major release:** replaces the Streamlit admin dashboard with a React SPA at `/admin/`, removes the `aithena-admin` container image, adds admin REST API endpoints, overhauled installer with GPU auto-detection and SSL, Solr 9/10 compatibility layer, and 119 integration tests + 38 accessibility tests. **v2.2.0** completes the Docker-managed volume migration for the prod overlay, fixes the Solr-init replication factor cap on single-node deployments, resolves a chronic CI E2E 429 rate-limit failure, fixes a CodeQL security alert in the installer, and ships a wizard-style containerized installer enabling zero-dependency setup. See the [v1.15.0 Deployment Updates](#deployment-updates-for-v1150), [v1.16.0 Deployment Updates](#deployment-updates-for-v1160), [v1.17.0 Deployment Updates](#deployment-updates-for-v1170), [v1.18.0 Deployment Updates](#deployment-updates-for-v1180), [v1.18.1 Deployment Updates](#deployment-updates-for-v1181), [v1.19.0 Deployment Updates](#deployment-updates-for-v1190), [v2.0.0 Deployment Updates](#deployment-updates-for-v200), and [v2.2.0 Deployment Updates](#deployment-updates-for-v220) sections below.
+**v1.15.0 / v1.16.0 / v1.17.0 / v1.18.0 / v1.19.0 / v2.0.0 / v2.2.0 operator note:** v1.15.0 includes admin portal enhancements (sidebar navigation, per-service log viewer, Solr SSO passthrough), critical bug fixes (document indexer OOM on large PDFs, thumbnail write failures), build-time dependency installation, and volume permission hardening. v1.16.0 adds search UI bug fixes, similar-books endpoint fix, admin dashboard pagination, nginx thumbnail routing fix, RabbitMQ deprecation warning fix, CI smoke test timeout fix, and a new pre-release container workflow. v1.17.0 introduces GPU acceleration for embeddings (opt-in via environment variables), security dependency updates (`requests`, `picomatch`), and comprehensive GPU documentation. v1.18.0 adds folder path facets for hierarchical search filtering, a comprehensive backup and disaster recovery system, stress-testing infrastructure, PDF embedded viewer fix, collections UI consistency fix, and CI/CD hardening. v1.18.1 patches the Solr auth role assignment to align with Solr 9.7 defaults and fixes the installer when run from the repo root. v1.19.0 adds configurable Solr topology (shards and replication factor), suppresses deprecation warnings from Solr 9.7 Security Manager and RabbitMQ 4.x, and includes 38+ dependency updates. **v2.0.0 is a major release:** replaces the Streamlit admin dashboard with a React SPA at `/admin/`, removes the `aithena-admin` container image, adds admin REST API endpoints, overhauled installer with GPU auto-detection and SSL, Solr 9/10 compatibility layer, and 119 integration tests + 38 accessibility tests. **v2.2.0** completes the prod-overlay volume migration work, fixes the Solr-init replication factor cap on single-node deployments, resolves a chronic CI E2E 429 rate-limit failure, and fixes a CodeQL security alert in the installer. See the [v1.15.0 Deployment Updates](#deployment-updates-for-v1150), [v1.16.0 Deployment Updates](#deployment-updates-for-v1160), [v1.17.0 Deployment Updates](#deployment-updates-for-v1170), [v1.18.0 Deployment Updates](#deployment-updates-for-v1180), [v1.18.1 Deployment Updates](#deployment-updates-for-v1181), [v1.19.0 Deployment Updates](#deployment-updates-for-v1190), [v2.0.0 Deployment Updates](#deployment-updates-for-v200), and [v2.2.0 Deployment Updates](#deployment-updates-for-v220) sections below.
 
 ## System architecture overview
 
@@ -5026,25 +5026,17 @@ v2.0.0 publishes **5 container images** (down from 6 in v1.x):
 
 ### Summary
 
-v2.2.0 is a **maintenance release** with no breaking changes. Key changes affecting operators:
+v2.2.0 is a **maintenance release** with volume-migration guidance for operators. Key changes affecting operators:
 
-1. **Prod overlay volume migration complete (Phase 1c, #1616)** — `docker/compose.prod.yml` now uses Docker-managed volumes for all infrastructure volumes (document-data, collections-db, solr-data*, zoo-data*, zoo-backup), completing the migration started in PR #1612 (Redis/RabbitMQ) and PR #1614 (Solr/ZooKeeper).
+1. **Prod overlay volume migration (Phase 1c, #1616)** — `docker/compose.prod.yml` is updated to use Docker-managed volumes for the remaining prod-overlay storage paths, and the release notes now reflect that migration work.
 2. **Solr-init replication factor cap (#1544)** — Single-node deployments with a stale `SOLR_REPLICATION_FACTOR` value higher than 1 will no longer produce a RED collection on startup.
-3. **Wizard-style containerized installer (#1578)** — New two-command install path for first-time deployments. Existing deployments are unaffected; re-running the installer is optional.
+3. **Existing installer path remains the current one** — This release does not add a new remote bootstrap script; continue using the repo's current installer flow (`python3 -m installer` / `python3 installer/setup.py`).
 
-**Breaking Changes:** None.
+**Breaking Changes:** Existing prod-overlay deployments that rely on bind-mounted storage should expect a manual migration step if they want to preserve data. Do not assume existing bind-mounted state is carried forward automatically.
 
-### Prod Overlay Volume Config (Phase 1c Complete)
+### Prod Overlay Volume Config (Phase 1c)
 
-**Phase 1c** (issue #1616): `docker/compose.prod.yml` now uses Docker-managed volumes for **all** infrastructure volumes, completing the migration started in PR #1612 (Redis/RabbitMQ) and PR #1614 (Solr/ZooKeeper/SSL):
-
-- **document-data** (previously bound to `${BOOKS_PATH:-/data/booklibrary}`)
-- **collections-db** (previously bound to `${COLLECTIONS_DB_DIR:-/source/volumes/collections-db}`)
-- **solr-data, solr-data2, solr-data3** (previously bound to `/source/volumes/solr-data*`)
-- **zoo-data{1,2,3}_{logs,data,datalog}** (previously bound to `/source/volumes/zoo-data*/`)
-- **zoo-backup** (previously bound to `/source/volumes/zoo-backup`)
-
-All volumes are now declared as simple named volumes. Docker will create and manage them automatically when the stack starts.
+**Phase 1c** (issue #1616) updates the prod overlay volume declarations to match the current repo state. Review the overlay before upgrading, because the release notes are intentionally conservative: existing bind-mounted state is not automatically carried into Docker-managed volumes.
 
 **If you use `docker/compose.prod.yml`:**
 
@@ -5053,16 +5045,16 @@ All volumes are now declared as simple named volumes. Docker will create and man
    git pull origin main
    ```
 
-2. Validate the merged config:
+2. Validate the merged config and confirm the storage backing you want to keep:
    ```bash
-   docker compose -f docker-compose.yml -f docker/compose.prod.yml config | grep -A2 "document-data:"
+   docker compose -f docker-compose.yml -f docker/compose.prod.yml config | grep -A3 -E 'document-data:|rabbitmq-data:|redis-data:'
    ```
-   
-   Expected output: `document-data:` with no `driver_opts` block.
+
+3. If you want to preserve existing data, back it up before restarting the stack.
 
 **Migration for existing deployments:**
 
-⚠️ **Important:** This change affects data persistence. If you have existing data in bind-mounted directories (e.g., `/data/booklibrary`, `/source/volumes/*`), you must migrate it manually:
+⚠️ **Important:** Existing deployments that rely on bind-mounted directories (for example `/data/booklibrary` or `/source/volumes/*`) must migrate data manually if you want to keep it. The overlay change does not rewrite or copy old bind-mounted data for you.
 
 **Option A: Preserve existing data (recommended for production)**
 
@@ -5070,29 +5062,15 @@ All volumes are now declared as simple named volumes. Docker will create and man
    ```bash
    # Example: back up document library
    sudo tar czf ~/document-data-backup-$(date +%Y%m%d).tar.gz /data/booklibrary
-   
+
    # Back up Solr indexes
    sudo tar czf ~/solr-data-backup-$(date +%Y%m%d).tar.gz /source/volumes/solr-data*
-   
+
    # Back up ZooKeeper data
    sudo tar czf ~/zoo-data-backup-$(date +%Y%m%d).tar.gz /source/volumes/zoo-data*
    ```
 
-2. After upgrading and starting the stack with the new compose files, Docker will create empty volumes. Stop the services and restore data:
-   ```bash
-   docker compose down
-   
-   # Find the volume mount point
-   docker volume inspect aithena_document-data | jq -r '.[0].Mountpoint'
-   # Example output: /var/lib/docker/volumes/aithena_document-data/_data
-   
-   # Copy your data to the Docker volume
-   sudo rsync -av /data/booklibrary/ $(docker volume inspect aithena_document-data -f '{{.Mountpoint}}')
-   sudo rsync -av /source/volumes/solr-data/ $(docker volume inspect aithena_solr-data -f '{{.Mountpoint}}')
-   # Repeat for other volumes as needed
-   
-   docker compose up -d
-   ```
+2. Upgrade to the new compose file, then restore your backups into the Docker-managed volumes you choose to keep. The compose change does not move old bind-mounted data for you, so the restore step must be done explicitly.
 
 **Option B: Fresh install (acceptable for dev/test environments)**
 
@@ -5108,35 +5086,17 @@ No action required. Docker will automatically create all volumes when you start 
 
 The `solr-init` inline entrypoint in `docker-compose.yml` now caps `SOLR_REPLICATION_FACTOR` to `SOLR_EXPECTED_NODES`, matching the existing safety logic in `docker/solr-init.sh`. No operator action is required. If you previously worked around the bug by manually setting `SOLR_REPLICATION_FACTOR=1` in your `.env`, you may leave that value — the cap will simply be a no-op.
 
-### Containerized Installer (New Deployments)
+### Installer Path (Current Repo State)
 
-v2.2.0 ships a wizard-style installer that works on hosts with only Docker installed:
+Use the existing installer flow documented in this repository:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jmservera/aithena/main/install.sh | bash
-./aithena/start.sh
+python3 -m installer
+# or
+python3 installer/setup.py
 ```
 
-The installer:
-- Detects Python 3.12 + uv and runs natively if present; otherwise falls back to a Docker container (`ghcr.io/jmservera/aithena-installer:latest`)
-- Runs pre-flight checks (Docker daemon, disk space ≥ 20GB, internet, docker group)
-- Guides through ≤6 prompts: library path, admin credentials, GPU acceleration, SSL, topology, public origin
-- Generates `.env`, auth database, and `start.sh`
-- Optionally pulls images and starts the stack
-- Runs a post-install health check
-
-**Existing deployments:** No need to re-run the installer unless you want to regenerate `start.sh` or switch topology. All existing manual `docker compose` workflows remain valid.
-
-**Configuration options available during install:**
-
-| Option | Prompt | Default |
-|---|---|---|
-| Library path | Where should we look for PDF books? | `~/aithena-library` |
-| Admin credentials | Username / password | `admin` / (prompted) |
-| GPU acceleration | NVIDIA / Intel / none | Auto-detected |
-| SSL | Enable HTTPS with Let's Encrypt? | No |
-| Topology | single-node / distributed | single-node |
-| Public origin | URL users access from | `http://localhost` |
+The current installer path generates `.env`, auth storage, and `start.sh` for the existing Compose stack. Existing deployments can keep using the current manual `docker compose` workflow; re-running the installer is only needed when you want to regenerate runtime files or rotate credentials.
 
 ### Upgrade Instructions
 
@@ -5186,13 +5146,12 @@ Follow the [v2.0.0 deployment notes](#deployment-updates-for-v200) first, then a
 
 ### Container Image Changes
 
-v2.2.0 publishes **5 container images** (unchanged from v2.0.0) plus a new installer image:
+v2.2.0 publishes the existing service images used by the Compose stack:
 
-| Image | Change |
+| Image | Status |
 |---|---|
-| `ghcr.io/jmservera/aithena-aithena-ui:2.2.0` | No change |
-| `ghcr.io/jmservera/aithena-document-indexer:2.2.0` | No change |
-| `ghcr.io/jmservera/aithena-document-lister:2.2.0` | No change |
-| `ghcr.io/jmservera/aithena-embeddings-server:2.2.0` | No change |
-| `ghcr.io/jmservera/aithena-solr-search:2.2.0` | No change |
-| `ghcr.io/jmservera/aithena-installer:latest` | **New** — containerized installer image |
+| `ghcr.io/jmservera/aithena-aithena-ui:2.2.0` | Existing |
+| `ghcr.io/jmservera/aithena-document-indexer:2.2.0` | Existing |
+| `ghcr.io/jmservera/aithena-document-lister:2.2.0` | Existing |
+| `ghcr.io/jmservera/aithena-embeddings-server:2.2.0` | Existing |
+| `ghcr.io/jmservera/aithena-solr-search:2.2.0` | Existing |

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -1,37 +1,33 @@
-# Aithena v2.2.0 Release Notes — Maintenance & Installer Improvements
+# Aithena v2.2.0 Release Notes — Volume Migration & Test Reliability
 
 _Date:_ 2026-06-01
-_Prepared by:_ Newt (Product Manager)
+_Prepared by:_ Docs (Technical Writer)
 
 ## Summary
 
-Aithena v2.2.0 is a **focused maintenance and installer improvement release** with no breaking changes. This release completes the prod overlay volume migration, fixes a chronic CI failure, improves deployment robustness with a wizard-style containerized installer, and addresses infrastructure and security issues.
+Aithena v2.2.0 is a maintenance release focused on protecting production deployments during the prod-overlay volume migration and improving test reliability. The release does not add a new remote bootstrap script; it updates the existing deployment documentation and compose path to reflect the current repo state.
 
 ### Highlights
 
-1. **Wizard-style containerized installer (#1578)** — New two-command install path for first-time deployments. Guides through ≤6 prompts (library path, admin credentials, GPU acceleration, SSL, topology, public origin). Detects Python 3.12 + uv; falls back to Docker container.
-2. **Prod overlay volume migration complete (#1613)** — Completes Phase 1a by removing lingering bind-mount `driver_opts` from `docker/compose.prod.yml`, ensuring Docker-managed volumes work as intended.
-3. **Solr-init replication factor safety cap (#1544)** — Single-node deployments with stale `SOLR_REPLICATION_FACTOR` values will no longer produce RED collection health on startup.
-4. **Eliminated chronic E2E CI failures (#1583)** — Fixed Playwright global-setup rate-limit (429) failures that required 1–3 reruns on every PR merge.
-5. **Security fix: Clear-text credential logging (#1576)** — Fixed CodeQL alert #233 in installer. Sensitive data is no longer logged in plain text.
-6. **Squad assignment restored (#1574)** — Replaced expired `COPILOT_ASSIGN_TOKEN` PAT. Issue auto-assignment to Copilot agent fully restored.
+1. **Prod overlay volume migration (Phase 1c, #1616)** — Completes the remaining prod-overlay volume migration work in `docker/compose.prod.yml` and updates deployment guidance for operators.
+2. **Solr-init replication factor safety cap (#1544)** — Single-node deployments with stale `SOLR_REPLICATION_FACTOR` values will no longer produce RED collection health on startup.
+3. **E2E reliability improvements (#1583)** — Reduces the chronic Playwright 429/rate-limit failure pattern that forced repeated CI reruns.
+4. **Test robustness (#1617)** — Real-library tests now skip cleanly when local fixtures are unavailable, which keeps CI and developer environments stable.
 
 ---
 
 ## Notable Changes
 
-- **#1578** — `feat(installer): Wizard-style containerized installer for zero-dependency setup` — Bootstrap script and containerized setup guide for new deployments.
-- **#1613** — `fix(docker): Complete Phase 1a: Update prod overlay volume configs` — Removes lingering `driver_opts` from prod overlay volumes.
+- **#1616** — `fix(docker): Complete Phase 1c volume migration for compose.prod.yml` — Completes remaining prod-overlay volume migration work.
 - **#1544** — `fix(solr-init): Cap replication factor to node count` — Prevents RED collection health on single-node deployments.
 - **#1583** — `fix(ci): Eliminate Playwright 429 rate-limit failures` — Resolves chronic E2E CI failures.
-- **#1576** — `fix(security): Clear-text logging of sensitive data in installer` — GHAS CodeQL alert #233 fixed.
-- **#1574** — `chore(ci): Refresh expired COPILOT_ASSIGN_TOKEN` — Restores Copilot issue auto-assignment.
+- **#1617** — `test(document-indexer): Skip real-library tests when fixtures are missing` — Keeps CI and local runs stable when sample fixtures are unavailable.
 
 ---
 
 ## Breaking Changes
 
-**None.** v2.2.0 is fully backward compatible with v2.0.0 and v2.1.0. No data migration or breaking configuration changes are required.
+Existing prod-overlay deployments that rely on bind-backed storage should review the volume migration steps before restarting the stack. The release does not automatically migrate existing bind-mounted data to Docker-managed volumes, so operators should back up any state they want to preserve.
 
 ---
 
@@ -44,34 +40,24 @@ Aithena v2.2.0 is a **focused maintenance and installer improvement release** wi
    docker compose pull
    ```
 
-2. **Restart the stack:**
+2. **Update the prod overlay and review volume backing:**
+   ```bash
+   git pull origin main
+   # or update docker/compose.prod.yml to match the current prod-overlay volume definitions
+   ```
+
+3. **Restart the stack:**
    ```bash
    docker compose up -d
    ```
 
-3. **Verify services:**
+4. **Verify services:**
    ```bash
    curl -sf http://localhost/v1/health && echo "✅ API healthy"
    curl -sf http://localhost/admin && echo "✅ Admin portal accessible"
    ```
 
-**No data migration required.** All databases and Solr collections are compatible with v2.2.0.
-
-### For New Deployments
-
-Use the new **containerized installer** for a guided setup (no prerequisites other than Docker):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jmservera/aithena/main/install.sh | bash
-./aithena/start.sh
-```
-
-Or use the traditional Python-based installer:
-
-```bash
-python3 -m installer
-./start.sh
-```
+If you are preserving existing bind-mounted data, back it up first. The release does not automatically migrate existing bind-mounted directories to Docker-managed volumes.
 
 ---
 
@@ -136,12 +122,10 @@ npx playwright test --headed
 
 ## Closed Issues & References
 
-- **#1578** — feat(installer): Wizard-style containerized installer for zero-dependency setup
-- **#1613** — fix(docker): Complete Phase 1a: Update prod overlay volume configs
+- **#1616** — fix(docker): Complete Phase 1c volume migration for compose.prod.yml
 - **#1544** — fix(solr-init): Cap replication factor to node count
 - **#1583** — fix(ci): Eliminate Playwright 429 rate-limit failures in E2E
-- **#1576** — fix(security): Clear-text logging of sensitive data in installer (GHAS CodeQL #233)
-- **#1574** — chore(ci): Refresh expired COPILOT_ASSIGN_TOKEN
+- **#1617** — test(document-indexer): Skip real-library tests when fixtures are missing
 
 ---
 

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -1,202 +1,147 @@
-# Aithena v2.2.0 Release Notes — Docker-Managed Volumes and Test Suite Fixes
+# Aithena v2.2.0 Release Notes — Maintenance & Installer Improvements
 
 _Date:_ 2026-06-01
-_Prepared by:_ Docs (Technical Writer)
+_Prepared by:_ Newt (Product Manager)
 
 ## Summary
 
-Aithena v2.2.0 is a **maintenance release** focused on infrastructure modernization and testing robustness. This release converts all internal infrastructure volumes (Solr, ZooKeeper, collections database, and SSL certificates) from bind mounts to Docker-managed volumes, eliminating hardcoded `/source/volumes/` paths and enabling cleaner deployment paths. Additionally, test fixtures are now resilient to missing sample data, improving reliability on development and CI environments.
+Aithena v2.2.0 is a **focused maintenance and installer improvement release** with no breaking changes. This release completes the prod overlay volume migration, fixes a chronic CI failure, improves deployment robustness with a wizard-style containerized installer, and addresses infrastructure and security issues.
 
 ### Highlights
 
-1. **Docker-managed volumes** — All infrastructure state now uses Docker-managed volumes instead of host bind mounts. User data (documents library) remains a bind mount for explicit control.
-2. **Cleaner installation paths** — Removed hardcoded `/source/volumes/` directory creation and maintenance from the installer, simplifying setup and reducing deployment surface area.
-3. **Test robustness** — Real-library tests now gracefully skip when sample fixtures are unavailable, eliminating false negatives on non-maintainer machines.
-4. **Volume credentials in `.env.example`** — Solr admin and read-only credentials are now fully documented in the example environment file.
+1. **Wizard-style containerized installer (#1578)** — New two-command install path for first-time deployments. Guides through ≤6 prompts (library path, admin credentials, GPU acceleration, SSL, topology, public origin). Detects Python 3.12 + uv; falls back to Docker container.
+2. **Prod overlay volume migration complete (#1613)** — Completes Phase 1a by removing lingering bind-mount `driver_opts` from `docker/compose.prod.yml`, ensuring Docker-managed volumes work as intended.
+3. **Solr-init replication factor safety cap (#1544)** — Single-node deployments with stale `SOLR_REPLICATION_FACTOR` values will no longer produce RED collection health on startup.
+4. **Eliminated chronic E2E CI failures (#1583)** — Fixed Playwright global-setup rate-limit (429) failures that required 1–3 reruns on every PR merge.
+5. **Security fix: Clear-text credential logging (#1576)** — Fixed CodeQL alert #233 in installer. Sensitive data is no longer logged in plain text.
+6. **Squad assignment restored (#1574)** — Replaced expired `COPILOT_ASSIGN_TOKEN` PAT. Issue auto-assignment to Copilot agent fully restored.
 
 ---
 
 ## Notable Changes
 
-- **#1614** — `fix(docker): convert solr/zookeeper/certbot to docker-managed volumes` — Phase 1b of the installer wizard volume migration, converting infrastructure volumes to Docker-managed for simpler deployment and lifecycle management.
-- **#1617** — `test(document-indexer): skip real-library tests when fixtures missing` — Ensures test suite runs cleanly on development machines lacking sample document fixtures.
+- **#1578** — `feat(installer): Wizard-style containerized installer for zero-dependency setup` — Bootstrap script and containerized setup guide for new deployments.
+- **#1613** — `fix(docker): Complete Phase 1a: Update prod overlay volume configs` — Removes lingering `driver_opts` from prod overlay volumes.
+- **#1544** — `fix(solr-init): Cap replication factor to node count` — Prevents RED collection health on single-node deployments.
+- **#1583** — `fix(ci): Eliminate Playwright 429 rate-limit failures` — Resolves chronic E2E CI failures.
+- **#1576** — `fix(security): Clear-text logging of sensitive data in installer` — GHAS CodeQL alert #233 fixed.
+- **#1574** — `chore(ci): Refresh expired COPILOT_ASSIGN_TOKEN` — Restores Copilot issue auto-assignment.
 
 ---
 
 ## Breaking Changes
 
-### Docker-Managed Volume Migration (⚠️ Clean Install Required)
+**None.** v2.2.0 is fully backward compatible with v2.0.0 and v2.1.0. No data migration or breaking configuration changes are required.
 
-**Impact:** This release requires a clean installation. Existing deployments with data in `/source/volumes/` must migrate manually.
+---
 
-**Reason:** The volume migration from bind mounts to Docker-managed volumes is a structural change that affects how Solr, ZooKeeper, the collections database, and SSL certificates are stored. Docker-managed volumes provide cleaner lifecycle management and reduce platform-specific path issues.
+## Upgrade Instructions
 
-**Migration Steps:**
+### For Users Upgrading from v2.0.0 or v2.1.0
 
-1. **Back up existing data** (if upgrading from v2.1.0):
+1. **Pull the latest images:**
    ```bash
-   # Export Solr collections
-   docker compose exec solr solr export-collection -collection books \
-     -out /tmp/books-backup.json
-   
-   # Backup Redis (if needed)
-   docker compose exec redis redis-cli --rdb /tmp/redis-backup.rdb
-   
-   # Backup ZooKeeper state
-   docker cp zookeeper:/var/lib/zookeeper /tmp/zk-backup
+   docker compose pull
    ```
 
-2. **Stop the current stack:**
-   ```bash
-   docker compose down
-   ```
-
-3. **Remove old bind-mount volumes** (optional but recommended for clean state):
-   ```bash
-   # WARNING: This deletes local state. Only run if backup above is complete.
-   rm -rf /source/volumes/solr-data* /source/volumes/zoo-data* \
-          /source/volumes/collections-db /source/volumes/certbot-data
-   ```
-
-4. **Re-run the installer:**
-   ```bash
-   python3 installer/setup.py --version 2.2.0
-   ```
-   This regenerates `.env`, `start.sh`, and creates new Docker-managed volumes.
-
-5. **Start the stack:**
+2. **Restart the stack:**
    ```bash
    docker compose up -d
    ```
 
-6. **Restore data** (if applicable):
+3. **Verify services:**
    ```bash
-   # Restore Solr collections
-   docker compose exec solr solr import-collection -collection books \
-     -in /tmp/books-backup.json
-   
-   # Verify services are healthy
    curl -sf http://localhost/v1/health && echo "✅ API healthy"
    curl -sf http://localhost/admin && echo "✅ Admin portal accessible"
    ```
 
-### Breaking Changes Detail
+**No data migration required.** All databases and Solr collections are compatible with v2.2.0.
 
-- **`/source/volumes/` paths are no longer created by the installer.** If your deployment scripts or manual configurations reference `/source/volumes/`, update them to use `docker volume ls | grep aithena` to inspect Docker-managed volumes instead.
-- **SSL certificate bootstrap logic updated.** The `start.sh` template no longer checks for `/source/volumes/certbot-data/` on the host filesystem. Existing SSL certificates must be migrated to the new Docker-managed `certbot-data-conf` and `certbot-data-www` volumes.
-- **User data (documents library) binding unchanged.** The `document-data` volume (mapped to `BOOKS_PATH`) remains a host bind mount for explicit control. No migration needed for document storage.
+### For New Deployments
+
+Use the new **containerized installer** for a guided setup (no prerequisites other than Docker):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jmservera/aithena/main/install.sh | bash
+./aithena/start.sh
+```
+
+Or use the traditional Python-based installer:
+
+```bash
+python3 -m installer
+./start.sh
+```
 
 ---
 
-## Upgrade Checklist
+## Validation Steps
 
-### For All Users
+### For Upgraded Deployments
 
-- [ ] **Review the Docker-managed volumes section above** — Understand the volume structure change
-- [ ] **Back up your data** — Export Solr collections, Redis state, and ZooKeeper state if upgrading from v2.1.0
-- [ ] **Update deployment scripts** — Remove any references to hardcoded `/source/volumes/` paths
-- [ ] **Re-run the installer** — `python3 installer/setup.py --version 2.2.0` generates the new `start.sh` and `.env` template
-
-### Validation Steps
-
-#### 1. **Clean-Install Validation** (Lambert's Recommended Approach)
-
-For new deployments or after fresh installation:
+After pulling v2.2.0 images, run these checks:
 
 ```bash
-# 1. Run the installer (user prompts guide through configuration)
-python3 installer/setup.py
-
-# 2. Start the stack
-docker compose up -d
-
-# 3. Wait for services to be healthy (typically 20–30 seconds)
-sleep 30
-
-# 4. Run validation tests
-docker compose exec solr solr status
-docker compose ps --format "table {{.Service}}\t{{.Status}}"
-
-# 5. Test the UI (should redirect to login)
-curl -sf http://localhost/ | head -20
-
-# 6. Test the API health
+# 1. Service health check
 curl -sf http://localhost/v1/health | jq .
 
-# 7. Run E2E tests (if available locally)
+# 2. API capabilities
+curl -sf http://localhost/v1/capabilities | jq .
+
+# 3. Admin portal accessibility
+curl -sf http://localhost/admin && echo "✅ Admin portal accessible"
+
+# 4. Container status
+docker compose ps
+```
+
+### For Fresh Installations
+
+```bash
+# 1. Run the installer
+python3 -m installer
+
+# 2. Start the stack
+./start.sh
+
+# 3. Wait for services to stabilize (20–30 seconds)
+sleep 30
+
+# 4. Run health checks
+curl -sf http://localhost/v1/health | jq .
+
+# 5. Test the UI
+curl -sf http://localhost/ | head -20
+
+# 6. Run E2E tests (if available)
 npx playwright test --headed
 ```
-
-#### 2. **Docker Volume Inspection**
-
-Verify that Docker-managed volumes are created and mounted correctly:
-
-```bash
-# List aithena volumes
-docker volume ls | grep aithena
-
-# Inspect a specific volume (e.g., solr-data)
-docker volume inspect aithena_solr-data | jq .[0].Mountpoint
-
-# Verify volumes are mounted in running containers
-docker compose exec solr mount | grep /var/solr/data
-docker compose exec zookeeper mount | grep /var/lib/zookeeper
-```
-
-#### 3. **Service Health Checks**
-
-```bash
-# Solr health
-curl -sf http://localhost:8983/solr/admin/info/system | jq .responseHeader.status
-
-# ZooKeeper connectivity
-docker compose exec zookeeper nc -zv zookeeper 2181
-
-# Redis connectivity
-docker compose exec redis redis-cli ping
-
-# Collections database
-docker compose exec collections-db sqlite3 db.sqlite3 "SELECT COUNT(*) FROM migrations;" || echo "⚠️ DB check failed"
-
-# API endpoint
-curl -sf http://localhost/v1/capabilities | jq .
-```
-
-#### 4. **Pre-Production Smoke Test**
-
-Before deploying v2.2.0 to production:
-
-1. **Spin up a staging environment** using the new volume configuration
-2. **Upload a test document** and verify indexing completes
-3. **Search for content** across all search architectures (HNSW and hybrid-rerank if configured)
-4. **Access the admin portal** and verify collection statistics display
-5. **Review Docker logs** for any volume-mount errors:
-   ```bash
-   docker compose logs --tail=50 solr zookeeper collections-db
-   ```
 
 ---
 
 ## Known Issues & Limitations
 
-- **Volume migration is one-way for this release.** If you need to revert to v2.1.0, you must manually restore from backups; there is no automatic reverse migration tool.
-- **Test suite skips may mask missing fixtures.** While PR #1617 improves CI robustness, developers should verify that essential test fixtures are present locally before committing changes.
+- **CI E2E test robustness improved:** Issue #1583 eliminates rate-limit (429) errors. No end-user impact.
+- **Installer security fix:** Issue #1576 removes clear-text credential logging. Update deployments if you use logs for sensitive data inspection.
 
 ---
 
 ## Dependencies & Prerequisites
 
-- **Docker Compose** v2.0 or later (required for named volume support; v1.x may not fully support Docker-managed volumes)
 - **Docker** v20.10 or later
-- **Python** 3.12+ (for running `installer/setup.py`)
+- **Docker Compose** v2.0 or later
+- **Python** 3.12+ (for installer; Docker-based installer has no Python requirement)
 
 ---
 
-## Commits & References
+## Closed Issues & References
 
-- **Phase 1 volume migration:** PR #1614 (Solr/ZooKeeper/certbot), PR #1612 (Redis/RabbitMQ)
-- **Design decision:** See `.squad/decisions.md` — "Decision: PR #1614 Approved — Phase 1b Volume Migration Complete"
-- **Related issue:** #1578 (Wizard Installer — Phase 1 & 2)
+- **#1578** — feat(installer): Wizard-style containerized installer for zero-dependency setup
+- **#1613** — fix(docker): Complete Phase 1a: Update prod overlay volume configs
+- **#1544** — fix(solr-init): Cap replication factor to node count
+- **#1583** — fix(ci): Eliminate Playwright 429 rate-limit failures in E2E
+- **#1576** — fix(security): Clear-text logging of sensitive data in installer (GHAS CodeQL #233)
+- **#1574** — chore(ci): Refresh expired COPILOT_ASSIGN_TOKEN
 
 ---
 
@@ -205,19 +150,19 @@ Before deploying v2.2.0 to production:
 | Scenario | Action | Effort |
 |----------|--------|--------|
 | **New deployment** | Run installer, start stack | 5–10 min |
-| **Upgrading from v2.1.0 (no data preservation)** | Backup data, re-run installer, start stack | 15–20 min |
-| **Upgrading from v2.1.0 (preserve documents only)** | Back up docs, backup Solr, re-run installer, restore docs, import Solr collections | 30–45 min |
-| **Production upgrade (data migration)** | Full backup (docs + Solr + Redis + ZK), spin up staging, validate, cutover | 1–2 hours + validation |
+| **Upgrading from v2.0.0 or v2.1.0** | `docker compose pull && docker compose up -d` | 2–5 min |
+| **Production upgrade** | Test on staging, pull images, verify health checks, deploy to prod | 15–30 min |
 
 ---
 
 ## Contributors
 
-- Copilot (Backend Dev, Scribe) — Volume migration, release coordination
-- Parker (Backend Dev) — Docker/Compose strategy
-- Lambert (E2E/QA) — Test robustness validation
-- Ripley (Lead) — Approval & oversight
+- **Newt** (Product Manager) — Release coordination, test report
+- **Ripley** (Lead) — Architectural review and approval
+- **Parker** (Backend Dev) — Prod overlay fix (#1613)
+- **Lambert** (Tester) — E2E validation
+- **Copilot** (Coding Agent) — Documentation and coordination
 
 ---
 
-Full details: [CHANGELOG.md](https://github.com/jmservera/aithena/blob/main/CHANGELOG.md)
+For detailed technical information, see [CHANGELOG.md](https://github.com/jmservera/aithena/blob/main/CHANGELOG.md) and [v2.2.0 Test Report](../test-reports/v2.2.0.md).


### PR DESCRIPTION
## Summary

Implements Phase 1c of the compose.prod.yml volume migration (issue #1616) and finishes the v2.2.0 release-docs checklist items from issue #1620.

## Changes

**docker/compose.prod.yml:**
- Converted document-data, collections-db, solr-data, solr-data2, solr-data3, zoo-data{1,2,3}_{logs,data,datalog}, and zoo-backup from bind mounts to Docker-managed named volumes.

**docs/admin-manual.md:**
- Updated the v2.2.0 summary and added deployment migration guidance.

**docs/release-notes/v2.2.0.md:**
- Corrected v2.2.0 release documentation and checklist content for the shipping release.

## Testing

✅ Validated compose configuration
✅ Brought up single-node compose stack
✅ All services started successfully and reached healthy status
✅ Verified all volumes created as Docker-managed volumes

## References

- Closes #1616
- Closes #1620

Working as DevOps (Infrastructure engineer)