### PR TITLE
docs: add v2.3.0 test report

### DIFF
--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -76,3 +76,7 @@
 - Admin import-safety, E2E stats/API field alignment, and admin logging allowlists improved CI reliability.
 - Lambert strengths: pytest fixtures, resilient Playwright E2E, CI/release gates, coverage audits.
 - Growth areas: deeper Vitest authoring, Locust/stress benchmarking, and documenting Solr auth requirements for E2E setup.
+
+### 2026-06-04T11:12:16.371+00:00 — v2.3.0 Pre-Release Evidence
+- For #1646, tie release test reports to both PR check rollups and focused local commands; avoid claiming exact test counts when GitHub check summaries do not expose them.
+- #1631 evidence hinges on `tests/test-compose-security.sh` plus `tests/test-pre-release-check.sh`: ZooKeeper ports stay private, Solr auth wiring is required, and accepted ZK/Solr config warnings are allowlisted without hiding real crashes or runtime connection failures.

--- a/.squad/agents/newt/history.md
+++ b/.squad/agents/newt/history.md
@@ -81,3 +81,5 @@
 11. **2026-03-22 — v1.12.1 release:** Branch protection blocks direct release pushes; use PRs for version bumps. CI integration tests can be flaky due to embeddings-server health timeouts, so distinguish infra flake from code regression.
 
 12. **2026-03-22 — Release decision:** v1.14.0 A/B UI should depend on benchmark need: if e5-base quality loss is negligible, skip UI and migrate; only build comparison UI when human quality judgment is needed.
+
+13. **2026-06-04 — v2.3.0 release docs:** Infrastructure maintenance releases require explicit operator-responsibility sections (ZooKeeper ACLs, Redis memory overcommit) in BOTH release notes and admin manual. Accepted-risk posture only holds when published where operators will find it during deployment. Release validation checklist should document framework first (accept blockers and constraints as legit) before test evidence arrives, reducing PM/infra/test interdependencies and making bottlenecks visible early.

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -2,7 +2,7 @@
 
 This manual covers deployment, configuration, monitoring, and troubleshooting for Aithena. If you are looking for end-user instructions, start with the [User Manual](user-manual.md). For the latest release features, see the [latest changelog](../CHANGELOG.md).
 
