### PR TITLE
fix(ci): set Redis overcommit before Compose startup

### DIFF
--- a/.github/workflows/dev-integration-test.yml
+++ b/.github/workflows/dev-integration-test.yml
@@ -164,6 +164,9 @@ jobs:
         run: |
           docker compose --profile production config >/dev/null
 
+      - name: Configure Redis memory overcommit
+        run: sudo sysctl vm.overcommit_memory=1
+
       - name: Build all container images
         run: |
           docker compose --profile production build

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -235,6 +235,9 @@ jobs:
         run: |
           docker compose --profile production config >/dev/null
 
+      - name: Configure Redis memory overcommit
+        run: sudo sysctl vm.overcommit_memory=1
+
       - name: Build all container images
         run: |
           docker compose --profile production build

--- a/.github/workflows/pre-release-validation.yml
+++ b/.github/workflows/pre-release-validation.yml
@@ -133,6 +133,9 @@ jobs:
             --profile production \
             config >/dev/null
 
+      - name: Configure Redis memory overcommit
+        run: sudo sysctl vm.overcommit_memory=1
+
       - name: Build all container images
         run: |
           docker compose \

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -51,11 +51,11 @@ This reduces startup races where the lister, indexer, or admin tools could come 
 
 ## Host Prerequisites
 
-Before starting the Docker Compose stack, apply the following kernel tuning on the **Docker host** (these cannot be set from inside a container).
+Before starting the Docker Compose stack, apply the following kernel tuning on the **Docker host**.
 
 ### Redis memory overcommit
 
-Redis background saves (RDB snapshots) fork the process, which requires the kernel to allow memory overcommit. Without this setting Redis logs `WARNING Memory overcommit must be enabled!` and background saves may fail.
+Redis background saves (RDB snapshots) fork the process, which requires the kernel to allow memory overcommit. Without this setting Redis logs `WARNING Memory overcommit must be enabled!` and background saves may fail. The CI workflows set this host sysctl before starting Compose; local and production operators should apply the host-level setting below.
 
 ```bash
 # Apply immediately (non-persistent):
@@ -66,7 +66,7 @@ echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/90-redis-overcommit.con
 sudo sysctl --system
 ```
 
-> **Note:** The compose stack sets `stop-writes-on-bgsave-error no` in `src/redis/redis.conf` so Redis remains available even when overcommit is disabled, but applying the host-level setting is still recommended to ensure reliable snapshots.
+> **Note:** This setting must be applied on the Docker host, not in Compose: `vm.overcommit_memory` is not namespaced by the Linux container runtime and will fail if configured as a service-level `sysctls` entry. The compose stack sets `stop-writes-on-bgsave-error no` in `src/redis/redis.conf` so Redis remains available even when overcommit is disabled, but keeping overcommit enabled is still recommended to ensure reliable snapshots.
 
 ### ZooKeeper credentials (production hardening)
 


### PR DESCRIPTION
## Summary
- Set `vm.overcommit_memory=1` on GitHub Actions runners before integration Compose stacks start
- Cover full integration, dev integration, and pre-release validation workflows
- Update admin docs with the local/production host sysctl fallback and note why Compose service sysctls are not portable for this kernel setting

Working as Brett (Infrastructure Architect)

Closes #1630

## Validation
- `AUTH_JWT_SECRET=dev AUTH_DB_DIR=. BOOKS_PATH=. SOLR_ADMIN_USER=solr_admin SOLR_ADMIN_PASS=SolrAdmin_dev2024! SOLR_READONLY_USER=solr_read SOLR_READONLY_PASS=SolrRead_dev2024! RABBITMQ_ADMIN_USER=admin RABBITMQ_ADMIN_PASS=admin_dev_pass RABBITMQ_LISTER_PASS=lister_dev_pass RABBITMQ_INDEXER_PASS=indexer_dev_pass RABBITMQ_SEARCH_PASS=search_dev_pass docker compose config --quiet`
- `AUTH_JWT_SECRET=dev AUTH_DB_DIR=. BOOKS_PATH=. SOLR_ADMIN_USER=solr_admin SOLR_ADMIN_PASS=SolrAdmin_dev2024! SOLR_READONLY_USER=solr_read SOLR_READONLY_PASS=SolrRead_dev2024! RABBITMQ_ADMIN_USER=admin RABBITMQ_ADMIN_PASS=admin_dev_pass RABBITMQ_LISTER_PASS=lister_dev_pass RABBITMQ_INDEXER_PASS=indexer_dev_pass RABBITMQ_SEARCH_PASS=search_dev_pass docker compose -f docker-compose.yml -f docker/compose.prod.yml config --quiet`
- Workflow YAML parsed with `python3 -c yaml.safe_load`
- `.squad/scripts/verify.sh`