### PR TITLE
Migrate HNSW schema parameters for Solr 10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -826,7 +826,7 @@ services:
           # --- books collection (multilingual-e5-base, 768D) ---
           CONFIGSET_DIR="/configsets/books"
           if [ "$${SOLR_VERSION:-9}" = "9" ]; then
-            CONFIGSET_DIR="/opt/solr/books-configset-solr9"
+            CONFIGSET_DIR="/var/solr/books-configset-solr9"
             mkdir -p "$$CONFIGSET_DIR"
             cp -R /configsets/books/. "$$CONFIGSET_DIR"/
             sed -i \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -830,8 +830,8 @@ services:
             mkdir -p "$$CONFIGSET_DIR"
             cp -R /configsets/books/. "$$CONFIGSET_DIR"/
             sed -i \
-              -e 's/hnswM=/hnswMaxConnections=/g' \
-              -e 's/hnswEfConstruction=/hnswBeamWidth=/g' \
+              -e 's/hnswM="/hnswMaxConnections="/g' \
+              -e 's/hnswEfConstruction="/hnswBeamWidth="/g' \
               "$$CONFIGSET_DIR/managed-schema.xml"
           fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -824,9 +824,20 @@ services:
           fi
 
           # --- books collection (multilingual-e5-base, 768D) ---
+          CONFIGSET_DIR="/configsets/books"
+          if [ "$${SOLR_VERSION:-9}" = "9" ]; then
+            CONFIGSET_DIR="/opt/solr/books-configset-solr9"
+            mkdir -p "$$CONFIGSET_DIR"
+            cp -R /configsets/books/. "$$CONFIGSET_DIR"/
+            sed -i \
+              -e 's/hnswM=/hnswMaxConnections=/g' \
+              -e 's/hnswEfConstruction=/hnswBeamWidth=/g' \
+              "$$CONFIGSET_DIR/managed-schema.xml"
+          fi
+
           echo "[solr-init] Uploading configset..."
           if ! solr zk ls /configs -z "$$ZK_HOST" | grep -qx 'books'; then
-            solr zk upconfig -z "$$ZK_HOST" -n books -d /configsets/books
+            solr zk upconfig -z "$$ZK_HOST" -n books -d "$$CONFIGSET_DIR"
           fi
 
           echo "[solr-init] Creating collection (shards=$$NUM_SHARDS, replicas=$$REPLICATION_FACTOR)..."

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -733,7 +733,7 @@ services:
 
           CONFIGSET_DIR="/configsets/books"
           if [ "$${SOLR_VERSION:-9}" = "9" ]; then
-            CONFIGSET_DIR="/opt/solr/books-configset-solr9"
+            CONFIGSET_DIR="/var/solr/books-configset-solr9"
             mkdir -p "$$CONFIGSET_DIR"
             cp -R /configsets/books/. "$$CONFIGSET_DIR"/
             sed -i \

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -737,8 +737,8 @@ services:
             mkdir -p "$$CONFIGSET_DIR"
             cp -R /configsets/books/. "$$CONFIGSET_DIR"/
             sed -i \
-              -e 's/hnswM=/hnswMaxConnections=/g' \
-              -e 's/hnswEfConstruction=/hnswBeamWidth=/g' \
+              -e 's/hnswM="/hnswMaxConnections="/g' \
+              -e 's/hnswEfConstruction="/hnswBeamWidth="/g' \
               "$$CONFIGSET_DIR/managed-schema.xml"
           fi
 

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -731,8 +731,19 @@ services:
             echo "WARNING: SOLR_REPLICATION_FACTOR=$$REPLICATION_FACTOR exceeds the default 3-node topology. Ensure you have enough Solr nodes." >&2
           fi
 
+          CONFIGSET_DIR="/configsets/books"
+          if [ "$${SOLR_VERSION:-9}" = "9" ]; then
+            CONFIGSET_DIR="/opt/solr/books-configset-solr9"
+            mkdir -p "$$CONFIGSET_DIR"
+            cp -R /configsets/books/. "$$CONFIGSET_DIR"/
+            sed -i \
+              -e 's/hnswM=/hnswMaxConnections=/g' \
+              -e 's/hnswEfConstruction=/hnswBeamWidth=/g' \
+              "$$CONFIGSET_DIR/managed-schema.xml"
+          fi
+
           if ! solr zk ls /configs -z "$$ZK_HOST" | grep -q 'books'; then
-            solr zk upconfig -z "$$ZK_HOST" -n books -d /configsets/books
+            solr zk upconfig -z "$$ZK_HOST" -n books -d "$$CONFIGSET_DIR"
           fi
 
           if ! curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=LIST&wt=json" | grep -q '"books"'; then

--- a/docker/solr-init.sh
+++ b/docker/solr-init.sh
@@ -115,8 +115,19 @@ if [ "${REPLICATION_FACTOR}" -gt "${EXPECTED_NODES}" ]; then
 fi
 
 # ── books collection (multilingual-e5-base, 768D) ────────────────────────────
+CONFIGSET_DIR="/configsets/books"
+if [ "${SOLR_VERSION:-9}" = "9" ]; then
+  CONFIGSET_DIR="/opt/solr/books-configset-solr9"
+  mkdir -p "${CONFIGSET_DIR}"
+  cp -R /configsets/books/. "${CONFIGSET_DIR}"/
+  sed -i \
+    -e 's/hnswM=/hnswMaxConnections=/g' \
+    -e 's/hnswEfConstruction=/hnswBeamWidth=/g' \
+    "${CONFIGSET_DIR}/managed-schema.xml"
+fi
+
 if ! solr zk ls /configs -z "${ZK_HOST}" | grep -qx 'books'; then