-**v1.15.0 / v1.16.0 / v1.17.0 / v1.18.0 / v1.19.0 / v2.0.0 / v2.2.0 / v2.2.1 operator note:** v1.15.0 includes admin portal enhancements (sidebar navigation, per-service log viewer, Solr SSO passthrough), critical bug fixes (document indexer OOM on large PDFs, thumbnail write failures), build-time dependency installation, and volume permission hardening. v1.16.0 adds search UI bug fixes, similar-books endpoint fix, admin dashboard pagination, nginx thumbnail routing fix, RabbitMQ deprecation warning fix, CI smoke test timeout fix, and a new pre-release container workflow. v1.17.0 introduces GPU acceleration for embeddings (opt-in via environment variables), security dependency updates (`requests`, `picomatch`), and comprehensive GPU documentation. v1.18.0 adds folder path facets for hierarchical search filtering, a comprehensive backup and disaster recovery system, stress-testing infrastructure, PDF embedded viewer fix, collections UI consistency fix, and CI/CD hardening. v1.18.1 patches the Solr auth role assignment to align with Solr 9.7 defaults and fixes the installer when run from the repo root. v1.19.0 adds configurable Solr topology (shards and replication factor), suppresses deprecation warnings from Solr 9.7 Security Manager and RabbitMQ 4.x, and includes 38+ dependency updates. **v2.0.0 is a major release:** replaces the Streamlit admin dashboard with a React SPA at `/admin/`, removes the `aithena-admin` container image, adds admin REST API endpoints, overhauled installer with GPU auto-detection and SSL, Solr 9/10 compatibility layer, and 119 integration tests + 38 accessibility tests. **v2.2.0** completes the prod-overlay volume migration work, fixes the Solr-init replication factor cap on single-node deployments, resolves a chronic CI E2E 429 rate-limit failure, and fixes a CodeQL security alert in the installer. **v2.2.1** is the follow-up maintenance patch for the 2.2.x line: it removes the remaining prod-overlay bind-mount overrides, preserves the single-node Solr safety guard, and improves release/test reliability. See the [v1.15.0 Deployment Updates](#deployment-updates-for-v1150), [v1.16.0 Deployment Updates](#deployment-updates-for-v1160), [v1.17.0 Deployment Updates](#deployment-updates-for-v1170), [v1.18.0 Deployment Updates](#deployment-updates-for-v1180), [v1.18.1 Deployment Updates](#deployment-updates-for-v1181), [v1.19.0 Deployment Updates](#deployment-updates-for-v1190), [v2.0.0 Deployment Updates](#deployment-updates-for-v200), [v2.2.0 Deployment Updates](#deployment-updates-for-v220), and [v2.2.1 Deployment Updates](#deployment-updates-for-v221) sections below.
+**v1.15.0 / v1.16.0 / v1.17.0 / v1.18.0 / v1.19.0 / v2.0.0 / v2.2.0 / v2.2.1 / v2.3.0 operator note:** v1.15.0 includes admin portal enhancements (sidebar navigation, per-service log viewer, Solr SSO passthrough), critical bug fixes (document indexer OOM on large PDFs, thumbnail write failures), build-time dependency installation, and volume permission hardening. v1.16.0 adds search UI bug fixes, similar-books endpoint fix, admin dashboard pagination, nginx thumbnail routing fix, RabbitMQ deprecation warning fix, CI smoke test timeout fix, and a new pre-release container workflow. v1.17.0 introduces GPU acceleration for embeddings (opt-in via environment variables), security dependency updates (`requests`, `picomatch`), and comprehensive GPU documentation. v1.18.0 adds folder path facets for hierarchical search filtering, a comprehensive backup and disaster recovery system, stress-testing infrastructure, PDF embedded viewer fix, collections UI consistency fix, and CI/CD hardening. v1.18.1 patches the Solr auth role assignment to align with Solr 9.7 defaults and fixes the installer when run from the repo root. v1.19.0 adds configurable Solr topology (shards and replication factor), suppresses deprecation warnings from Solr 9.7 Security Manager and RabbitMQ 4.x, and includes 38+ dependency updates. **v2.0.0 is a major release:** replaces the Streamlit admin dashboard with a React SPA at `/admin/`, removes the `aithena-admin` container image, adds admin REST API endpoints, overhauled installer with GPU auto-detection and SSL, Solr 9/10 compatibility layer, and 119 integration tests + 38 accessibility tests. **v2.2.0** completes the prod-overlay volume migration work, fixes the Solr-init replication factor cap on single-node deployments, resolves a chronic CI E2E 429 rate-limit failure, and fixes a CodeQL security alert in the installer. **v2.2.1** is the follow-up maintenance patch for the 2.2.x line: it removes the remaining prod-overlay bind-mount overrides, preserves the single-node Solr safety guard, and improves release/test reliability. **v2.3.0** is an infrastructure hardening release: enforces host-level Redis memory overcommit, documents ZooKeeper security posture constraints, and improves pre-release validation. See the [v1.15.0 Deployment Updates](#deployment-updates-for-v1150), [v1.16.0 Deployment Updates](#deployment-updates-for-v1160), [v1.17.0 Deployment Updates](#deployment-updates-for-v1170), [v1.18.0 Deployment Updates](#deployment-updates-for-v1180), [v1.18.1 Deployment Updates](#deployment-updates-for-v1181), [v1.19.0 Deployment Updates](#deployment-updates-for-v1190), [v2.0.0 Deployment Updates](#deployment-updates-for-v200), [v2.2.0 Deployment Updates](#deployment-updates-for-v220), [v2.2.1 Deployment Updates](#deployment-updates-for-v221), and [v2.3.0 Deployment Updates](#deployment-updates-for-v230) sections below.
 
 ## System architecture overview
 
@@ -5264,3 +5264,120 @@ v2.2.1 publishes the existing service images with the new release tag:
 | `ghcr.io/jmservera/aithena-document-lister:2.2.1` | Updated tag |
 | `ghcr.io/jmservera/aithena-embeddings-server:2.2.1` | Updated tag |
 | `ghcr.io/jmservera/aithena-solr-search:2.2.1` | Updated tag |
+
+## Deployment Updates for v2.3.0
+
+### Summary
+
+v2.3.0 is a **maintenance release focused on infrastructure hardening and operational clarity.** This release does not add user-facing features or API changes. Key changes affecting operators:
+
+1. **Pre-release deprecation cleanup (#1628)** — Known RabbitMQ deprecation warnings are now classified, reducing alert fatigue during validation.
+2. **Pre-release validation improvements (#1629)** — Pre-release log analysis is more precise, surfacing only actionable warnings.
+3. **Redis memory overcommit requirement (#1630)** — Host-level `vm.overcommit_memory=1` is now enforced in all deployment topologies and documented as a hard requirement.
+4. **ZooKeeper security posture publication (#1631)** — Accepted risk model for default ZooKeeper/Solr configuration is now documented; CI validation prevents accidental port publication.
+
+**Breaking Changes:** None. All services maintain API and schema compatibility.
+
+### Host Prerequisites (Updated for v2.3.0)
+
+#### Redis Memory Overcommit (Updated Requirement)
+
+**v2.3.0 enforces this requirement across all CI and deployment workflows.** The Docker host kernel must allow memory overcommit for Redis background snapshots (RDB save).
+
+**Required host configuration (before starting the Compose stack):**
+
+```bash
+# Apply immediately (non-persistent):
+sudo sysctl vm.overcommit_memory=1
+
+# Make persistent across reboots:
+echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/90-redis-overcommit.conf
+sudo sysctl --system
+```
+
+**Why this matters:**
+
+- CI workflows now validate this setting before starting the integration test stack.
+- Local developers must apply this setting to avoid `WARNING Memory overcommit must be enabled!` and RDB snapshot failures.
+- Production deployments should verify this is applied on the Docker host.
+
+#### ZooKeeper Security Posture (Production Constraint)
+
+**Aithena's default Docker Compose deployment does not enable ZooKeeper ACLs. This is an accepted security posture for non-regulated deployments.**
+
+**Key constraints:**
+
+- ZooKeeper ports (`2181`, `2888`, `3888`) **must NOT be published** outside the Compose network.
+- Solr BasicAuth and role-based access control (RBAC) protect all HTTP APIs.
+- The Compose network boundary is the security perimeter.
+
+**For regulated or multi-tenant deployments:**
+
+If your deployment requires ZooKeeper ACL-based access control, implement it per the [Apache Solr ZooKeeper Access Control guide](https://solr.apache.org/guide/solr/latest/deployment-guide/zookeeper-access-control.html). v2.3.0 CI validation will catch accidental port publication, but explicit ZooKeeper ACL setup must be done by the operator.
+
+### Upgrade Instructions
+
+**From v2.2.1 → v2.3.0:**
+
+1. **Apply/verify host prerequisites (IMPORTANT):**
+   ```bash
+   # Check Redis memory overcommit setting
+   grep vm.overcommit_memory /proc/sys/vm/overcommit_memory
+   # Should return: 1
+   
+   # If not set, apply it now
+   sudo sysctl vm.overcommit_memory=1
+   echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/90-redis-overcommit.conf
+   sudo sysctl --system
+   ```
+
+2. **Pull the latest service images:**
+   ```bash
+   docker compose pull
+   ```
+
+3. **Restart services:**
+   ```bash
+   docker compose up -d
+   # or
+   ./start.sh
+   ```
+
+4. **Verify health:**
+   ```bash
+   curl -sf http://localhost/v1/health | jq .
+   curl -sf http://localhost/admin && echo "✅ Admin portal accessible"
+   
+   # Check Redis memory overcommit is working
+   docker compose logs redis | grep -i "memory overcommit" || echo "✅ No warnings"
+   ```
+
+### Configuration Changes
+
+| Change | File | Required action |
+|---|---|---|
+| Enforce Redis memory overcommit (`vm.overcommit_memory=1`) on Docker host | Host sysctl | **REQUIRED.** Apply before starting Compose. |
+| Classify known RabbitMQ deprecation warnings | `e2e/pre-release-allowlist.txt` | No operator action. Reduces validation noise. |
+| Improve pre-release log analysis heuristics | `e2e/pre-release-check.sh` | No operator action. More precise warning detection. |
+| Document ZooKeeper security posture constraint | `docs/admin-manual.md` | No operator action. Do not publish ZooKeeper ports. |
+
+### Data Migration
+
+**No application-level data migration is required.** Solr schema, auth storage, and API contracts are unchanged.
+
+### Container Image Changes
+
+v2.3.0 publishes the existing service images with the new release tag:
+
+| Image | Status |
+|---|---|
+| `ghcr.io/jmservera/aithena-aithena-ui:2.3.0` | Updated tag |
+| `ghcr.io/jmservera/aithena-document-indexer:2.3.0` | Updated tag |
+| `ghcr.io/jmservera/aithena-document-lister:2.3.0` | Updated tag |
+| `ghcr.io/jmservera/aithena-embeddings-server:2.3.0` | Updated tag |
+| `ghcr.io/jmservera/aithena-solr-search:2.3.0` | Updated tag |
+
+### Known Limitations
+
+- **RabbitMQ deprecation warnings:** Allowlisted in v2.3.0. These are informational and do not indicate functional problems.
+- **Pre-release validation:** No longer surfaces allowlisted warnings, improving signal-to-noise ratio during release operations.

--- a/docs/release-notes/v2.3.0.md
+++ b/docs/release-notes/v2.3.0.md
@@ -1,0 +1,190 @@
+# Aithena v2.3.0 Release Notes — Infrastructure Hardening
+
+_Date:_ 2026-06-04
+_Prepared by:_ Newt (Product Manager)
+
+## Summary
+
+Aithena v2.3.0 is a maintenance release focused on infrastructure hardening and operational reliability. This release consolidates deprecation warnings, hardens security posture for ZooKeeper and Solr, and improves CI/CD validation. It does not introduce new user-facing features or API changes.
+
+### Highlights
+
+1. **Pre-release deprecation cleanup (#1628)** — Classifies known RabbitMQ deprecation warnings to reduce operator confusion during container startup.
+2. **Pre-release connection warning noise reduction (#1629)** — Improves pre-release log analysis to focus on actionable warnings, reducing false positives during validation.
+3. **Redis memory overcommit hardening (#1630)** — Ensures Redis background save reliability across all deployment topologies by requiring host-level `vm.overcommit_memory=1` configuration.
+4. **ZooKeeper/Solr security posture documentation (#1631)** — Publishes accepted risk model for default ZooKeeper/Solr BasicAuth configuration and establishes CI validation to prevent accidental port publication.
+
+---
+
+## Notable Changes
+
+- **#1628** — `chore(release): Classify known RabbitMQ deprecation` — Adds RabbitMQ deprecation patterns to pre-release allowlist so only new warnings surface during validation.
+- **#1629** — `fix: Reduce pre-release connection warning noise` — Refines pre-release check heuristics to distinguish informational logs from genuine issues.
+- **#1630** — `fix(ci): Set Redis overcommit before Compose startup` — Ensures CI workflows apply host sysctl before starting the stack; documents operator requirement in admin manual.
+- **#1631** — `fix(ci): Keep ZooKeeper private in validation stacks` — Adds CI regression check to prevent accidental publication of ZooKeeper ports; updates admin manual with security posture documentation.
+
+---
+
+## Breaking Changes
+
+No breaking changes. All services maintain API compatibility. There are no schema or data model changes.
+
+---
+
+## Operator Responsibilities (v2.3.0)
+
+### ZooKeeper ACLs (Accepted Risk)
+
+Aithena's default Docker Compose deployment does **not** enable ZooKeeper ACLs. This is an **accepted security posture** because:
+
+- ZooKeeper is only exposed on the private Compose network (no ports published to host by default).
+- Solr BasicAuth and role-based access control (RBAC) protect all HTTP APIs.
+- The Compose network boundary is the security perimeter for unregulated deployments.
+
+**Production Constraint:** Do not publish ZooKeeper ports (`2181`, `2888`, `3888`) outside the Compose network. If your deployment requires multi-tenant isolation or regulated data access, implement ZooKeeper ACLs per the [Apache Solr ZooKeeper Access Control guide](https://solr.apache.org/guide/solr/latest/deployment-guide/zookeeper-access-control.html).
+
+See the [Admin Manual — ZooKeeper credentials (production hardening)](../admin-manual.md#zookeeper-credentials-production-hardening) section for detailed guidance.
+
+### Redis Memory Overcommit (Required)
+
+Redis requires the Docker host kernel to allow memory overcommit for background snapshots (RDB save). Without this setting, Redis logs `WARNING Memory overcommit must be enabled!` and background saves may fail.
+
+**Deployment requirement:** Apply `vm.overcommit_memory=1` on the Docker host before starting the Compose stack.
+
+```bash
+# Apply immediately (non-persistent):
+sudo sysctl vm.overcommit_memory=1
+
+# Make persistent across reboots:
+echo "vm.overcommit_memory = 1" | sudo tee /etc/sysctl.d/90-redis-overcommit.conf
+sudo sysctl --system
+```
+
+See the [Admin Manual — Redis memory overcommit](../admin-manual.md#redis-memory-overcommit) section for more information.
+
+---
+
+## Upgrade Instructions
+
+### For Users Upgrading from v2.2.0 or v2.2.1
+
+1. **Apply host-level sysctl (new requirement):**
+   ```bash
+   sudo sysctl vm.overcommit_memory=1
+   ```
+
+2. **Pull the latest images:**
+   ```bash
+   docker compose pull
+   ```
+
+3. **Restart the stack:**
+   ```bash
+   docker compose up -d
+   ```
+
+4. **Verify services:**
+   ```bash
+   curl -sf http://localhost/v1/health && echo "✅ API healthy"
+   curl -sf http://localhost/admin && echo "✅ Admin portal accessible"
+   ```
+
+### For Fresh Installations
+
+```bash
+# 1. Apply host-level sysctl
+sudo sysctl vm.overcommit_memory=1
+
+# 2. Run the installer
+python3 -m installer
+
+# 3. Start the stack
+./start.sh
+
+# 4. Wait for services to stabilize (20–30 seconds)
+sleep 30
+
+# 5. Run health checks
+curl -sf http://localhost/v1/health | jq .
+
+# 6. Test the UI
+curl -sf http://localhost/ | head -20
+
+# 7. Run E2E tests (if available)
+npx playwright test --headed
+```
+
+---
+
+## Validation Steps
+
+### Pre-Release Check (CI)
+
+The pre-release validation workflow checks:
+
+- ✅ No unclassified deprecation warnings in container logs
+- ✅ ZooKeeper ports are private (not published via Compose)
+- ✅ Solr collection health is GREEN
+- ✅ API health endpoint responds
+- ✅ Admin portal is accessible
+
+### Operator Validation
+
+After upgrading to v2.3.0, verify:
+
+```bash
+# 1. Host sysctl is applied
+grep vm.overcommit_memory /proc/sys/vm/overcommit_memory
+# Should return: 1
+
+# 2. Redis is healthy
+curl -s http://localhost:6379 && echo "✅ Redis accessible"
+
+# 3. ZooKeeper ports are not exposed on host
+netstat -tuln | grep -E "(2181|2888|3888)" || echo "✅ ZooKeeper ports private"
+
+# 4. Service health
+curl -sf http://localhost/v1/health | jq .
+
+# 5. Container logs (check for RabbitMQ deprecation only — it is allowlisted)
+docker compose logs | grep -i warning | head -10
+```
+
+---
+
+## Known Issues & Limitations
+
+- **RabbitMQ 4.x deprecation warnings:** Issue #1628 allowlists known RabbitMQ deprecated-feature warnings. These do not indicate functional problems and are expected until RabbitMQ 4.x features are stabilized upstream.
+- **Pre-release validation noise:** Issue #1629 reduces false positives in pre-release log analysis. Some informational logs may still surface; they are not blockers.
+
+---
+
+## Dependencies & Prerequisites
+
+- **Docker** v20.10 or later
+- **Docker Compose** v2.0 or later
+- **Python** 3.12+ with `uv`; run the repo-local installer with `uv run installer/setup.py`
+- **Host kernel setting:** `vm.overcommit_memory=1` (required for Redis background saves)
+
+---
+
+## Closed Issues & References
+
+- **#1628** — `chore(release): Classify known RabbitMQ deprecation`
+- **#1629** — `fix: Reduce pre-release connection warning noise`
+- **#1630** — `fix(ci): Set Redis overcommit before Compose startup`
+- **#1631** — `fix(ci): Keep ZooKeeper private in validation stacks`
+
+---
+
+## Contributors
+
+- **Newt** (Product Manager) — Release coordination and documentation
+- **Ripley** (Lead) — Architectural review and approval
+- **Brett** (Infra Architect) — Infrastructure hardening and CI validation
+- **Kane** (Security Engineer) — Security posture review
+- **Copilot** (Coding Agent) — Implementation and coordination
+
+---
+
+For detailed technical information, see [CHANGELOG.md](https://github.com/jmservera/aithena/blob/main/CHANGELOG.md), the [v2.3.0 Test Report](../test-reports/v2.3.0.md), and the [Admin Manual](../admin-manual.md).

--- a/docs/test-reports/v2.3.0.md
+++ b/docs/test-reports/v2.3.0.md
@@ -1,0 +1,102 @@
+# Test Report — v2.3.0
+
+| Field | Value |
+|---|---|
+| **Version** | 2.3.0 |
+| **Date** | 2026-06-04T11:12:16.371+00:00 |
+| **Runner** | Lambert (Tester) |
+| **Issue** | #1646 |
+| **Verdict** | ✅ **Pass for pre-release evidence captured so far** — active target is v2.3.0 on `dev`; `main` remains v2.2.1. The release is not tagged here. CI evidence for PRs #1649 and #1650 is green, and focused local validation for the pre-release warning path passed. |
+
+---
+
+## Active Release Target
+
+- `VERSION` on local `dev` and `origin/dev`: `2.3.0-dev`
+- `VERSION` on `main` and `origin/main`: `2.2.1`
+- Latest v2 tag observed: `v2.2.1`
+- Scope respected: this report addresses v2.3.0 issue #1646 and the closed v2.3.0 pre-release config warning issue #1631. v2.5 research issues were not touched.
+
+---
+
+## Summary
+
+v2.3.0 is currently a maintenance/infrastructure pre-release cycle centered on #1631: pre-release log analyzer config warnings from ZooKeeper and Solr startup posture. The implemented evidence path is:
+
+1. Keep ZooKeeper client ports private in CI validation stacks while exposing only ports needed by automated tests.
+2. Add a Compose security regression check to CI.
+3. Require Solr auth variables in pre-release readiness checks instead of silently falling back to unauthenticated probes.
+4. Allowlist accepted ZooKeeper/Solr startup config noise without hiding real crash, connection, or security findings.
+5. Validate the follow-up Squad coordinator workflow/security changes in #1650 after #1649 merged.
+
+No release tag was pushed and no release publication was attempted.
+
+---
+
+## CI / Check Evidence
+
+| Artifact | Result | Evidence |
+|---|---:|---|
+| PR #1649 — Keep ZooKeeper private in CI validation stacks | ✅ Merged / green | `CI - Unit & Integration Tests` passed, including `document-indexer tests`, `solr-search tests`, `aithena-ui tests`, `document-lister tests`, `embeddings-server tests`, `Python lint (ruff)`, `Compose security regression`, and `All tests passed`. `Dev Integration Test (Single-Node)` passed, including `Run integration & E2E tests`. `Security Scanning` passed: Bandit, Checkov, zizmor. CodeQL passed for actions, JavaScript/TypeScript, and Python. |
+| PR #1650 — Squad coordinator upgrade to v0.9.4 | ✅ Merged / green | Same required CI matrix passed after the workflow/agent upgrade: unit/integration jobs, Compose security regression, single-node integration/E2E, Security Scanning, and CodeQL. |
+| Dependabot Manager checks on both PRs | ⏭️ Skipped | Skips were unrelated to this release evidence path; required CI/security checks were green. |
+
+Representative check links captured from GitHub:
+
+- PR #1649 CI all-tests job: https://github.com/jmservera/aithena/actions/runs/26925247266/job/79434104650
+- PR #1649 single-node integration job: https://github.com/jmservera/aithena/actions/runs/26925247258/job/79434520172
+- PR #1650 CI all-tests job: https://github.com/jmservera/aithena/actions/runs/26947198064/job/79503359545
+- PR #1650 single-node integration job: https://github.com/jmservera/aithena/actions/runs/26947198202/job/79503989568
+
+---
+
+## Local Validation Evidence
+
+Executed from repo root at the release target state.
+
+| Command | Result | Notes |
+|---|---:|---|
+| `sh tests/test-pre-release-check.sh` | ✅ Pass | 38 assertions passed, 0 failed. Confirms clean logs, fatal errors, warning exit codes, allowlist behavior, startup retry filtering, runtime connection warning detection, and accepted ZooKeeper/Solr config posture filtering. |
+| `bash tests/test-compose-security.sh` | ✅ Pass | Validated default CI topology, single-node CI topology, and production topology. Confirms ZooKeeper services do not publish host ports and Solr services carry auth variables. |
+| `docker compose -f docker-compose.yml -f docker/compose.ci-ports.yml -f docker/compose.e2e.yml --profile production config >/dev/null` | ✅ Pass | Merged CI/E2E Compose config renders successfully. |
+
+---
+
+## Per-Service / Gate Breakdown
+
+| Area | Status | Evidence |
+|---|---:|---|
+| document-indexer | ✅ Pass in CI | PRs #1649 and #1650 both report `document-indexer tests` success. |
+| solr-search | ✅ Pass in CI | PRs #1649 and #1650 both report `solr-search tests` success. |
+| aithena-ui | ✅ Pass in CI | PRs #1649 and #1650 both report lint, format, build, and Vitest through `aithena-ui tests` success. UI source was not part of #1631. |
+| document-lister | ✅ Pass in CI | PRs #1649 and #1650 both report `document-lister tests` success. |
+| embeddings-server | ✅ Pass in CI | PRs #1649 and #1650 both report `embeddings-server tests` success. |
+| Python lint | ✅ Pass in CI | PRs #1649 and #1650 both report `Python lint (ruff)` success. |
+| Compose security regression | ✅ Pass in CI and local | CI job passed on both PRs; local `tests/test-compose-security.sh` passed. |
+| Single-node integration/E2E | ✅ Pass in CI | PRs #1649 and #1650 both report `Dev integration tests (single-node)` and `Run integration & E2E tests` success. |
+| Security scanning | ✅ Pass in CI | Bandit, Checkov, zizmor, and CodeQL passed on both PRs. |
+
+---
+
+## Critical Validations
+
+- **#1631 warning closure:** `e2e/pre-release-allowlist.txt` now explicitly accepts known ZooKeeper/Solr startup config posture: ZooKeeper client/secure/observer port config lines, `maxCnxns` startup noise, and Solr default ZooKeeper credential/ACL provider notices.
+- **No hidden crash path:** `tests/test-pre-release-check.sh` still proves fatal/crash findings exit with error and allowlisted noise does not suppress unrelated real errors.
+- **Runtime connection warnings preserved:** the local analyzer test confirms real runtime connection failures remain warnings after startup-window filtering.
+- **ZooKeeper host exposure regression covered:** `tests/test-compose-security.sh` rejects published ZooKeeper ports and validates all relevant Solr services expose auth environment keys.
+- **CI wiring covered:** `.github/workflows/ci.yml` runs `Compose security regression` as part of the required all-tests aggregate when build-relevant changes exist.
+
+---
+
+## Known Gaps / Accepted Risks
+
+- The full `Pre-release Validation` workflow was not rerun locally because it builds and starts the full Docker stack, installs E2E dependencies, and runs browser tests; this is better represented by GitHub Actions evidence. The related single-node integration/E2E workflow passed for PRs #1649 and #1650.
+- The local evidence does not prove production ZooKeeper ACL hardening. The report only records the accepted current posture: default ZooKeeper credentials/ACL provider warnings are treated as known config noise inside the private Compose network.
+- CI check output available through GitHub PR checks confirms job success, but this report does not claim exact per-service test counts because the PR check summary did not expose full test totals.
+- Release documentation issues #1645, #1647, and #1648 remain separate open v2.3.0 release-gate items owned by Newt.
+
+---
+
+## Release-Gate Conclusion
+
+For issue #1646, the v2.3.0 test evidence file is present and grounded in real CI and local validation. The current evidence supports continuing the v2.3.0 pre-release process, subject to Newt completing the remaining release notes/manual/checklist documentation and any final release approval gate.

--- a/docs/v2.3.0-RELEASE-VALIDATION-CHECKLIST.md
+++ b/docs/v2.3.0-RELEASE-VALIDATION-CHECKLIST.md
@@ -1,0 +1,169 @@
+# v2.3.0 Release Validation Checklist
+
+**Version:** 2.3.0  
+**Target Date:** 2026-06-11  
+**Release Type:** Maintenance (Infrastructure Hardening)  
+**Status:** ⏳ IN PROGRESS (Documentation & Validation Coordination Phase)
+
+---
+
+## Pre-Release Checklist
+
+### Milestone Scope
+
+- [ ] **All issues in v2.3.0 milestone are closed or moved**
+  - Closed issues: #1628, #1629, #1630, #1631 (infrastructure PRs merged to dev)
+  - Open issues: #1645 (release notes), #1646 (test report), #1647 (manual updates), #1648 (this checklist)
+  - Ready to move to v2.4 backlog: _(none identified yet)_
+
+### Release Documentation
+
+- [x] **Release notes drafted** — `docs/release-notes/v2.3.0.md`
+  - Covers all 4 infrastructure hardening topics (#1628–#1631)
+  - Documents operator responsibilities (ZooKeeper ACLs, Redis memory overcommit)
+  - Includes breaking changes (none), upgrade instructions, and validation steps
+
+- [x] **Admin manual updated** — `docs/admin-manual.md`
+  - Section 1: Expanded ZooKeeper credentials documentation with security implications
+  - Section 2: Updated Redis memory overcommit requirement with host-level enforcement note
+  - Section 3: Added v2.3.0 deployment updates subsection
+  - Includes operator constraints and required host prerequisites
+
+- [ ] **User manual review** — `docs/user-manual.md`
+  - **Assessment:** No user-visible changes. v2.3.0 is operator/infrastructure-only.
+  - **Conclusion:** No user manual updates required.
+  - **Rationale:** #1628–#1631 cover pre-release validation, CI hardening, and security posture documentation. No new features, API changes, or UI modifications.
+
+### Test Evidence (Pending Lambert)
+
+- [ ] **Test report framework** — `docs/test-reports/v2.3.0.md`
+  - **Status:** Placeholder prepared, pending Lambert implementation evidence
+  - **Required evidence:**
+    - [ ] Service tests pass for #1628–#1631 changes (if applicable)
+    - [ ] Frontend/build status (if touched; confirm not touched)
+    - [ ] Docker Compose pre-release validation status
+    - [ ] Known limitations and accepted risks
+
+- [ ] **CI validation log**
+  - [ ] Pre-release validation workflow passed on latest dev commit
+  - [ ] Compose security regression test passed (ZooKeeper ports private)
+  - [ ] Redis overcommit setting enforced in CI workflows
+
+### Accepted Risk Documentation
+
+- [x] **#1631 ZooKeeper ACL constraint documented**
+  - Published in admin manual: "ZooKeeper credentials (production hardening)" section
+  - Published in release notes: "Operator Responsibilities (v2.3.0)" section
+  - Constraint: Do not publish ZooKeeper ports (`2181`, `2888`, `3888`) outside Compose network
+  - Accepted posture: Default deployment uses Solr BasicAuth + network boundary as security perimeter
+  - Migration path: For regulated deployments, implement ZooKeeper ACLs per Apache Solr guide
+
+- [x] **#1630 Redis memory overcommit requirement documented**
+  - Published in admin manual: "Redis memory overcommit" section (expanded)
+  - Published in release notes: "Operator Responsibilities (v2.3.0)" section
+  - Requirement: Host must apply `vm.overcommit_memory=1` before starting Compose
+  - CI enforcement: All workflows validate this before starting integration tests
+
+### Deployment Configuration
+
+- [ ] **Configuration files validated**
+  - [ ] `docker-compose.yml` — no breaking changes
+  - [ ] `docker/compose.prod.yml` — no breaking changes
+  - [ ] `docker/compose.single-node.yml` — no breaking changes
+  - [ ] `.env.example` — updated if needed (confirm no changes required)
+  - [ ] `src/redis/redis.conf` — no changes (existing `stop-writes-on-bgsave-error no` remains)
+
+- [ ] **Host-level requirements documented**
+  - [x] Redis memory overcommit: `vm.overcommit_memory=1` (documented in admin manual + release notes)
+  - [x] ZooKeeper port constraints: no publication outside Compose (documented in admin manual + release notes)
+
+### Security & Compliance
+
+- [x] **Security review completed**
+  - No new code vulnerabilities introduced
+  - CI infrastructure hardened (ZooKeeper ports now validated as private)
+  - Accepted risks documented with clear migration path
+  - No CVEs or high-severity security issues
+
+- [ ] **Dependency audit**
+  - [ ] No new dependencies introduced for #1628–#1631
+  - [ ] No major version bumps in dependencies
+  - [ ] Existing vulnerability baseline unchanged
+
+### Container Images
+
+- [ ] **Images published with v2.3.0 tag**
+  - [ ] `ghcr.io/jmservera/aithena-aithena-ui:2.3.0`
+  - [ ] `ghcr.io/jmservera/aithena-document-indexer:2.3.0`
+  - [ ] `ghcr.io/jmservera/aithena-document-lister:2.3.0`
+  - [ ] `ghcr.io/jmservera/aithena-embeddings-server:2.3.0`
+  - [ ] `ghcr.io/jmservera/aithena-solr-search:2.3.0`
+
+- [ ] **Container startup validation**
+  - [ ] All containers start successfully with v2.3.0 images
+  - [ ] No startup errors in logs related to #1628–#1631 changes
+  - [ ] Health checks pass for all services
+
+---
+
+## Release Gate Sign-Off (Newt)
+
+| Checklist Item | Status | Notes |
+|---|---|---|
+| Milestone scope clearly defined | ✅ | 4 infrastructure PRs (#1628–#1631) merged to dev; 4 release doc issues (#1645–#1648) in progress |
+| Release notes complete and accurate | ✅ | `docs/release-notes/v2.3.0.md` created with full operator responsibilities |
+| Admin manual updated appropriately | ✅ | ZooKeeper & Redis sections expanded; v2.3.0 deployment subsection added |
+| User manual review completed | ✅ | No changes required (infrastructure-only release) |
+| Test report framework prepared | ⏳ | Awaiting Lambert evidence for #1646 |
+| Accepted risks clearly documented | ✅ | ZooKeeper ACLs and Redis memory overcommit constraints published |
+| Configuration validated | ⏳ | Pending final CI validation |
+| Security/compliance review passed | ✅ | No vulnerabilities; no CVEs; accepted risks documented |
+| Container images ready | ⏳ | Awaiting final image build and publication |
+
+---
+
+## Newt Release-Gate Verdict
+
+**Status:** ⏳ **PENDING** (Awaiting Lambert evidence for #1646)
+
+**Blockers:**
+- [ ] Lambert test report evidence (#1646) not yet available
+- [ ] Container images not yet published to GHCR
+
+**Approved (Conditional):**
+- ✅ Release notes are accurate and complete
+- ✅ Admin manual is updated appropriately
+- ✅ User manual impact is documented (no changes required)
+- ✅ Accepted risks are clearly stated
+- ⏳ Test evidence framework is prepared; awaiting implementation results
+
+**Next Steps:**
+1. Lambert completes test evidence for #1646 (expected by 2026-06-10)
+2. Newt verifies test evidence and updates this checklist
+3. Container images are published to GHCR (expected during final release build)
+4. Newt records final release-gate approval
+
+**Final Sign-Off:** _(Pending test evidence)_  
+**Signed by:** Newt (Product Manager)  
+**Date:** _(To be recorded on v2.3.0 release)_
+
+---
+
+## Related Issues
+
+- **#1645** — Release notes (this checklist references `docs/release-notes/v2.3.0.md`)
+- **#1646** — Test report (framework prepared; evidence pending)
+- **#1647** — User/admin manual updates (completed)
+- **#1648** — Release validation checklist (this document)
+
+## Implementation Issues (All Closed)
+
+- **#1628** — Pre-release deprecation cleanup (Merged)
+- **#1629** — Pre-release connection warning noise reduction (Merged)
+- **#1630** — Redis memory overcommit hardening (Merged)
+- **#1631** — ZooKeeper security posture documentation (Merged)
+
+---
+
+**Last Updated:** 2026-06-04  
+**Updated by:** Newt (Product Manager)


### PR DESCRIPTION
Closes #1646

Working as Lambert (Tester).

## Summary
- Added docs/test-reports/v2.3.0.md using the existing test-report convention.
- Captured active release target evidence: dev is 2.3.0-dev, main is 2.2.1; no release tags pushed.
- Documented CI/check evidence for PRs #1649 and #1650 plus focused local validation.
- Appended Lambert history learnings for future release evidence work.

## Validation
- sh tests/test-pre-release-check.sh
- bash tests/test-compose-security.sh
- docker compose -f docker-compose.yml -f docker/compose.ci-ports.yml -f docker/compose.e2e.yml --profile production config >/dev/null
- .squad/scripts/verify.sh

## Notes
- Full pre-release validation workflow was not rerun locally because it builds/starts the full stack and runs browser E2E; CI evidence is documented instead.
- Existing uncommitted files in the shared checkout were not included in this branch commit.
