### PR TITLE
fix: reduce pre-release connection warning noise

### DIFF
--- a/.squad/agents/parker/history.md
+++ b/.squad/agents/parker/history.md
@@ -103,6 +103,7 @@
 
 <!-- Append learnings below this line -->
 
+- **2026-06-03T22:02:03.765+00:00 (#1629):** Pre-release connection warnings can be false positives when the analyzer matches bare `reconnect` in filenames/search URLs (for example `reconnect.pdf`) or document-indexer's expected Solr readiness loop. Keep runtime dependency failures visible, but require reconnect language to describe connection behavior and allow known startup readiness probes.
 - **2026-06-03T21:25:25.755+00:00 (PR #1623):** `/v1/upload` has its own in-memory `upload_rate_limiter` in `src/solr-search/main.py`, so disabling the shared search limiter with `RATE_LIMIT_REQUESTS_PER_MINUTE=0` is not enough unless upload limiting reads the same CI default or `UPLOAD_RATE_LIMIT_REQUESTS_PER_MINUTE=0` is set. E2E upload-heavy tests (`e2e/test_web_api_semantic.py`) can exhaust the old hard-coded 10/minute limit before semantic assertions run.
 - **2026-05-24 (#1544):** Inline Solr init replicationFactor handling in docker-compose.yml must mirror docker/solr-init.sh by clamping SOLR_REPLICATION_FACTOR to EXPECTED_NODES, not merely warning.
 ### Installer Wizard Research Spike (#1578, 2026-05-24)

--- a/e2e/pre-release-check.sh
+++ b/e2e/pre-release-check.sh
@@ -300,6 +300,32 @@ scan_slow_startups() {
   done < "$LOG_FILE"
 }
 
+# Expected startup readiness probes can continue after the coarse startup window
+# in slower CI runs. Keep those out of warning issues while still surfacing
+# runtime dependency failures.
+is_expected_startup_connection_line() {
+  _svc="$1"
+  _lc_line="$2"
+  case "$_svc:$_lc_line" in
+    document-indexer*:*"waiting for solr collection"*) return 0 ;;
+  esac
+  return 1
+}
+
+is_actionable_connection_line() {
+  _lc_line="$1"
+  case "$_lc_line" in
+    *"connection refused"*|*"connection reset"*|*"connection timed out"*) return 0 ;;
+    *"reconnecting"*|*"reconnect attempt"*|*"failed to reconnect"*|*"trying to reconnect"*) return 0 ;;
+    *"retrying"*|*"retry"*"attempt"*)
+      case "$_lc_line" in
+        *"connection"*|*"rabbitmq"*|*"redis"*|*"solr"*|*"amqp"*|*"socket"*|*"broker"*) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
 # --- Category 5: Connection retries (after startup window) ---
 scan_connection_retries() {
   TOTAL_LINES="$(wc -l < "$LOG_FILE")"
@@ -316,11 +342,12 @@ scan_connection_retries() {
     fi
     svc="$(extract_service "$line")"
     lc_line="$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')"
-    case "$lc_line" in
-      *"retrying"*|*"connection refused"*|*"reconnect"*|*"retry"*"attempt"*|*"connection reset"*|*"connection timed out"*)
-        add_finding "connection" "warning" "${svc:-unknown}" "$line" "$LINE_NUM"
-        ;;
-    esac
+    if is_expected_startup_connection_line "${svc:-unknown}" "$lc_line"; then
+      continue
+    fi
+    if is_actionable_connection_line "$lc_line"; then
+      add_finding "connection" "warning" "${svc:-unknown}" "$line" "$LINE_NUM"
+    fi
   done < "$LOG_FILE"
 }
 

--- a/tests/test-pre-release-check.sh
+++ b/tests/test-pre-release-check.sh
@@ -10,7 +10,8 @@ ALLOWLIST="$REPO_ROOT/e2e/pre-release-allowlist.txt"
 PASS=0
 FAIL=0
 