-  solr zk upconfig -z "${ZK_HOST}" -n books -d /configsets/books
+  solr zk upconfig -z "${ZK_HOST}" -n books -d "${CONFIGSET_DIR}"
 fi
 
 if ! curl -fsS -u "${SOLR_AUTH_USER}:${SOLR_AUTH_PASS}" \

--- a/docker/solr-init.sh
+++ b/docker/solr-init.sh
@@ -117,7 +117,7 @@ fi
 # ── books collection (multilingual-e5-base, 768D) ────────────────────────────
 CONFIGSET_DIR="/configsets/books"
 if [ "${SOLR_VERSION:-9}" = "9" ]; then
-  CONFIGSET_DIR="/opt/solr/books-configset-solr9"
+  CONFIGSET_DIR="/var/solr/books-configset-solr9"
   mkdir -p "${CONFIGSET_DIR}"
   cp -R /configsets/books/. "${CONFIGSET_DIR}"/
   sed -i \

--- a/docker/solr-init.sh
+++ b/docker/solr-init.sh
@@ -121,8 +121,8 @@ if [ "${SOLR_VERSION:-9}" = "9" ]; then
   mkdir -p "${CONFIGSET_DIR}"
   cp -R /configsets/books/. "${CONFIGSET_DIR}"/
   sed -i \
-    -e 's/hnswM=/hnswMaxConnections=/g' \
-    -e 's/hnswEfConstruction=/hnswBeamWidth=/g' \
+    -e 's/hnswM="/hnswMaxConnections="/g' \
+    -e 's/hnswEfConstruction="/hnswBeamWidth="/g' \
     "${CONFIGSET_DIR}/managed-schema.xml"
 fi
 

--- a/docs/migration/solr-9-to-10.md
+++ b/docs/migration/solr-9-to-10.md
@@ -56,9 +56,10 @@
 | `book_embedding` | `knn_vector_768` | Book-level semantic search (768D, cosine) |
 | `embedding_v` | `knn_vector_768` | Chunk-level embedding for granular search |
 
-**HNSW configuration**: The vector field types use Solr defaults and do not set
-version-specific HNSW attributes. Upload the updated configset and run a full
-reindex when moving an existing collection from Solr 9 to Solr 10.
+**HNSW configuration**: The source configset uses Solr 10 HNSW names. During
+the compatibility window, `solr-init` rewrites those names before uploading to
+Solr 9. Upload the updated configset and run a full reindex when moving an
+existing collection from Solr 9 to Solr 10.
 
 **Key fields** (book metadata, ADR-002):
 - `title_s`/`title_t`, `author_s`/`author_t`, `year_i`, `category_s`, `language_detected_s`, `series_s`
@@ -143,17 +144,18 @@ All `solr` CLI commands now require full double-dash flags. This breaks every `s
 - `docker-compose.yml` — solr-init entrypoint (lines ~710–798)
 - `docker/compose.prod.yml` — solr-init entrypoint (lines ~658–736)
 
-### 2.2 HNSW Parameter Renames (🟢 Guarded by Defaults)
+### 2.2 HNSW Parameter Renames (🟡 Requires Configset Upload + Reindex)
 
 | Solr 9 | Solr 10 |
 |--------|---------|
 | `hnswMaxConnections` | `hnswM` |
 | `hnswBeamWidth` | `hnswEfConstruction` |
 
-**Our impact**: The active configset omits these version-specific attributes, so
-it remains valid on both Solr 9 and Solr 10. If explicit HNSW tuning is restored,
-use the Solr 10 names before uploading to Solr 10 and perform a full reindex so
-HNSW graphs are rebuilt with the updated schema.
+**Our impact**: The byte-vector type uses custom graph tuning. The source
+configset now uses Solr 10 names (`hnswM`, `hnswEfConstruction`); Solr 9
+bootstrap rewrites them during upload. After uploading the updated configset to
+Solr 10, perform a full reindex so HNSW graphs are rebuilt with the Solr 10
+schema.
 
 ### 2.3 `blockUnknown` Default Change (🟡 Medium Impact)
 

--- a/docs/migration/solr-9-to-10.md
+++ b/docs/migration/solr-9-to-10.md
@@ -56,7 +56,9 @@
 | `book_embedding` | `knn_vector_768` | Book-level semantic search (768D, cosine) |
 | `embedding_v` | `knn_vector_768` | Chunk-level embedding for granular search |
 
-**HNSW configuration**: Uses defaults — `hnswMaxConnections` and `hnswBeamWidth` are **not** explicitly set in the schema. This simplifies migration since the Solr 10 parameter renames (`hnswM`, `hnswEfConstruction`) do not require a schema edit.
+**HNSW configuration**: The vector field types use Solr defaults and do not set
+version-specific HNSW attributes. Upload the updated configset and run a full
+reindex when moving an existing collection from Solr 9 to Solr 10.
 
 **Key fields** (book metadata, ADR-002):
 - `title_s`/`title_t`, `author_s`/`author_t`, `year_i`, `category_s`, `language_detected_s`, `series_s`
@@ -141,14 +143,17 @@ All `solr` CLI commands now require full double-dash flags. This breaks every `s
 - `docker-compose.yml` — solr-init entrypoint (lines ~710–798)
 - `docker/compose.prod.yml` — solr-init entrypoint (lines ~658–736)
 
-### 2.2 HNSW Parameter Renames (🟢 Low Impact for Us)
+### 2.2 HNSW Parameter Renames (🟢 Guarded by Defaults)
 
 | Solr 9 | Solr 10 |
 |--------|---------|
 | `hnswMaxConnections` | `hnswM` |
 | `hnswBeamWidth` | `hnswEfConstruction` |
 
