### PR TITLE
docs(squad): record release blocker after PR 1623

### DIFF
--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -362,6 +362,13 @@ Batched 16 low/medium-risk Dependabot PRs into a single PR (#1584), merged to de
 - Closed all 16 superseded PRs with back-reference
 
 ### Learnings
+
+### Release Coordination After PR #1623 — 2026-06-03
+
+- PR #1623 reached green CI and all review threads were resolved before merge into `dev`.
+- Newt's release gate approved v2.2.0 after PR #1623, and release metadata PR #1624 merged to `dev` with `VERSION` and `CHANGELOG.md` updated.
+- Release stopped before dev→main/tag because `v2.2.0` already exists and is published on an older `dev` commit; the tag is an ancestor of current `dev`, but it does not contain the final release metadata and PR #1623 history.
+- Do not move the published tag ad hoc. Require Newt approval for an alternate patch version (likely v2.2.1) or an explicit tag-remediation decision before continuing release mechanics.
 - **Lockfile conflicts are routine**: When stacking multiple dependency bumps for the same service, cherry-picking creates lockfile conflicts. Solution: accept theirs, then `uv lock` once at the end.
 - **npm lockfile was auto-consistent**: Despite 6 npm dependency cherry-picks, the package-lock.json auto-merged cleanly. Only uv.lock needed regeneration.
 - **Rulesets ≠ branch protection**: `--admin` does NOT bypass repository rulesets. Must satisfy required status checks + resolve conversations.

--- a/.squad/decisions/inbox/ripley-release-after-pr1623.md
+++ b/.squad/decisions/inbox/ripley-release-after-pr1623.md
@@ -1,0 +1,27 @@
+# Decision: Block v2.2.0 Tag After PR #1623
+
+**Author:** Ripley (Lead)  
+**Date:** 2026-06-03  
+**Status:** Blocked — needs Newt version decision  
+**Scope:** Release v2.2.0 after PR #1623
+
+## Context
+
+PR #1623 merged into `dev` after checks passed and review threads were resolved. Newt approved the release gate for v2.2.0, and PR #1624 merged the release metadata (`VERSION`, `CHANGELOG.md`, and Newt history) to `dev`.
+
+A pre-tag audit found that `v2.2.0` already exists and has a published GitHub Release. The existing tag points to an older `dev` commit that is an ancestor of current `dev`, but it does not include the final PR #1623 work or the merged release metadata from PR #1624.
+
+## Decision
+
+Do not move, delete, or reuse the published `v2.2.0` tag during this release pass. Stop before dev→main/tag until Newt explicitly approves either:
+
+1. a new patch version for the complete release commit, likely `v2.2.1`, or
+2. a deliberate remediation plan for the already-published `v2.2.0` tag/release.
+
+## Rationale
+
+Moving an existing published tag would break release auditability and consumers that may already have pulled `v2.2.0`. Tagging current `dev` as `v2.2.0` is impossible without rewriting the existing tag, and tagging a new patch without Newt approval would bypass the release gate.
+
+## Follow-up
+
+Newt should issue a short release-gate addendum naming the approved patch version. After that, Ripley can resume the standard sequence: merge `dev` to `main`, tag the approved version on the release commit, push the tag, and monitor `release.yml`.

--- a/.squad/skills/release-orchestration/SKILL.md
+++ b/.squad/skills/release-orchestration/SKILL.md
@@ -17,6 +17,19 @@ Apply when planning releases, coordinating multi-release delivery, managing larg
 
 **Core principle:** Release docs must be merged to `dev` BEFORE creating the version tag.
 
+
+### Tag-Collision Preflight
+
+Before dev→main or tagging, verify the target tag does not already exist and no GitHub Release has been published for it:
+
+```bash
+git fetch origin --tags
+git rev-parse vX.Y.Z^{}
+gh release view vX.Y.Z
+```
+
+If the tag/release already exists but does not point at the final release commit that contains the release docs and metadata, stop. Do not move a published tag without an explicit release-remediation decision; ask Newt to approve a new patch version or a tag repair plan.
+
 ### Release Sequence
 1. Close all milestone issues
 2. Trigger `release-docs` workflow (generates release notes + test report)


### PR DESCRIPTION
Records Ripley release coordination notes after PR #1623, documents the v2.2.0 tag collision blocker, and adds tag-collision preflight guidance.\n\nRelease remains blocked: existing published v2.2.0 tag points at an older commit, so Newt must approve v2.2.1 or a tag remediation plan before dev→main/tag.\n\nValidation: .squad/scripts/verify.sh