### PR TITLE
fix: allow PR squad assignment comments

### DIFF
--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -3,11 +3,13 @@ name: Squad Issue Assign
 on:
   issues:
     types: [labeled]
-  pull_request:
+  # PR label routing needs a base-repository write token; do not execute PR-head code here.
+  pull_request_target:
     types: [labeled]
 
 permissions:
   issues: write
+  pull-requests: write
   contents: read
 
 jobs:

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -337,6 +337,11 @@ Each merged skill preserves key patterns, examples, and anti-patterns from all s
 
 ## Learnings
 
+### PR #1637 assign-work blocker (2026-06-03T22:02:03.765+00:00)
+
+- PR-label routing is team metadata, not product validation. When `Squad Issue Assign` handles PR labels, it needs the base-repository token context (`pull_request_target`) and explicit PR/issue write permissions.
+- Keep `pull_request_target` routing workflows limited to trusted metadata scripts and base-branch checkout; never execute PR-head code in that context.
+
 ### Project Review (2026-05-12)
 
 - **v2.1 shipped, but top-level docs lag behind.** `VERSION` and GitHub Releases are at `2.1.0`, and `CHANGELOG.md` covers the release well, but `README.md` still advertises `v1.9.1` / `v1.10.0` development state.

--- a/.squad/decisions/inbox/ripley-pr1637-ci.md
+++ b/.squad/decisions/inbox/ripley-pr1637-ci.md
@@ -1,0 +1,22 @@
+# Decision: PR #1637 CI Routing Fix
+
+**Author:** Ripley (Lead)  
+**Date:** 2026-06-03T22:02:03.765+00:00  
+**Status:** Implemented  
+**Scope:** Squad Issue Assign PR label routing
+
+## Context
+
+PR #1637 was product-approved by Newt but blocked by the `assign-work` check. The failing job was triggered by PR label routing and failed while creating the assignment comment with `Resource not accessible by integration`.
+
+## Decision
+
+Run the `Squad Issue Assign` workflow on `pull_request_target` for PR label routing and explicitly grant `pull-requests: write` alongside `issues: write`.
+
+## Rationale
+
+The `assign-work` job is team routing metadata automation: it comments on issues/PRs when a `squad:{member}` label is applied. It needs the base-repository token context to write PR assignment comments; the routing decision itself does not depend on untrusted PR code.
+
+## Safety Boundary
+
+Keep PR-triggered `pull_request_target` routing workflows restricted to trusted metadata operations and base-branch checkout. Do not add steps that execute PR-head code in this workflow context.


### PR DESCRIPTION
## Summary
- switch Squad Issue Assign PR label handling to pull_request_target so routing comments use a base-repository write token
- explicitly grant pull-requests: write and document the metadata-only security boundary
- record Ripley learning and decision for PR #1637 CI routing

## Validation
- .squad/scripts/verify.sh

Unblocks PR #1637 assign-work failure.