-tmpdir="$(mktemp -d)"
+tmpdir="$REPO_ROOT/.test-artifacts/pre-release-check.$$"
+mkdir -p "$tmpdir"
 trap 'rm -rf "$tmpdir"' EXIT
 
 assert_exit() {
@@ -171,6 +172,53 @@ sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/mixed.txt" > "$tmpdir/out.json"
 assert_exit "exit code 1 (real error)" 1 "$rc"
 assert_json_count "1 real finding (others filtered)" "$tmpdir/out.json" 1
 assert_json_field "category=crash" "$tmpdir/out.json" 0 "category" "crash"
+
+# -------------------------------------------------------
+echo "Test 12: Expected Solr startup readiness retries are ignored after startup window"
+: > "$tmpdir/solr-startup.txt"
+i=1
+while [ "$i" -le 65 ]; do
+  echo "app1  | 2024-01-01 startup line $i" >> "$tmpdir/solr-startup.txt"
+  i=$((i + 1))
+done
+cat >> "$tmpdir/solr-startup.txt" <<'EOF'
+document-indexer-1  | {"timestamp":"2026-06-03T22:45:43Z","level":"INFO","message":"Waiting for Solr collection books (1/60): HTTPConnectionPool(host='solr', port=8983): Failed to establish a new connection: [Errno 111] Connection refused"}
+EOF
+sh "$ANALYZER" "$tmpdir/solr-startup.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0 (expected startup retry)" 0 "$rc"
+assert_no_category "no connection findings" "$tmpdir/out.json" "connection"
+
+# -------------------------------------------------------
+echo "Test 13: Reconnect in filenames and URLs is not a connection warning"
+: > "$tmpdir/reconnect-filename.txt"
+i=1
+while [ "$i" -le 65 ]; do
+  echo "app1  | 2024-01-01 startup line $i" >> "$tmpdir/reconnect-filename.txt"
+  i=$((i + 1))
+done
+cat >> "$tmpdir/reconnect-filename.txt" <<'EOF'
+document-lister-1  | {"timestamp":"2026-06-03T22:46:23Z","level":"INFO","message":"Document already processed: /data/documents/uploads/reconnect.pdf"}
+nginx-1            | 172.18.0.1 - - [03/Jun/2026:22:47:01 +0000] "GET /v1/search/?q=reconnect&page=1&limit=10 HTTP/1.1" 200 123
+EOF
+sh "$ANALYZER" "$tmpdir/reconnect-filename.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0 (reconnect content only)" 0 "$rc"
+assert_no_category "no connection findings" "$tmpdir/out.json" "connection"
+
+# -------------------------------------------------------
+echo "Test 14: Runtime connection failures are still warnings"
+: > "$tmpdir/runtime-connection.txt"
+i=1
+while [ "$i" -le 65 ]; do
+  echo "app1  | 2024-01-01 startup line $i" >> "$tmpdir/runtime-connection.txt"
+  i=$((i + 1))
+done
+cat >> "$tmpdir/runtime-connection.txt" <<'EOF'
+document-lister-1  | 2024-01-01 RabbitMQ connection timed out while publishing
+EOF
+sh "$ANALYZER" "$tmpdir/runtime-connection.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 2 (runtime connection warning)" 2 "$rc"
+assert_json_count "1 connection finding" "$tmpdir/out.json" 1
+assert_json_field "category=connection" "$tmpdir/out.json" 0 "category" "connection"
 
 # -------------------------------------------------------
 echo ""


### PR DESCRIPTION
Closes #1629

Working as Parker (Backend Dev).

## Summary
- Ignore document-indexer Solr readiness retries as expected startup probes in pre-release log analysis.
- Stop treating bare `reconnect` in filenames/search URLs as connection warnings.
- Preserve runtime connection timeout/refused/reset and explicit reconnect warnings.

## Validation
- `sh tests/test-pre-release-check.sh`
- `.squad/scripts/verify.sh` (no changed services detected)