### PR TITLE
Keep ZooKeeper private in CI validation stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,19 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
 
+  compose-security-regression:
+    name: Compose security regression
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate Compose security posture
+        run: sh tests/test-compose-security.sh
+
   all-tests-passed:
     name: All tests passed
     if: always()
@@ -273,6 +286,7 @@ jobs:
       - document-lister-tests
       - embeddings-server-tests
       - python-lint
+      - compose-security-regression
     steps:
       - name: Evaluate results
         env:
@@ -283,13 +297,14 @@ jobs:
           LISTER_RESULT: ${{ needs.document-lister-tests.result }}
           EMBEDDINGS_RESULT: ${{ needs.embeddings-server-tests.result }}
           LINT_RESULT: ${{ needs.python-lint.result }}
+          COMPOSE_SECURITY_RESULT: ${{ needs.compose-security-regression.result }}
           BUILD_NEEDED: ${{ needs.changes.outputs.build }}
         run: |
           if [ "$CHANGES_RESULT" = "failure" ] || [ "$CHANGES_RESULT" = "cancelled" ]; then
             echo "❌ Change detection failed"
             exit 1
           fi
-          for result in "$INDEXER_RESULT" "$SEARCH_RESULT" "$UI_RESULT" "$LISTER_RESULT" "$EMBEDDINGS_RESULT" "$LINT_RESULT"; do
+          for result in "$INDEXER_RESULT" "$SEARCH_RESULT" "$UI_RESULT" "$LISTER_RESULT" "$EMBEDDINGS_RESULT" "$LINT_RESULT" "$COMPOSE_SECURITY_RESULT"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "❌ One or more required jobs failed"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate Compose security posture
-        run: sh tests/test-compose-security.sh
+        run: bash tests/test-compose-security.sh
 
   all-tests-passed:
     name: All tests passed

--- a/.github/workflows/dev-integration-test.yml
+++ b/.github/workflows/dev-integration-test.yml
@@ -120,7 +120,7 @@ jobs:
           # Reuse the canonical single-node overlay so CI exercises the same
           # compose wiring as local/installer deployments. The CI-only file
           # below provides tmpfs volumes for faster, ephemeral storage.
-          echo "COMPOSE_FILE=docker-compose.yml:docker/compose.single-node.yml:docker/compose.dev-ports.yml:docker/compose.e2e.yml:docker-compose.github-actions.yml" >> "$GITHUB_ENV"
+          echo "COMPOSE_FILE=docker-compose.yml:docker/compose.single-node.yml:docker/compose.ci-ports.yml:docker/compose.e2e.yml:docker-compose.github-actions.yml" >> "$GITHUB_ENV"
           cat > docker-compose.github-actions.yml <<'EOF'
           volumes:
             rabbitmq-data:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -131,7 +131,7 @@ jobs:
             # Reuse the canonical single-node overlay so CI exercises the same
             # compose wiring as local/installer deployments. The CI-only file
             # below provides tmpfs volumes for faster, ephemeral storage.
-            echo "COMPOSE_FILE=docker-compose.yml:docker/compose.single-node.yml:docker/compose.dev-ports.yml:docker/compose.e2e.yml:docker-compose.github-actions.yml" >> "$GITHUB_ENV"
+            echo "COMPOSE_FILE=docker-compose.yml:docker/compose.single-node.yml:docker/compose.ci-ports.yml:docker/compose.e2e.yml:docker-compose.github-actions.yml" >> "$GITHUB_ENV"
             cat > docker-compose.github-actions.yml <<'EOF'
           volumes:
             rabbitmq-data:
@@ -166,7 +166,7 @@ jobs:
               driver_opts: { type: tmpfs, device: tmpfs, o: "size=50m" }
           EOF
           else
-            echo "COMPOSE_FILE=docker-compose.yml:docker/compose.dev-ports.yml:docker/compose.e2e.yml:docker-compose.github-actions.yml" >> "$GITHUB_ENV"
+            echo "COMPOSE_FILE=docker-compose.yml:docker/compose.ci-ports.yml:docker/compose.e2e.yml:docker-compose.github-actions.yml" >> "$GITHUB_ENV"
             cat > docker-compose.github-actions.yml <<'EOF'
           volumes:
             rabbitmq-data:

--- a/.github/workflows/pre-release-validation.yml
+++ b/.github/workflows/pre-release-validation.yml
@@ -189,6 +189,11 @@ jobs:
             return 1
           }
 
+          if [ -z "${SOLR_ADMIN_USER:-}" ] || [ -z "${SOLR_ADMIN_PASS:-}" ]; then
+            echo "::error::Missing SOLR_ADMIN_USER or SOLR_ADMIN_PASS from generated .env; cannot run authenticated Solr readiness checks." >&2
+            exit 1
+          fi
+
           SOLR_AUTH="${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}"
           wait_for_url "http://localhost:8983/solr/admin/info/system" "Solr" 60 5 "$SOLR_AUTH"
           wait_for_url "http://localhost:8983/solr/books/admin/ping?distrib=true" "Solr books collection" 60 5 "$SOLR_AUTH"

--- a/.github/workflows/pre-release-validation.yml
+++ b/.github/workflows/pre-release-validation.yml
@@ -63,6 +63,10 @@ jobs:
             --auth-db-path "$RUNNER_TEMP/aithena-auth/users.db" \
             --reset
 
+          if [ -f .env ]; then
+            grep -E '^(SOLR_ADMIN_USER|SOLR_ADMIN_PASS|SOLR_READONLY_USER|SOLR_READONLY_PASS|ADMIN_API_KEY)=' .env >> "$GITHUB_ENV" || true
+          fi
+
           cat > docker-compose.github-actions.yml <<'EOF'
           volumes:
             rabbitmq-data:
@@ -127,7 +131,7 @@ jobs:
         run: |
           docker compose \
             -f docker-compose.yml \
-            -f docker/compose.dev-ports.yml \
+            -f docker/compose.ci-ports.yml \
             -f docker/compose.e2e.yml \
             -f docker-compose.github-actions.yml \
             --profile production \
@@ -140,7 +144,7 @@ jobs:
         run: |
           docker compose \
             -f docker-compose.yml \
-            -f docker/compose.dev-ports.yml \
+            -f docker/compose.ci-ports.yml \
             -f docker/compose.e2e.yml \
             -f docker-compose.github-actions.yml \
             --profile production \
@@ -150,7 +154,7 @@ jobs:
         run: |
           docker compose \
             -f docker-compose.yml \
-            -f docker/compose.dev-ports.yml \
+            -f docker/compose.ci-ports.yml \
             -f docker/compose.e2e.yml \
             -f docker-compose.github-actions.yml \
             --profile production \
@@ -163,9 +167,16 @@ jobs:
             local label="$2"
             local attempts="${3:-60}"
             local sleep_seconds="${4:-5}"
+            local auth="${5:-}"
 
             for ((attempt=1; attempt<=attempts; attempt+=1)); do
-              if curl --fail --silent --show-error "$url" >/dev/null; then
+              if [ -n "$auth" ]; then
+                curl_args=(--user "$auth")
+              else
+                curl_args=()
+              fi
+
+              if curl --fail --silent --show-error "${curl_args[@]}" "$url" >/dev/null; then
                 echo "$label is ready ($url)"
                 return 0
               fi
@@ -178,15 +189,16 @@ jobs:
             return 1
           }
 
-          wait_for_url "http://localhost:8983/solr/admin/info/system" "Solr"
-          wait_for_url "http://localhost:8983/solr/books/admin/ping?distrib=true" "Solr books collection"
+          SOLR_AUTH="${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}"
+          wait_for_url "http://localhost:8983/solr/admin/info/system" "Solr" 60 5 "$SOLR_AUTH"
+          wait_for_url "http://localhost:8983/solr/books/admin/ping?distrib=true" "Solr books collection" 60 5 "$SOLR_AUTH"
           wait_for_url "http://localhost:8080/health" "solr-search API"
           wait_for_url "http://localhost/health" "nginx"
           wait_for_url "http://localhost/search" "Aithena UI"
 
           docker compose \
             -f docker-compose.yml \