-**Our impact**: **None** — our schema uses defaults and does not explicitly set these parameters. If custom HNSW tuning is added later, use the Solr 10 names.
+**Our impact**: The active configset omits these version-specific attributes, so
+it remains valid on both Solr 9 and Solr 10. If explicit HNSW tuning is restored,
+use the Solr 10 names before uploading to Solr 10 and perform a full reindex so
+HNSW graphs are rebuilt with the updated schema.
 
 ### 2.3 `blockUnknown` Default Change (🟡 Medium Impact)
 

--- a/docs/migration/solr-compat-layer.md
+++ b/docs/migration/solr-compat-layer.md
@@ -22,11 +22,12 @@ controlled by the `SOLR_VERSION` environment variable and implemented primarily 
 
 | Solr 9 | Solr 10 | Affected Files |
 |--------|---------|----------------|
-| `hnswMaxConnections` | `maxConnections` | `src/solr/books/managed-schema.xml:46` |
-| `hnswBeamWidth` | `beamWidth` | `src/solr/books/managed-schema.xml:46` |
+| `hnswMaxConnections` | `hnswM` | `src/solr/books/managed-schema.xml` |
+| `hnswBeamWidth` | `hnswEfConstruction` | `src/solr/books/managed-schema.xml` |
 
-**Current state**: We use HNSW defaults — no explicit parameters in the schema.
-If custom tuning is added later, the compat layer provides version-aware names.
+**Current state**: The active configset omits version-specific HNSW tuning
+attributes, so schema uploads are valid on both Solr 9 and Solr 10. If custom
+tuning is added later, the compat layer provides version-aware names.
 
 **Compat approach**: `solr_compat.hnsw_params()` returns the correct parameter
 names for the detected Solr version.
@@ -140,5 +141,6 @@ When switching from Solr 9 to 10:
 2. [ ] Update `src/solr/Dockerfile` to `FROM solr:10`
 3. [ ] Update `src/solr/books/solrconfig.xml` `luceneMatchVersion` to `10.0`
 4. [ ] Verify CLI commands in `docker-compose.yml` use double-dash syntax
-5. [ ] Re-index all data (required after `luceneMatchVersion` change)
+5. [ ] Upload the updated `books` configset and re-index all data (required after
+       configset and `luceneMatchVersion` changes)
 6. [ ] Run full test suite

--- a/docs/migration/solr-compat-layer.md
+++ b/docs/migration/solr-compat-layer.md
@@ -25,9 +25,9 @@ controlled by the `SOLR_VERSION` environment variable and implemented primarily 
 | `hnswMaxConnections` | `hnswM` | `src/solr/books/managed-schema.xml` |
 | `hnswBeamWidth` | `hnswEfConstruction` | `src/solr/books/managed-schema.xml` |
 
-**Current state**: The active configset omits version-specific HNSW tuning
-attributes, so schema uploads are valid on both Solr 9 and Solr 10. If custom
-tuning is added later, the compat layer provides version-aware names.
+**Current state**: The source configset uses Solr 10 names. During the
+compatibility window, `solr-init` rewrites `hnswM` / `hnswEfConstruction` back
+to the Solr 9 names before uploading the configset to a Solr 9 cluster.
 
 **Compat approach**: `solr_compat.hnsw_params()` returns the correct parameter
 names for the detected Solr version.
@@ -142,5 +142,5 @@ When switching from Solr 9 to 10:
 3. [ ] Update `src/solr/books/solrconfig.xml` `luceneMatchVersion` to `10.0`
 4. [ ] Verify CLI commands in `docker-compose.yml` use double-dash syntax
 5. [ ] Upload the updated `books` configset and re-index all data (required after
-       configset and `luceneMatchVersion` changes)
+       HNSW schema parameter and `luceneMatchVersion` changes)
 6. [ ] Run full test suite

--- a/docs/prd/solr10-migration-prd.md
+++ b/docs/prd/solr10-migration-prd.md
@@ -271,14 +271,18 @@ solr auth enable --type basicAuth \
 
 ### 4.2 🔴 HNSW Parameter Renames
 
-**Impact**: Conditional. `src/solr/books/managed-schema.xml` currently uses the vector field type defaults and does **not** explicitly set `hnswMaxConnections` / `hnswBeamWidth`.
+**Impact**: Guarded by defaults. `src/solr/books/managed-schema.xml` omits
+version-specific HNSW tuning attributes on active vector field types, so the
+configset remains valid on both Solr 9 and Solr 10.
 
 | Current | Solr 10 |
 |---------|---------|
 | `hnswMaxConnections` | `hnswM` |
 | `hnswBeamWidth` | `hnswEfConstruction` |
 
-**Action**: No schema change is needed for this item unless we explicitly tune HNSW parameters in schema. If we later add these settings, use the Solr 10 names above; a reindex would then be required.
+**Action**: Keep active vector field types free of the Solr 9 names above. If
+explicit HNSW tuning is restored, use the Solr 10 names and perform a full
+reindex so vector graphs are rebuilt.
 
 ### 4.3 🔴 `blockUnknown` Default Change
 

--- a/docs/prd/solr10-migration-prd.md
+++ b/docs/prd/solr10-migration-prd.md
@@ -271,18 +271,18 @@ solr auth enable --type basicAuth \
 
 ### 4.2 🔴 HNSW Parameter Renames
 
-**Impact**: Guarded by defaults. `src/solr/books/managed-schema.xml` omits
-version-specific HNSW tuning attributes on active vector field types, so the
-configset remains valid on both Solr 9 and Solr 10.
+**Impact**: Required for the byte-vector field. `src/solr/books/managed-schema.xml`
+uses defaults for the float32 vector type, but explicitly tunes graph degree for
+the byte-vector type. Solr 10 requires the renamed HNSW schema parameters.
 
 | Current | Solr 10 |
 |---------|---------|
 | `hnswMaxConnections` | `hnswM` |
 | `hnswBeamWidth` | `hnswEfConstruction` |
 
