### PR TITLE
docs: clarify v2.2 release upgrade notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ No API or schema breaking changes. Deployment upgrade note: existing prod-overla
 
 ### Breaking Changes
 
-None. Existing prod-overlay deployments should review the volume migration steps in upgrade instructions before restarting the stack.
+- No API or schema breaking changes.
+- Deployment upgrade note: existing prod-overlay deployments that previously relied on bind-mounted volume paths must review the volume migration and backup steps before restarting, because storage backing changes can require manual data migration.
 
 ## [2.1.0] — 2026-04-21
 

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -116,7 +116,7 @@ npx playwright test --headed
 
 - **Docker** v20.10 or later
 - **Docker Compose** v2.0 or later
-- **Python** 3.12+ for the repo-local installer path
+- **Python** 3.12+ plus `uv`; run the repo-local installer with `uv run installer/setup.py`
 
 ---
 

--- a/docs/release-notes/v2.2.1.md
+++ b/docs/release-notes/v2.2.1.md
@@ -118,7 +118,7 @@ npx playwright test --headed
 
 - **Docker** v20.10 or later
 - **Docker Compose** v2.0 or later
-- **Python** 3.12+ for the repo-local installer path
+- **Python** 3.12+ plus `uv`; run the repo-local installer with `uv run installer/setup.py`
 
 ---
 


### PR DESCRIPTION
Final follow-up for release PR review threads on #1625.\n\nChanges:\n- Clarifies volume migration upgrade risk in CHANGELOG\n- Names the canonical `uv run installer/setup.py` installer invocation in v2.2.0/v2.2.1 release notes\n\nValidation: .squad/scripts/verify.sh (no changed services detected).