-            -f docker/compose.dev-ports.yml \
+            -f docker/compose.ci-ports.yml \
             -f docker/compose.e2e.yml \
             -f docker-compose.github-actions.yml \
             --profile production \
@@ -224,7 +236,7 @@ jobs:
         run: |
           docker compose \
             -f docker-compose.yml \
-            -f docker/compose.dev-ports.yml \
+            -f docker/compose.ci-ports.yml \
             -f docker/compose.e2e.yml \
             -f docker-compose.github-actions.yml \
             --profile production \
@@ -237,6 +249,7 @@ jobs:
         with:
           compose-logs-path: ${{ runner.temp }}/compose-logs.txt
           version-file: ./VERSION
+          allowlist-path: ./e2e/pre-release-allowlist.txt
           create-issues: 'true'
           milestone: ${{ inputs.milestone }}
 
@@ -257,7 +270,7 @@ jobs:
         run: |
           docker compose \
             -f docker-compose.yml \
-            -f docker/compose.dev-ports.yml \
+            -f docker/compose.ci-ports.yml \
             -f docker/compose.e2e.yml \
             -f docker-compose.github-actions.yml \
             --profile production \

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -129,6 +129,10 @@ Use overlay files (not profiles) when making a sidecar optional affects the main
 
 ## Learnings
 
+### PR #1649 Solr readiness auth fail-fast (2026-06-04T01:20:37.644+00:00)
+
+- Authenticated Solr readiness probes must validate `SOLR_ADMIN_USER` and `SOLR_ADMIN_PASS` before constructing curl credentials; missing installer-exported `.env` values should fail fast with an explicit CI error instead of retrying opaque 401 responses.
+
 ### Issue #1631 CI ZooKeeper exposure follow-up (2026-06-04T01:20:37.644+00:00)
 
 - Use `docker/compose.ci-ports.yml` for CI and pre-release stacks that need host access to Redis/RabbitMQ/Solr/search APIs; keep `docker/compose.dev-ports.yml` local-only because it publishes ZooKeeper client ports for debugging.

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -129,6 +129,11 @@ Use overlay files (not profiles) when making a sidecar optional affects the main
 
 ## Learnings
 
+### Issue #1631 CI ZooKeeper exposure follow-up (2026-06-04T01:20:37.644+00:00)
+
+- Use `docker/compose.ci-ports.yml` for CI and pre-release stacks that need host access to Redis/RabbitMQ/Solr/search APIs; keep `docker/compose.dev-ports.yml` local-only because it publishes ZooKeeper client ports for debugging.
+- Compose config regression tests should assert both sides of Kane's security posture: ZooKeeper services have no published ports in CI/production overlays, and Solr services keep `SOLR_AUTH_USER`/`SOLR_AUTH_PASS` wired before init/health checks.
+
 ### GPU Compose Override Pattern
 - Used override files (`docker/compose.gpu-nvidia.yml`, `docker/compose.gpu-intel.yml`) rather than profiles — consistent with existing ssl/e2e overlay pattern
 - `DEVICE` and `BACKEND` env vars in base compose default to `cpu`/`torch` for backward compatibility

--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -94,6 +94,8 @@
 9. **Pydantic Field constraints** (ge, max_length) are model-level defense that persists across refactors — validate at model first, then runtime
 10. **Password length BEFORE hashing** — Argon2 processes full input, 1MB password = CPU DoS
 11. **CORS allow_credentials=true** needs strict origin validation — misconfigured browser + malicious origin = CSRF risk
+12. **Solr default ZK credentials/ACL providers** are medium-risk defense-in-depth findings, not automatic release blockers, only when ZooKeeper remains private to Compose and Solr HTTP auth is enabled.
+13. **For #1631 acceptance**, default Solr/ZK provider warnings are acceptable only if production Compose keeps ZooKeeper internal, Solr BasicAuth/RBAC remains required, and dev port overrides are treated as local-debug only.
 
 ## Reskill Notes
 
@@ -144,4 +146,3 @@
 **Decision Record:** `.squad/decisions.md` → "Security Analysis: Internal Service Authentication (Redis, ZooKeeper, Solr)"
 
 **Next:** Pending team consensus on compliance implications; network isolation discussion recommended.