-**Action**: Keep active vector field types free of the Solr 9 names above. If
-explicit HNSW tuning is restored, use the Solr 10 names and perform a full
-reindex so vector graphs are rebuilt.
+**Action**: Use the Solr 10 names above in the source configset, let Solr 9
+bootstrap rewrite them during the compatibility window, upload the configset
+during migration, and perform a full reindex so vector graphs are rebuilt.
 
 ### 4.3 🔴 `blockUnknown` Default Change
 

--- a/scripts/solr-import.sh
+++ b/scripts/solr-import.sh
@@ -48,6 +48,12 @@
 #   Use --no-transform to disable or --transform-schema to force this payload
 #   transformation.
 #
+# Configset upload transformation (Solr 10 → 9):
+#   When --configset-dir points at a Solr 10 configset and the target is Solr 9,
+#   upload a staged copy with HNSW schema attributes renamed back:
+#     hnswM                  →  hnswMaxConnections
+#     hnswEfConstruction     →  hnswBeamWidth
+#
 # Exit codes:
 #   0  Import succeeded
 #   1  Fatal error
@@ -388,15 +394,24 @@ upload_configset() {
         return 1
     fi
 
+    local upload_dir="$config_dir"
+    local staged_dir=""
+    if [[ -n "$SOLR_MAJOR_VERSION" ]] && [[ "$SOLR_MAJOR_VERSION" -eq 9 ]]; then
+        staged_dir=$(stage_configset_for_solr9 "$config_dir" "$config_name") || return 1
+        upload_dir="$staged_dir"
+    fi
+
     if [[ "$DRY_RUN" == "1" ]]; then
-        log_info "[DRY_RUN] Would upload configset '${config_name}' from ${config_dir}"
+        log_info "[DRY_RUN] Would upload configset '${config_name}' from ${upload_dir}"
+        cleanup_staged_configset "$staged_dir"
         return 0
     fi
 
     # Create a ZIP of the configset directory
     local zip_file="${PROJECT_ROOT}/.configset-upload-${TIMESTAMP}.zip"
-    (cd "$config_dir" && zip -r "$zip_file" . -x '.*') &>/dev/null || {
-        log_error "Failed to create configset ZIP from ${config_dir}"
+    (cd "$upload_dir" && zip -r "$zip_file" . -x '.*') &>/dev/null || {
+        cleanup_staged_configset "$staged_dir"
+        log_error "Failed to create configset ZIP from ${upload_dir}"
         return 1
     }
 
@@ -408,11 +423,13 @@ upload_configset() {
         --data-binary "@${zip_file}" \
         "${SOLR_URL}/api/cluster/configs/${config_name}" 2>&1) || {
         rm -f "$zip_file"
+        cleanup_staged_configset "$staged_dir"
         log_error "Failed to upload configset: ${response}"
         return 1
     }
 
     rm -f "$zip_file"
+    cleanup_staged_configset "$staged_dir"
 
     # Check for errors in response
     if echo "$response" | grep -qi '"error"'; then
@@ -421,6 +438,52 @@ upload_configset() {
     fi
 
     log_info "Configset '${config_name}' uploaded successfully"
+}
+
+# ---------------------------------------------------------------------------
+# stage_configset_for_solr9 — rewrite Solr 10-only HNSW schema params for Solr 9
+# ---------------------------------------------------------------------------
+stage_configset_for_solr9() {
+    local config_dir="$1"
+    local config_name="$2"
+    local safe_name
+    safe_name=$(printf '%s' "$config_name" | tr -c 'A-Za-z0-9._-' '_')
+    local staged_dir="${PROJECT_ROOT}/.configset-upload-${safe_name}-${TIMESTAMP}-solr9"
+
+    if [[ -e "$staged_dir" ]]; then
+        log_error "Staged configset path already exists: ${staged_dir}"
+        return 1
+    fi
+
+    mkdir -p "$staged_dir" || {
+        log_error "Failed to create staged configset directory: ${staged_dir}"
+        return 1
+    }
+    cp -R "${config_dir}/." "$staged_dir/" || {
+        cleanup_staged_configset "$staged_dir"
+        log_error "Failed to stage configset from ${config_dir}"
+        return 1
+    }
+
+    local schema_file="${staged_dir}/managed-schema.xml"
+    if [[ -f "$schema_file" ]]; then
+        sed -i \
+            -e 's/hnswM="/hnswMaxConnections="/g' \
+            -e 's/hnswEfConstruction="/hnswBeamWidth="/g' \
+            "$schema_file"
+        log_info "Staged Solr 9-compatible configset for upload: ${staged_dir}"
+    else
+        log_warn "Configset has no managed-schema.xml; no Solr 9 HNSW rewrite applied"
+    fi
+
+    printf '%s\n' "$staged_dir"
+}
+
+cleanup_staged_configset() {
+    local staged_dir="${1:-}"
+    if [[ -n "$staged_dir" && "$staged_dir" == "${PROJECT_ROOT}/.configset-upload-"*"-solr9" && -d "$staged_dir" ]]; then
+        rm -rf -- "$staged_dir"
+    fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/solr-import.sh
+++ b/scripts/solr-import.sh
@@ -40,12 +40,13 @@
 #   LOG_FILE                  Log file (default: /var/log/aithena-solr-import.log)
 #   DRY_RUN                   Set to 1 to skip actual writes
 #
-# Schema transformation (Solr 9 → 10):
-#   When the target is Solr 10, HNSW parameters in DenseVectorField definitions
-#   are automatically renamed:
+# JSON payload transformation (Solr 9 → 10):
+#   When the target is Solr 10, HNSW parameter keys that may appear in exported
+#   update payloads are automatically renamed:
 #     hnswMaxConnections  →  hnswM
 #     hnswBeamWidth       →  hnswEfConstruction
-#   Use --no-transform to disable or --transform-schema to force.
+#   Use --no-transform to disable or --transform-schema to force this payload
+#   transformation.
 #
 # Exit codes:
 #   0  Import succeeded
@@ -456,11 +457,11 @@ count_lines() {
 }
 
 # ---------------------------------------------------------------------------
-# transform_batch_for_solr10 — rename HNSW params in document JSON
+# transform_batch_for_solr10 — rename HNSW params in update payload JSON
 # ---------------------------------------------------------------------------
 transform_batch_for_solr10() {
     local input="$1"
-    # Rename HNSW parameters that may appear in exported document data.
+    # Rename HNSW parameter keys that may appear in exported update payloads.
     # The primary renames for Solr 10:
     #   hnswMaxConnections → hnswM
     #   hnswBeamWidth      → hnswEfConstruction

--- a/scripts/solr-import.sh
+++ b/scripts/solr-import.sh
@@ -45,8 +45,9 @@
 #   update payloads are automatically renamed:
 #     hnswMaxConnections  →  hnswM
 #     hnswBeamWidth       →  hnswEfConstruction
-#   Use --no-transform to disable or --transform-schema to force this payload
-#   transformation.
+#   Use --no-transform to disable this payload transformation. The legacy
+#   --transform-schema flag name is retained for compatibility; it also forces
+#   payload key renames.
 #
 # Configset upload transformation (Solr 10 → 9):
 #   When --configset-dir points at a Solr 10 configset and the target is Solr 9,

--- a/scripts/solr-import.sh
+++ b/scripts/solr-import.sh
@@ -43,8 +43,8 @@
 # Schema transformation (Solr 9 → 10):
 #   When the target is Solr 10, HNSW parameters in DenseVectorField definitions
 #   are automatically renamed:
-#     hnswMaxConnections  →  maxConnections
-#     hnswBeamWidth       →  beamWidth
+#     hnswMaxConnections  →  hnswM
+#     hnswBeamWidth       →  hnswEfConstruction
 #   Use --no-transform to disable or --transform-schema to force.
 #
 # Exit codes:
@@ -462,15 +462,15 @@ transform_batch_for_solr10() {
     local input="$1"
     # Rename HNSW parameters that may appear in exported document data.
     # The primary renames for Solr 10:
-    #   hnswMaxConnections → maxConnections
-    #   hnswBeamWidth      → beamWidth
+    #   hnswMaxConnections → hnswM
+    #   hnswBeamWidth      → hnswEfConstruction
     if command -v python3 &>/dev/null; then
         python3 -c "
 import sys
 
 RENAMES = {
-    'hnswMaxConnections': 'maxConnections',
-    'hnswBeamWidth': 'beamWidth',
+    'hnswMaxConnections': 'hnswM',
+    'hnswBeamWidth': 'hnswEfConstruction',
 }
 
 data = sys.stdin.read()
@@ -480,8 +480,8 @@ print(data, end='')
 " <<< "$input"
     else
         echo "$input" | sed \
-            -e 's/hnswMaxConnections/maxConnections/g' \
-            -e 's/hnswBeamWidth/beamWidth/g'
+            -e 's/hnswMaxConnections/hnswM/g' \
+            -e 's/hnswBeamWidth/hnswEfConstruction/g'
     fi
 }
 

--- a/src/solr-search/solr_compat.py
+++ b/src/solr-search/solr_compat.py
@@ -92,10 +92,10 @@ def reset_cached_version() -> None:
 # ---------------------------------------------------------------------------
 
 # Solr 9: hnswMaxConnections / hnswBeamWidth
-# Solr 10: maxConnections / beamWidth
+# Solr 10: hnswM / hnswEfConstruction
 _HNSW_PARAM_MAP: dict[int, dict[str, str]] = {
     9: {"max_connections": "hnswMaxConnections", "beam_width": "hnswBeamWidth"},
-    10: {"max_connections": "maxConnections", "beam_width": "beamWidth"},
+    10: {"max_connections": "hnswM", "beam_width": "hnswEfConstruction"},
 }
 
 

--- a/src/solr-search/tests/test_solr_compat.py
+++ b/src/solr-search/tests/test_solr_compat.py
@@ -193,9 +193,9 @@ class TestDenseVectorFieldType:
 
 
 class TestManagedSchemaHnswCompatibility:
-    """Tests for Solr 9/10 HNSW compatibility in the active configset."""
+    """Tests for Solr 10 HNSW compatibility in the active configset."""
 
-    def test_managed_schema_omits_version_specific_hnsw_param_names(self):
+    def test_managed_schema_uses_solr10_hnsw_param_names(self):
         schema = ET.parse(MANAGED_SCHEMA_PATH).getroot()  # nosec B314
         vector_field_types = [
             field_type
@@ -208,5 +208,8 @@ class TestManagedSchemaHnswCompatibility:
         for field_type in vector_field_types:
             assert "hnswMaxConnections" not in field_type.attrib
             assert "hnswBeamWidth" not in field_type.attrib
-            assert "hnswM" not in field_type.attrib
-            assert "hnswEfConstruction" not in field_type.attrib
+            assert "maxConnections" not in field_type.attrib
+            assert "beamWidth" not in field_type.attrib
+
+        byte_vector = next(ft for ft in vector_field_types if ft.attrib["name"] == "knn_vector_768_byte")
+        assert byte_vector.attrib["hnswM"] == "12"

--- a/src/solr-search/tests/test_solr_compat.py
+++ b/src/solr-search/tests/test_solr_compat.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import xml.etree.ElementTree as ET  # nosec B405
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 import solr_compat
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MANAGED_SCHEMA_PATH = REPO_ROOT / "src" / "solr" / "books" / "managed-schema.xml"
 
 
 @pytest.fixture(autouse=True)
@@ -124,7 +129,7 @@ class TestHnswParams:
     def test_solr_10_param_names(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("SOLR_VERSION", "10")
         result = solr_compat.hnsw_params(max_connections=16, beam_width=100)
-        assert result == {"maxConnections": 16, "beamWidth": 100}
+        assert result == {"hnswM": 16, "hnswEfConstruction": 100}
 
     def test_custom_values(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("SOLR_VERSION", "9")
@@ -170,8 +175,8 @@ class TestDenseVectorFieldType:
             hnsw_max_connections=32,
             hnsw_beam_width=200,
         )
-        assert result["maxConnections"] == 32
-        assert result["beamWidth"] == 200
+        assert result["hnswM"] == 32
+        assert result["hnswEfConstruction"] == 200
         assert "hnswMaxConnections" not in result
 
     def test_custom_field_name_and_dims(self, monkeypatch: pytest.MonkeyPatch):
@@ -184,3 +189,23 @@ class TestDenseVectorFieldType:
         assert result["name"] == "custom_vector"
         assert result["vectorDimension"] == 384
         assert result["similarityFunction"] == "dot_product"
+
+
+class TestManagedSchemaHnswCompatibility:
+    """Tests for Solr 9/10 HNSW compatibility in the active configset."""
+
+    def test_managed_schema_omits_version_specific_hnsw_param_names(self):
+        schema = ET.parse(MANAGED_SCHEMA_PATH).getroot()  # nosec B314
+        vector_field_types = [
+            field_type
+            for field_type in schema.findall("fieldType")
+            if field_type.attrib.get("class") == "solr.DenseVectorField"
+        ]
+
+        assert vector_field_types, "managed-schema.xml must define DenseVectorField types"
+
+        for field_type in vector_field_types:
+            assert "hnswMaxConnections" not in field_type.attrib
+            assert "hnswBeamWidth" not in field_type.attrib
+            assert "hnswM" not in field_type.attrib
+            assert "hnswEfConstruction" not in field_type.attrib

--- a/src/solr-search/tests/test_solr_compat.py
+++ b/src/solr-search/tests/test_solr_compat.py
@@ -211,5 +211,9 @@ class TestManagedSchemaHnswCompatibility:
             assert "maxConnections" not in field_type.attrib
             assert "beamWidth" not in field_type.attrib
 
-        byte_vector = next(ft for ft in vector_field_types if ft.attrib["name"] == "knn_vector_768_byte")
+        byte_vectors = [
+            field_type for field_type in vector_field_types if field_type.attrib["name"] == "knn_vector_768_byte"
+        ]
+        assert byte_vectors, "managed-schema.xml must define knn_vector_768_byte"
+        byte_vector = byte_vectors[0]
         assert byte_vector.attrib["hnswM"] == "12"

--- a/src/solr-search/tests/test_solr_compat.py
+++ b/src/solr-search/tests/test_solr_compat.py
@@ -178,6 +178,7 @@ class TestDenseVectorFieldType:
         assert result["hnswM"] == 32
         assert result["hnswEfConstruction"] == 200
         assert "hnswMaxConnections" not in result
+        assert "hnswBeamWidth" not in result
 
     def test_custom_field_name_and_dims(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("SOLR_VERSION", "9")

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -11,7 +11,10 @@ and verifies that:
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -20,6 +23,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 COMPOSE_PATH = REPO_ROOT / "docker-compose.yml"
 SECURITY_JSON_PATH = REPO_ROOT / "src" / "solr" / "security.json"
 SOLR_INIT_SCRIPT_PATH = REPO_ROOT / "docker" / "solr-init.sh"
+SOLR_IMPORT_SCRIPT_PATH = REPO_ROOT / "scripts" / "solr-import.sh"
 
 
 def _load_solr_init_script() -> str:
@@ -46,6 +50,12 @@ def _load_security_json() -> dict:
 def _load_shared_solr_init_script() -> str:
     """Load docker/solr-init.sh."""
     with open(SOLR_INIT_SCRIPT_PATH, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _load_solr_import_script() -> str:
+    """Load scripts/solr-import.sh."""
+    with open(SOLR_IMPORT_SCRIPT_PATH, encoding="utf-8") as fh:
         return fh.read()
 
 
@@ -143,3 +153,49 @@ def test_init_scripts_rewrite_solr10_hnsw_params_for_solr9():
         assert 'solr zk upconfig -z "${ZK_HOST}" -n books -d "${CONFIGSET_DIR}"' in script or (
             'solr zk upconfig -z "$$ZK_HOST" -n books -d "$$CONFIGSET_DIR"' in script
         )
+
+
+def test_solr_import_configset_upload_stages_solr9_hnsw_rewrite():
+    """solr-import --configset-dir must not upload Solr 10 HNSW params to Solr 9."""
+    script = _load_solr_import_script()
+    assert "stage_configset_for_solr9" in script
+    assert 'SOLR_MAJOR_VERSION" -eq 9' in script
+
+    scratch = REPO_ROOT / ".pytest-solr-import-configset" / str(os.getpid())
+    config_dir = scratch / "source-configset"
+    staged_root = scratch / "staged-root"
+    shutil.rmtree(scratch, ignore_errors=True)
+    config_dir.mkdir(parents=True)
+    staged_root.mkdir(parents=True)
+    schema = config_dir / "managed-schema.xml"
+    schema.write_text(
+        '<schema><fieldType name="knn_vector_768_byte" class="solr.DenseVectorField" '
+        'hnswM="12" hnswEfConstruction="100"/></schema>',
+        encoding="utf-8",
+    )
+
+    try:
+        bash = f"""
+set -euo pipefail
+PROJECT_ROOT={staged_root}
+LOG_FILE=/dev/null
+eval "$(sed '/^main "\\$@"/,$d' scripts/solr-import.sh)"
+staged="$(stage_configset_for_solr9 {config_dir} books)"
+test -f "${{staged}}/managed-schema.xml"
+grep -q 'hnswMaxConnections="12"' "${{staged}}/managed-schema.xml"
+grep -q 'hnswBeamWidth="100"' "${{staged}}/managed-schema.xml"
+! grep -q 'hnswM=' "${{staged}}/managed-schema.xml"
+! grep -q 'hnswEfConstruction=' "${{staged}}/managed-schema.xml"
+grep -q 'hnswM="12"' {schema}
+cleanup_staged_configset "$staged"
+test ! -d "$staged"
+"""
+        subprocess.run(  # noqa: S603 - script under test and paths are repo-local fixtures
+            ["/bin/bash", "-c", bash],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -138,8 +138,8 @@ def test_init_scripts_rewrite_solr10_hnsw_params_for_solr9():
     """Solr 9 bootstrap must rewrite source Solr 10 HNSW schema names."""
     for script in (_load_solr_init_script(), _load_shared_solr_init_script()):
         assert 'SOLR_VERSION:-9}" = "9"' in script
-        assert "hnswM=/hnswMaxConnections=" in script
-        assert "hnswEfConstruction=/hnswBeamWidth=" in script
+        assert 'hnswM="/hnswMaxConnections="' in script
+        assert 'hnswEfConstruction="/hnswBeamWidth="' in script
         assert 'solr zk upconfig -z "${ZK_HOST}" -n books -d "${CONFIGSET_DIR}"' in script or (
             'solr zk upconfig -z "$$ZK_HOST" -n books -d "$$CONFIGSET_DIR"' in script
         )

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -19,6 +19,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[3]
 COMPOSE_PATH = REPO_ROOT / "docker-compose.yml"
 SECURITY_JSON_PATH = REPO_ROOT / "src" / "solr" / "security.json"
+SOLR_INIT_SCRIPT_PATH = REPO_ROOT / "docker" / "solr-init.sh"
 
 
 def _load_solr_init_script() -> str:
@@ -40,6 +41,12 @@ def _load_security_json() -> dict:
     """Load and parse src/solr/security.json."""
     with open(SECURITY_JSON_PATH, encoding="utf-8") as fh:
         return json.load(fh)
+
+
+def _load_shared_solr_init_script() -> str:
+    """Load docker/solr-init.sh."""
+    with open(SOLR_INIT_SCRIPT_PATH, encoding="utf-8") as fh:
+        return fh.read()
 
 
 # ---------- 1. Admin role assignment ----------
@@ -125,3 +132,14 @@ def test_security_json_matches_solr97_roles():
     assert perm_map.get("read") == "search", "read must require search role"
     assert perm_map.get("collection-admin-edit") == "admin", "collection-admin-edit must require admin role"
     assert perm_map.get("update") == "index", "update must require index role"
+
+
+def test_init_scripts_rewrite_solr10_hnsw_params_for_solr9():
+    """Solr 9 bootstrap must rewrite source Solr 10 HNSW schema names."""
+    for script in (_load_solr_init_script(), _load_shared_solr_init_script()):
+        assert 'SOLR_VERSION:-9}" = "9"' in script
+        assert "hnswM=/hnswMaxConnections=" in script
+        assert "hnswEfConstruction=/hnswBeamWidth=" in script
+        assert 'solr zk upconfig -z "${ZK_HOST}" -n books -d "${CONFIGSET_DIR}"' in script or (
+            'solr zk upconfig -z "$$ZK_HOST" -n books -d "$$CONFIGSET_DIR"' in script
+        )

--- a/src/solr/README.md
+++ b/src/solr/README.md
@@ -204,7 +204,7 @@ docker exec solr solr config-set-upload \
 3. **Sorting**: Use `sort=year_i desc` or `sort=title_s asc` for result ordering.
 4. **Pagination**: Use `start=0&rows=20` for 20 results per page.
 5. **kNN topK**: Set `topK` ≥ `rows` on the kNN QParser. A value of 100–200 is a good starting point for re-ranking hybrid searches.
-6. **HNSW tuning**: The default HNSW parameters (`hnswM=16`, `hnswEfConstruction=100` in Solr 10) suit collections up to ~1 M vectors. Increase `hnswM` (e.g. 32) for higher recall at the cost of more memory.
+6. **HNSW tuning**: The default HNSW parameters suit collections up to ~1 M vectors (`hnswMaxConnections=16`, `hnswBeamWidth=100` in Solr 9; `hnswM=16`, `hnswEfConstruction=100` in Solr 10). Increase graph degree (`hnswMaxConnections`/`hnswM`, e.g. 32) for higher recall at the cost of more memory.
 
 ## References
 

--- a/src/solr/README.md
+++ b/src/solr/README.md
@@ -204,7 +204,7 @@ docker exec solr solr config-set-upload \
 3. **Sorting**: Use `sort=year_i desc` or `sort=title_s asc` for result ordering.
 4. **Pagination**: Use `start=0&rows=20` for 20 results per page.
 5. **kNN topK**: Set `topK` ≥ `rows` on the kNN QParser. A value of 100–200 is a good starting point for re-ranking hybrid searches.
-6. **HNSW tuning**: The default HNSW parameters (`hnswMaxConnections=16`, `hnswBeamWidth=100`) suit collections up to ~1 M vectors. Increase `hnswMaxConnections` (e.g. 32) for higher recall at the cost of more memory.
+6. **HNSW tuning**: The default HNSW parameters (`hnswM=16`, `hnswEfConstruction=100` in Solr 10) suit collections up to ~1 M vectors. Increase `hnswM` (e.g. 32) for higher recall at the cost of more memory.
 
 ## References
 

--- a/src/solr/books/managed-schema.xml
+++ b/src/solr/books/managed-schema.xml
@@ -43,9 +43,10 @@
   <fieldType name="ignored" class="solr.StrField" indexed="false" stored="false" multiValued="true"/>
   <!-- 768-dim dense vector field type for multilingual-e5-base (replaces distiluse, benchmark #926).
        HNSW index with cosine similarity for kNN semantic search.
-       Uses Solr defaults for HNSW tuning. If custom params are needed:
+       Uses Solr defaults for HNSW tuning so the configset remains valid on Solr 9 and Solr 10.
+       If custom params are needed:
          Solr 9:  hnswMaxConnections="16" hnswBeamWidth="100"
-         Solr 10: maxConnections="16" beamWidth="100"
+         Solr 10: hnswM="16" hnswEfConstruction="100"
        See docs/migration/solr-compat-layer.md and src/solr-search/solr_compat.py
 
        Vector quantization modes (VECTOR_QUANTIZATION env var):
@@ -58,9 +59,8 @@
   <!-- float32 vector type — used for "none" and "fp16" quantization modes -->
   <fieldType name="knn_vector_768" class="solr.DenseVectorField" vectorDimension="768" similarityFunction="cosine" knnAlgorithm="hnsw"/>
   <!-- BYTE (int8) vector type — used for "int8" quantization mode.
-       vectorEncoding="BYTE" stores each dimension as a signed byte [-128, 127].
-       hnswMaxConnections tuned to 12 (vs default 16) for memory savings with byte vectors. -->
-  <fieldType name="knn_vector_768_byte" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="12"/>
+       vectorEncoding="BYTE" stores each dimension as a signed byte [-128, 127]. -->
+  <fieldType name="knn_vector_768_byte" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw"/>
   <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
   <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType" geo="true" maxDistErr="0.001" distErrPct="0.025" distanceUnits="kilometers"/>
   <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">

--- a/src/solr/books/managed-schema.xml
+++ b/src/solr/books/managed-schema.xml
@@ -43,8 +43,8 @@
   <fieldType name="ignored" class="solr.StrField" indexed="false" stored="false" multiValued="true"/>
   <!-- 768-dim dense vector field type for multilingual-e5-base (replaces distiluse, benchmark #926).
        HNSW index with cosine similarity for kNN semantic search.
-       Uses Solr defaults for HNSW tuning so the configset remains valid on Solr 9 and Solr 10.
-       If custom params are needed:
+       Uses Solr 10 HNSW parameter names. The solr-init bootstrap rewrites these
+       names for Solr 9 during the compatibility window. If custom params are needed:
          Solr 9:  hnswMaxConnections="16" hnswBeamWidth="100"
          Solr 10: hnswM="16" hnswEfConstruction="100"
        See docs/migration/solr-compat-layer.md and src/solr-search/solr_compat.py
@@ -59,8 +59,9 @@
   <!-- float32 vector type — used for "none" and "fp16" quantization modes -->
   <fieldType name="knn_vector_768" class="solr.DenseVectorField" vectorDimension="768" similarityFunction="cosine" knnAlgorithm="hnsw"/>
   <!-- BYTE (int8) vector type — used for "int8" quantization mode.
-       vectorEncoding="BYTE" stores each dimension as a signed byte [-128, 127]. -->
-  <fieldType name="knn_vector_768_byte" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw"/>
+       vectorEncoding="BYTE" stores each dimension as a signed byte [-128, 127].
+       hnswM tuned to 12 (vs default 16) for memory savings with byte vectors. -->
+  <fieldType name="knn_vector_768_byte" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw" hnswM="12"/>
   <fieldType name="location" class="solr.LatLonPointSpatialField" docValues="true"/>
   <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType" geo="true" maxDistErr="0.001" distErrPct="0.025" distanceUnits="kilometers"/>
   <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">


### PR DESCRIPTION
## Summary
- Closes #1336
- Working as Ash (Search Engineer)
- ⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Changes
- Migrated the source `books` configset to Solr 10 HNSW schema naming (`hnswM`; compat layer also maps `hnswEfConstruction`).
- Preserved current Solr 9.7 compatibility by rewriting Solr 10 HNSW names back to Solr 9 names during `solr-init` configset upload when `SOLR_VERSION=9`.
- Corrected `solr_compat.py` and import payload transformation mapping to emit `hnswM` / `hnswEfConstruction` for Solr 10.
- Updated migration docs/reindex guidance and added schema/init compatibility tests.

## Evidence
- Apache Solr 10 reference/source confirms `hnswMaxConnections` → `hnswM` and `hnswBeamWidth` → `hnswEfConstruction`.
- Current Docker base remains `solr:9.7`; CI validates the Solr 9 rewrite path while source schema is Solr 10-ready.

## Validation
- [x] `python3 -m bandit -c .bandit -r . -f txt -q` — no findings for this change
- [x] `.squad/scripts/verify.sh` — all checks passed (embeddings-server + solr-search; 80 + 1100 tests)
- [x] Pre-commit hook passed during commits (solr-search lint/format/tests)
