### PR TITLE
Preserve OpenVINO smoke failures through tee

### DIFF
--- a/.github/workflows/openvino-release-gate.yml
+++ b/.github/workflows/openvino-release-gate.yml
@@ -68,6 +68,7 @@ jobs:
         env:
           SMOKE_TIMEOUT: '240'
         run: |
+          set -o pipefail
           chmod +x e2e/smoke-openvino-permissions.sh
           ./e2e/smoke-openvino-permissions.sh \
             local/aithena-embeddings-server:openvino-release-gate \

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -331,6 +331,7 @@ jobs:
         env:
           RC_TAG: ${{ needs.prepare.outputs.full_tag }}-openvino
         run: |
+          set -o pipefail
           chmod +x e2e/smoke-openvino-permissions.sh
           ./e2e/smoke-openvino-permissions.sh \
             "ghcr.io/jmservera/aithena-embeddings-server:${RC_TAG}" \

--- a/e2e/smoke-openvino-permissions.ci.yml
+++ b/e2e/smoke-openvino-permissions.ci.yml
@@ -50,6 +50,7 @@
         env:
           RC_TAG: ${{ needs.prepare.outputs.full_tag }}-openvino
         run: |
+          set -o pipefail
           chmod +x e2e/smoke-openvino-permissions.sh
           ./e2e/smoke-openvino-permissions.sh \
             "ghcr.io/jmservera/aithena-embeddings-server:${RC_TAG}" \

--- a/tests/test-openvino-smoke-pipefail.sh
+++ b/tests/test-openvino-smoke-pipefail.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Verifies OpenVINO smoke diagnostics do not mask failures when piped through tee.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ARTIFACT_DIR="$ROOT/.test-artifacts/openvino-pipefail"
+mkdir -p "$ARTIFACT_DIR"
+trap 'rm -rf "$ARTIFACT_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_pipefail_in_block() {
+  local file="$1"
+  local label="$2"
+  if python3 - "$ROOT/$file" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+needle = "OpenVINO"
+if needle not in text:
+    raise SystemExit(1)
+
+lines = text.splitlines()
+for index, line in enumerate(lines):
+    if "2>&1 | tee openvino-smoke-output.txt" not in line:
+        continue
+    start = max(0, index - 8)
+    block = "\n".join(lines[start:index])
+    if "set -o pipefail" in block or "set -euo pipefail" in block or "bash -o pipefail" in block:
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+  then
+    PASS=$((PASS + 1))
+    echo "  ✅ $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ❌ $label"
+  fi
+}
+
+assert_pipeline_fails() {
+  local output="$ARTIFACT_DIR/pipeline-output.txt"
+  if bash -c 'set -o pipefail; false 2>&1 | tee "$1"' bash "$output"; then
+    FAIL=$((FAIL + 1))
+    echo "  ❌ pipefail propagates smoke command failure"
+  else
+    PASS=$((PASS + 1))
+    echo "  ✅ pipefail propagates smoke command failure"
+  fi
+}
+
+echo "Checking OpenVINO smoke tee pipelines"
+assert_pipefail_in_block ".github/workflows/openvino-release-gate.yml" "release gate has pipefail before tee"
+assert_pipefail_in_block ".github/workflows/pre-release.yml" "pre-release job has pipefail before tee"
+assert_pipefail_in_block "e2e/smoke-openvino-permissions.ci.yml" "CI job snippet has pipefail before tee"
+assert_pipeline_fails
+
+echo ""
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/tests/test-openvino-smoke-pipefail.sh
+++ b/tests/test-openvino-smoke-pipefail.sh
@@ -4,9 +4,19 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ARTIFACT_DIR="$ROOT/.test-artifacts/openvino-pipefail"
+ARTIFACT_DIR="$ROOT/.test-artifacts/openvino-pipefail.$$"
 mkdir -p "$ARTIFACT_DIR"
-trap 'rm -rf "$ARTIFACT_DIR"' EXIT
+
+cleanup() {
+  local status=$?
+  if [ "$status" -eq 0 ]; then
+    rm -rf "$ARTIFACT_DIR"
+  else
+    echo "Retained artifacts: $ARTIFACT_DIR"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
 
 PASS=0
 FAIL=0
@@ -24,14 +34,21 @@ if needle not in text:
     raise SystemExit(1)
 
 lines = text.splitlines()
+found = False
+missing_pipefail = False
 for index, line in enumerate(lines):
     if "2>&1 | tee openvino-smoke-output.txt" not in line:
         continue
+    found = True
     start = max(0, index - 8)
     block = "\n".join(lines[start:index])
-    if "set -o pipefail" in block or "set -euo pipefail" in block or "bash -o pipefail" in block:
-        raise SystemExit(0)
-raise SystemExit(1)
+    if not ("set -o pipefail" in block or "set -euo pipefail" in block or "bash -o pipefail" in block):
+        print(f"missing pipefail before tee at line {index + 1}", file=sys.stderr)
+        missing_pipefail = True
+if not found:
+    print("no OpenVINO smoke tee pipeline found", file=sys.stderr)
+    raise SystemExit(1)
+raise SystemExit(1 if missing_pipefail else 0)
 PY
   then
     PASS=$((PASS + 1))


### PR DESCRIPTION
Follow-up to #1666 after it was merged before Lambert's requested revision could land.

Changes:
- Add pipefail before OpenVINO smoke diagnostics are piped through tee.
- Add shell validation that checks all OpenVINO smoke tee blocks and demonstrates pipefail propagates a failing pipeline.

Validation:
- bash tests/test-openvino-smoke-pipefail.sh
- .squad/scripts/verify.sh

Do not merge automatically.