-

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -337,6 +337,11 @@ Each merged skill preserves key patterns, examples, and anti-patterns from all s
 
 ## Learnings
 
+### PR #1649 compose regression CI gate (2026-06-04T01:20:37.644+00:00)
+
+- Reviewer-requested regression scripts for infrastructure/security posture must land inside a required CI aggregate before merge; manual green evidence is insufficient when the script protects accepted security posture.
+- For PR #1649, wiring `tests/test-compose-security.sh` into the required `All tests passed` aggregate keeps the gate small while ensuring ZooKeeper port exposure and Solr auth wiring regressions block the PR.
+
 ### PR #1638 assign-work unblock (2026-06-03T22:02:03.765+00:00)
 
 - Reused the PR #1643 routing-workflow permission pattern for PR-label assignment blockers: the base branch now carries `pull_request_target` plus explicit PR write permission for safe metadata-only assignment comments.

--- a/.squad/decisions/inbox/ripley-pr1649-ci-revision.md
+++ b/.squad/decisions/inbox/ripley-pr1649-ci-revision.md
@@ -1,0 +1,9 @@
+# PR #1649 compose regression CI gate
+
+Date: 2026-06-04T01:20:37.644+00:00
+
+Decision: Compose security regression checks that protect accepted CI/pre-release posture must run inside a required CI aggregate before merge, not remain manual-only validation.
+
+Context: Lambert requested changes on PR #1649 because `tests/test-compose-security.sh` verified ZooKeeper host-port exposure and Solr auth wiring locally but was not wired into required CI.
+
+Outcome: Add the compose regression script as a CI job feeding the required `All tests passed` check so future regressions block PR merge.

--- a/.squad/decisions/inbox/ripley-pr1649-ci-revision.md
+++ b/.squad/decisions/inbox/ripley-pr1649-ci-revision.md
@@ -1,9 +1,18 @@
-# PR #1649 compose regression CI gate
+# Decision: PR #1649 Compose Regression CI Gate
 
-Date: 2026-06-04T01:20:37.644+00:00
+**Author:** Ripley  
+**Date:** 2026-06-04T01:20:37.644+00:00  
+**Status:** Accepted  
+**Scope:** CI and pre-release validation
 
-Decision: Compose security regression checks that protect accepted CI/pre-release posture must run inside a required CI aggregate before merge, not remain manual-only validation.
+## Context
 
-Context: Lambert requested changes on PR #1649 because `tests/test-compose-security.sh` verified ZooKeeper host-port exposure and Solr auth wiring locally but was not wired into required CI.
+Lambert requested changes on PR #1649 because `tests/test-compose-security.sh` verified ZooKeeper host-port exposure and Solr auth wiring locally but was not wired into required CI.
 
-Outcome: Add the compose regression script as a CI job feeding the required `All tests passed` check so future regressions block PR merge.
+## Decision
+
+Compose security regression checks that protect accepted CI/pre-release posture must run inside a required CI aggregate before merge, not remain manual-only validation.
+
+## Outcome
+
+Add the compose regression script as a CI job feeding the required `All tests passed` check so future regressions block PR merge.

--- a/docker/compose.ci-ports.yml
+++ b/docker/compose.ci-ports.yml
@@ -1,0 +1,39 @@
+#
+# CI/pre-release host port override.
+#
+# This mirrors the non-ZooKeeper ports needed by automated tests from
+# docker/compose.dev-ports.yml. ZooKeeper ports stay private to the Compose
+# network per the issue #1631 security posture.
+services:
+  redis:
+    ports:
+      - "6379:6379"
+
+  rabbitmq:
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  embeddings-server:
+    ports:
+      - "8085:8080"
+
+  solr-search:
+    ports:
+      - "8080:8080"
+
+  redis-commander:
+    ports:
+      - "8081:8081"
+
+  solr:
+    ports:
+      - "8983:8983"
+
+  solr2:
+    ports:
+      - "8984:8983"
+
+  solr3:
+    ports:
+      - "8985:8983"

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -70,7 +70,9 @@ sudo sysctl --system
 
 ### ZooKeeper credentials (production hardening)
 
-Solr logs `Using default ZkCredentialsProvider/ZkACLProvider` at startup. This is informational — it means ZooKeeper znodes are world-readable. For production deployments that require ZooKeeper ACL-based access control, see the [Apache Solr ZooKeeper Access Control](https://solr.apache.org/guide/solr/latest/deployment-guide/zookeeper-access-control.html) documentation.
+Solr logs `Using default ZkCredentialsProvider/ZkACLProvider` at startup. In the default Docker Compose deployment this is an accepted posture: ZooKeeper is only exposed on the private Compose network, Solr BasicAuth/RBAC protects HTTP APIs, and no ZooKeeper ports should be published to the host.
+
+Security implication: any already-compromised container on the Compose network could read or modify SolrCloud znodes, including configsets and `security.json`. Treat ZooKeeper ACLs as required hardening for regulated or multi-tenant production deployments, and do not publish `2181`, `2888`, or `3888` outside the Compose network. For deployments that require ZooKeeper ACL-based access control, see the [Apache Solr ZooKeeper Access Control](https://solr.apache.org/guide/solr/latest/deployment-guide/zookeeper-access-control.html) documentation.
 
 ## Deployment with Docker Compose
 

--- a/e2e/pre-release-allowlist.txt
+++ b/e2e/pre-release-allowlist.txt
@@ -40,3 +40,21 @@ deprecation:*will not be permitted by default*future minor version of RabbitMQ*=
 # Connection retries during startup are normal for Docker Compose orchestration
 connection:*retrying*=ignore
 connection:*connection refused*=ignore
+
+# ZooKeeper client/secure/observer ports are intentionally supplied through
+# ZOO_SERVERS in the Compose ensemble, not separate static config keys.
+config:*clientPort is not set*=ignore
+config:*secureClientPort is not set*=ignore
+config:*observerMasterPort is not set*=ignore
+
+# ZooKeeper maxCnxns defaults to unlimited when not explicitly configured.
+# The Compose services set ZOO_MAX_CLIENT_CNXNS=60, so this startup line is
+# informational noise from the image bootstrap path.
+config:*maxCnxns is not configured*=ignore
+
+# Solr's default ZooKeeper credentials/ACL providers leave znodes open inside
+# the private Compose network. This is an accepted dev/CI and default production
+# posture until Brett implements optional ZK ACL hardening; do not hide any
+# other authentication or authorization failures.
+config:*Using default ZkCredentialsProvider*=ignore
+config:*Using default ZkACLProvider*=ignore

--- a/tests/test-compose-security.sh
+++ b/tests/test-compose-security.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Validate Compose network exposure and Solr auth wiring.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  echo "SKIP: docker compose is not available"
+  exit 0
+fi
+
+ARTIFACT_DIR="$ROOT/.test-artifacts/compose-security"
+mkdir -p "$ARTIFACT_DIR/e2e-library"
+
+export E2E_LIBRARY_PATH="$ARTIFACT_DIR/e2e-library"
+export SOLR_ADMIN_USER="${SOLR_ADMIN_USER:-solr_admin}"
+export SOLR_ADMIN_PASS="${SOLR_ADMIN_PASS:-SolrAdmin_test_2026!}"
+export SOLR_READONLY_USER="${SOLR_READONLY_USER:-solr_read}"
+export SOLR_READONLY_PASS="${SOLR_READONLY_PASS:-SolrRead_test_2026!}"
+export RABBITMQ_ADMIN_USER="${RABBITMQ_ADMIN_USER:-admin}"
+export RABBITMQ_ADMIN_PASS="${RABBITMQ_ADMIN_PASS:-admin_test_pass}"
+export RABBITMQ_LISTER_PASS="${RABBITMQ_LISTER_PASS:-lister_test_pass}"
+export RABBITMQ_INDEXER_PASS="${RABBITMQ_INDEXER_PASS:-indexer_test_pass}"
+export RABBITMQ_SEARCH_PASS="${RABBITMQ_SEARCH_PASS:-search_test_pass}"
+export ADMIN_API_KEY="${ADMIN_API_KEY:-admin-test-key}"
+export AUTH_JWT_SECRET="${AUTH_JWT_SECRET:-compose-security-test-secret}"
+export AUTH_DB_DIR="${AUTH_DB_DIR:-$ARTIFACT_DIR/auth}"
+mkdir -p "$AUTH_DB_DIR"
+
+check_compose() {
+  label="$1"
+  shift
+  docker compose "$@" --profile production config --format json |
+    python3 -c '
+import json
+import sys
+
+label = sys.argv[1]
+data = json.load(sys.stdin)
+services = data.get("services", {})
+failures = []
+
+for service_name in ("zoo1", "zoo2", "zoo3"):
+    ports = services.get(service_name, {}).get("ports") or []
+    if ports:
+        failures.append(f"{label}: {service_name} publishes ports: {ports}")
+
+for service_name in ("solr", "solr2", "solr3", "solr-init"):
+    service = services.get(service_name)
+    if service is None:
+        continue
+    if "distributed-only" in (service.get("profiles") or []):
+        continue
+    env = service.get("environment") or {}
+    if isinstance(env, list):
+        env_keys = {item.split("=", 1)[0] for item in env}
+    else:
+        env_keys = set(env)
+    for key in ("SOLR_AUTH_USER", "SOLR_AUTH_PASS"):
+        if key not in env_keys:
+            failures.append(f"{label}: {service_name} missing {key}")
+
+if failures:
+    print("\n".join(failures), file=sys.stderr)
+    sys.exit(1)
+
+print(f"OK: {label}")
+' "$label"
+}
+
+check_compose "default CI topology" \
+  -f docker-compose.yml \
+  -f docker/compose.ci-ports.yml \
+  -f docker/compose.e2e.yml
+
+check_compose "single-node CI topology" \
+  -f docker-compose.yml \
+  -f docker/compose.single-node.yml \
+  -f docker/compose.ci-ports.yml \
+  -f docker/compose.e2e.yml
+
+check_compose "production topology" \
+  -f docker/compose.prod.yml
+
+rm -rf "$ARTIFACT_DIR"

--- a/tests/test-compose-security.sh
+++ b/tests/test-compose-security.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Validate Compose network exposure and Solr auth wiring.
-set -eu
+set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"

--- a/tests/test-pre-release-check.sh
+++ b/tests/test-pre-release-check.sh
@@ -235,6 +235,20 @@ assert_json_count "1 connection finding" "$tmpdir/out.json" 1
 assert_json_field "category=connection" "$tmpdir/out.json" 0 "category" "connection"
 
 # -------------------------------------------------------
+echo "Test 16: Allowlist ignores accepted ZooKeeper/Solr config posture"
+cat > "$tmpdir/zk-config.txt" <<'EOF'
+zoo1  | 2026-06-03 clientPort is not set
+zoo1  | 2026-06-03 secureClientPort is not set
+zoo1  | 2026-06-03 observerMasterPort is not set
+zoo1  | 2026-06-03 maxCnxns is not configured
+solr1 | 2026-06-03 Using default ZkCredentialsProvider
+solr1 | 2026-06-03 Using default ZkACLProvider
+EOF
+sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/zk-config.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0 (accepted ZK/Solr config)" 0 "$rc"
+assert_json_count "0 findings (accepted config posture)" "$tmpdir/out.json" 0
+
+# -------------------------------------------------------
 echo ""
 echo "========================================"
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- Adds a CI/pre-release port override that omits ZooKeeper host port publishing while keeping required test ports.
- Moves CI/pre-release workflows from the local dev port override to the CI override and authenticates Solr readiness checks.
- Documents/allowlists Kane-approved #1631 Solr/ZooKeeper informational config warnings and adds compose regression coverage.

Closes #1631
Working as Brett (Infrastructure Architect) with Kane security posture requirements.

## Validation
- `sh tests/test-compose-security.sh`
- `TMPDIR=$PWD/.test-artifacts/tmp sh tests/test-pre-release-check.sh`
- `.squad/scripts/verify.sh`

## PR Checklist
- [x] Python lint (ruff) passed where applicable
- [x] Python format/test coverage passed through CI/validation where applicable
- [x] UI lint/format/tests passed through CI where applicable
- [x] Compose security regression and pre-release validation checks passed
- [x] Review threads resolved and linked issue verified
