### PR TITLE
Prepare scalar quantization benchmark validation

### DIFF
--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -120,6 +120,56 @@ Aggregate (per mode and category):
 - **Console:** Human-readable summary with per-mode stats and errors
 - **JSON** (`--output`): Full result data for further analysis
 
+
+## Scalar Quantization Validation (#1344)
+
+Use this workflow after PR #1670 (Solr 10 `bits=7` compatibility) merges and the same corpus can be indexed twice. It avoids hardware-intensive runs by reusing the existing 30-query suite and comparing top-k agreement between a float32 reference collection and an int8/scalar-quantized candidate collection.
+
+### Validation checklist
+
+1. Confirm the runtime contains the #1670 schema fix (`ScalarQuantizedDenseVectorField bits="7"` on Solr 10; Solr 9 compatibility still rewrites to `DenseVectorField vectorEncoding="BYTE"`).
+2. Index the same representative corpus with `VECTOR_QUANTIZATION=none` and save a float32 benchmark report.
+3. Re-index the same corpus with `VECTOR_QUANTIZATION=int8` and save a candidate benchmark report.
+4. Compare reports with `compare_quantization.py`; treat recall@10 below `0.95` for any semantic/hybrid query as a release blocker until reviewed.
+5. Capture memory from `docker stats --no-stream solr solr2 solr3` (or the existing `e2e/benchmark.sh` report when a small generated corpus is acceptable) for float32 and int8 runs.
+6. Attach the JSON reports, comparison output, Solr memory samples, corpus size, and any failed query IDs to #1344.
+
+### Commands
+
+```bash
+# Float32 reference run
+VECTOR_QUANTIZATION=none docker compose up -d --build
+python3 scripts/index_test_corpus.py --status-only
+python3 scripts/verify_collections.py --verbose
+python3 scripts/benchmark/run_benchmark.py \
+  --base-url http://localhost:8080 \
+  --modes semantic hybrid \
+  --output results/benchmark-1344-float32.json
+
+docker stats --no-stream solr solr2 solr3
+
+# Int8/scalar-quantized candidate run after re-indexing the same corpus
+VECTOR_QUANTIZATION=int8 docker compose up -d --build
+python3 scripts/index_test_corpus.py --status-only
+python3 scripts/verify_collections.py --verbose
+python3 scripts/benchmark/run_benchmark.py \
+  --base-url http://localhost:8080 \
+  --modes semantic hybrid \
+  --output results/benchmark-1344-int8.json
+
+docker stats --no-stream solr solr2 solr3
+
+# Offline recall/latency comparison (safe to run without Docker)
+python3 scripts/benchmark/compare_quantization.py \
+  --baseline results/benchmark-1344-float32.json \
+  --candidate results/benchmark-1344-int8.json \
+  --top-k 10 \
+  --min-recall 0.95 \
+  --output results/benchmark-1344-quantization-comparison.json
+```
+
+**Remaining blocker:** do not execute the int8/Solr 10 validation until #1670 is merged or equivalent `bits=7` schema support is present in the target environment.
+
 ## Running Tests
 
 ```bash

--- a/scripts/benchmark/compare_quantization.py
+++ b/scripts/benchmark/compare_quantization.py
@@ -159,13 +159,47 @@ def summarize(comparisons: list[Comparison], *, min_recall: float) -> dict[str, 
             "mean_latency_delta_pct": round(statistics.mean(deltas), 4) if deltas else None,
             "candidate_error_count": sum(1 for c in mode_items if c.candidate_error),
             "baseline_error_count": sum(1 for c in mode_items if c.baseline_error),
+            "empty_baseline_result_count": sum(1 for c in mode_items if not c.baseline_ids),
         }
 
-    failures = [
-        {"query_id": c.query_id, "mode": c.mode, "recall_at_k": c.recall_at_k, "error": c.candidate_error}
-        for c in comparisons
-        if c.candidate_error or (c.recall_at_k is not None and c.recall_at_k < min_recall)
-    ]
+    failures: list[dict[str, Any]] = []
+    for c in comparisons:
+        reasons = []
+        if c.baseline_error:
+            reasons.append("baseline_error")
+        if not c.baseline_ids:
+            reasons.append("empty_baseline_top_k_ids")
+        if c.candidate_error:
+            reasons.append("candidate_error")
+        if c.recall_at_k is not None and c.recall_at_k < min_recall:
+            reasons.append("recall_below_threshold")
+
+        if reasons:
+            failures.append(
+                {
+                    "query_id": c.query_id,
+                    "mode": c.mode,
+                    "recall_at_k": c.recall_at_k,
+                    "reasons": reasons,
+                    "error": c.candidate_error or c.baseline_error,
+                    "baseline_error": c.baseline_error,
+                    "candidate_error": c.candidate_error,
+                },
+            )
+
+    if not comparisons:
+        failures.append(
+            {
+                "query_id": None,
+                "mode": None,
+                "recall_at_k": None,
+                "reasons": ["no_baseline_comparisons"],
+                "error": "baseline report has no comparable results",
+                "baseline_error": "baseline report has no comparable results",
+                "candidate_error": None,
+            },
+        )
+
     return {
         "total_comparisons": len(comparisons),
         "min_recall_threshold": min_recall,
@@ -224,6 +258,8 @@ def format_summary(output: dict[str, Any]) -> str:
             f"min_recall={stats['min_recall_at_k']} "
             f"mean_latency_delta_pct={stats['mean_latency_delta_pct']} "
             f"below_threshold={len(stats['queries_below_min_recall'])} "
+            f"baseline_errors={stats['baseline_error_count']} "
+            f"empty_baselines={stats['empty_baseline_result_count']} "
             f"candidate_errors={stats['candidate_error_count']}",
         )
     lines.append("")

--- a/scripts/benchmark/compare_quantization.py
+++ b/scripts/benchmark/compare_quantization.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Compare float32 and scalar-quantized benchmark reports.
+
+The benchmark runner records top-k result IDs for every query/mode. This tool
+uses a float32 report as the reference set and computes recall@k/top-k overlap
+for a quantized candidate report, plus latency deltas. It is intentionally
+offline: no Solr, Docker, or embedding services are required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MIN_RECALL = 0.95
+DEFAULT_TOP_K = 10
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """Per-query/mode comparison between reference and candidate results."""
+
+    query_id: str
+    mode: str
+    baseline_ids: list[str]
+    candidate_ids: list[str]
+    recall_at_k: float | None
+    overlap_count: int
+    baseline_latency_ms: float | None
+    candidate_latency_ms: float | None
+    latency_delta_pct: float | None
+    baseline_error: str | None = None
+    candidate_error: str | None = None
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    """Load a benchmark JSON report."""
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict) or not isinstance(data.get("results"), list):
+        raise ValueError(f"{path} is not a benchmark report with a results list")
+    return data
+
+
+def _key(result: dict[str, Any]) -> tuple[str, str]:
+    return str(result.get("query_id", "")), str(result.get("mode", ""))
+
+
+def _result_index(report: dict[str, Any]) -> dict[tuple[str, str], dict[str, Any]]:
+    indexed: dict[tuple[str, str], dict[str, Any]] = {}
+    for result in report.get("results", []):
+        if isinstance(result, dict):
+            indexed[_key(result)] = result
+    return indexed
+
+
+def _top_ids(result: dict[str, Any], top_k: int) -> list[str]:
+    ids = result.get("top_k_ids", [])
+    if not isinstance(ids, list):
+        return []
+    return [str(item) for item in ids[:top_k]]
+
+
+def _latency(result: dict[str, Any]) -> float | None:
+    value = result.get("latency_ms")
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _latency_delta_pct(baseline: float | None, candidate: float | None) -> float | None:
+    if baseline is None or candidate is None or baseline <= 0:
+        return None
+    return round(((candidate - baseline) / baseline) * 100.0, 4)
+
+
+def _recall_at_k(baseline_ids: list[str], candidate_ids: list[str]) -> tuple[float | None, int]:
+    if not baseline_ids:
+        return None, 0
+    overlap = len(set(baseline_ids) & set(candidate_ids))
+    return round(overlap / len(baseline_ids), 4), overlap
+
+
+def compare_reports(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    top_k: int = DEFAULT_TOP_K,
+) -> list[Comparison]:
+    """Compare matching query_id/mode pairs in two benchmark reports."""
+    baseline_results = _result_index(baseline)
+    candidate_results = _result_index(candidate)
+    comparisons: list[Comparison] = []
+
+    for key in sorted(baseline_results):
+        base = baseline_results[key]
+        cand = candidate_results.get(key)
+        if cand is None:
+            query_id, mode = key
+            baseline_ids = _top_ids(base, top_k)
+            comparisons.append(
+                Comparison(
+                    query_id=query_id,
+                    mode=mode,
+                    baseline_ids=baseline_ids,
+                    candidate_ids=[],
+                    recall_at_k=0.0 if baseline_ids else None,
+                    overlap_count=0,
+                    baseline_latency_ms=_latency(base),
+                    candidate_latency_ms=None,
+                    latency_delta_pct=None,
+                    baseline_error=base.get("error"),
+                    candidate_error="missing result",
+                ),
+            )
+            continue
+
+        baseline_ids = _top_ids(base, top_k)
+        candidate_ids = _top_ids(cand, top_k)
+        recall, overlap = _recall_at_k(baseline_ids, candidate_ids)
+        baseline_latency = _latency(base)
+        candidate_latency = _latency(cand)
+        comparisons.append(
+            Comparison(
+                query_id=key[0],
+                mode=key[1],
+                baseline_ids=baseline_ids,
+                candidate_ids=candidate_ids,
+                recall_at_k=recall,
+                overlap_count=overlap,
+                baseline_latency_ms=baseline_latency,
+                candidate_latency_ms=candidate_latency,
+                latency_delta_pct=_latency_delta_pct(baseline_latency, candidate_latency),
+                baseline_error=base.get("error"),
+                candidate_error=cand.get("error"),
+            ),
+        )
+
+    return comparisons
+
+
+def summarize(comparisons: list[Comparison], *, min_recall: float) -> dict[str, Any]:
+    """Build aggregate recall and latency summaries."""
+    by_mode: dict[str, dict[str, Any]] = {}
+    for mode in sorted({c.mode for c in comparisons}):
+        mode_items = [c for c in comparisons if c.mode == mode]
+        recalls = [c.recall_at_k for c in mode_items if c.recall_at_k is not None]
+        deltas = [c.latency_delta_pct for c in mode_items if c.latency_delta_pct is not None]
+        by_mode[mode] = {
+            "query_count": len(mode_items),
+            "mean_recall_at_k": round(statistics.mean(recalls), 4) if recalls else None,
+            "min_recall_at_k": min(recalls) if recalls else None,
+            "queries_below_min_recall": [
+                c.query_id for c in mode_items if c.recall_at_k is not None and c.recall_at_k < min_recall
+            ],
+            "mean_latency_delta_pct": round(statistics.mean(deltas), 4) if deltas else None,
+            "candidate_error_count": sum(1 for c in mode_items if c.candidate_error),
+            "baseline_error_count": sum(1 for c in mode_items if c.baseline_error),
+        }
+
+    failures = [
+        {"query_id": c.query_id, "mode": c.mode, "recall_at_k": c.recall_at_k, "error": c.candidate_error}
+        for c in comparisons
+        if c.candidate_error or (c.recall_at_k is not None and c.recall_at_k < min_recall)
+    ]
+    return {
+        "total_comparisons": len(comparisons),
+        "min_recall_threshold": min_recall,
+        "by_mode": by_mode,
+        "failures": failures,
+        "passed": not failures,
+    }
+
+
+def comparison_to_dict(comparison: Comparison) -> dict[str, Any]:
+    """Serialize a comparison to a JSON-compatible dict."""
+    return {
+        "query_id": comparison.query_id,
+        "mode": comparison.mode,
+        "baseline_ids": comparison.baseline_ids,
+        "candidate_ids": comparison.candidate_ids,
+        "recall_at_k": comparison.recall_at_k,
+        "overlap_count": comparison.overlap_count,
+        "baseline_latency_ms": comparison.baseline_latency_ms,
+        "candidate_latency_ms": comparison.candidate_latency_ms,
+        "latency_delta_pct": comparison.latency_delta_pct,
+        "baseline_error": comparison.baseline_error,
+        "candidate_error": comparison.candidate_error,
+    }
+
+
+def build_output(
+    baseline_path: Path,
+    candidate_path: Path,
+    comparisons: list[Comparison],
+    *,
+    top_k: int,
+    min_recall: float,
+) -> dict[str, Any]:
+    """Build the full JSON comparison report."""
+    return {
+        "baseline_report": str(baseline_path),
+        "candidate_report": str(candidate_path),
+        "top_k": top_k,
+        "summary": summarize(comparisons, min_recall=min_recall),
+        "comparisons": [comparison_to_dict(c) for c in comparisons],
+    }
+
+
+def format_summary(output: dict[str, Any]) -> str:
+    """Format a concise human-readable summary."""
+    lines = ["QUANTIZATION RECALL COMPARISON", "=" * 36]
+    summary = output["summary"]
+    lines.append(f"top_k: {output['top_k']}")
+    lines.append(f"min_recall_threshold: {summary['min_recall_threshold']}")
+    lines.append(f"total_comparisons: {summary['total_comparisons']}")
+    lines.append("")
+    for mode, stats in sorted(summary["by_mode"].items()):
+        lines.append(
+            f"{mode}: mean_recall={stats['mean_recall_at_k']} "
+            f"min_recall={stats['min_recall_at_k']} "
+            f"mean_latency_delta_pct={stats['mean_latency_delta_pct']} "
+            f"below_threshold={len(stats['queries_below_min_recall'])} "
+            f"candidate_errors={stats['candidate_error_count']}",
+        )
+    lines.append("")
+    lines.append("PASS" if summary["passed"] else "FAIL")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare float32 and scalar-quantized benchmark JSON reports.",
+    )
+    parser.add_argument("--baseline", required=True, type=Path, help="Float32 benchmark JSON report")
+    parser.add_argument("--candidate", required=True, type=Path, help="Quantized benchmark JSON report")
+    parser.add_argument("--top-k", type=int, default=DEFAULT_TOP_K, help="Top-k depth to compare")
+    parser.add_argument(
+        "--min-recall",
+        type=float,
+        default=DEFAULT_MIN_RECALL,
+        help="Minimum per-query recall@k threshold for pass/fail",
+    )
+    parser.add_argument("--output", "-o", type=Path, help="Optional JSON output path")
+    args = parser.parse_args()
+
+    baseline = load_report(args.baseline)
+    candidate = load_report(args.candidate)
+    comparisons = compare_reports(baseline, candidate, top_k=args.top_k)
+    output = build_output(
+        args.baseline,
+        args.candidate,
+        comparisons,
+        top_k=args.top_k,
+        min_recall=args.min_recall,
+    )
+    print(format_summary(output))
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(f"\nJSON comparison saved to: {args.output}")
+
+    sys.exit(0 if output["summary"]["passed"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/tests/test_compare_quantization.py
+++ b/scripts/benchmark/tests/test_compare_quantization.py
@@ -1,0 +1,170 @@
+"""Tests for scalar quantization benchmark report comparison."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from compare_quantization import (  # noqa: E402
+    build_output,
+    compare_reports,
+    format_summary,
+    load_report,
+    summarize,
+)
+
+
+def _result(query_id: str, mode: str, ids: list[str], latency_ms: float = 10.0) -> dict:
+    return {
+        "query_id": query_id,
+        "query": "test",
+        "collection": "books",
+        "mode": mode,
+        "top_k_ids": ids,
+        "top_k_scores": [1.0] * len(ids),
+        "total_results": len(ids),
+        "latency_ms": latency_ms,
+        "degraded": False,
+        "error": None,
+    }
+
+
+def _report(results: list[dict]) -> dict:
+    return {
+        "timestamp": "2026-06-05T00:00:00Z",
+        "base_url": "http://localhost:8080",
+        "queries_file": "queries.json",
+        "collection": "books",
+        "total_queries": len(results),
+        "modes_tested": sorted({r["mode"] for r in results}),
+        "summary": {},
+        "results": results,
+    }
+
+
+class TestCompareReports:
+    def test_identical_results_have_full_recall(self) -> None:
+        baseline = _report([_result("sk-01", "semantic", ["a", "b", "c"])])
+        candidate = _report([_result("sk-01", "semantic", ["a", "b", "c"])])
+
+        comparisons = compare_reports(baseline, candidate, top_k=3)
+
+        assert len(comparisons) == 1
+        assert comparisons[0].recall_at_k == 1.0
+        assert comparisons[0].overlap_count == 3
+
+    def test_partial_overlap_computes_recall_at_k(self) -> None:
+        baseline = _report([_result("sk-01", "semantic", ["a", "b", "c", "d"])])
+        candidate = _report([_result("sk-01", "semantic", ["a", "x", "c", "y"])])
+
+        comparison = compare_reports(baseline, candidate, top_k=4)[0]
+
+        assert comparison.recall_at_k == 0.5
+        assert comparison.overlap_count == 2
+
+    def test_missing_candidate_result_fails_comparison(self) -> None:
+        baseline = _report([_result("sk-01", "hybrid", ["a", "b"])])
+        candidate = _report([])
+
+        comparison = compare_reports(baseline, candidate, top_k=2)[0]
+
+        assert comparison.recall_at_k == 0.0
+        assert comparison.candidate_error == "missing result"
+
+    def test_latency_delta_is_reported(self) -> None:
+        baseline = _report([_result("sk-01", "semantic", ["a"], latency_ms=100.0)])
+        candidate = _report([_result("sk-01", "semantic", ["a"], latency_ms=125.0)])
+
+        comparison = compare_reports(baseline, candidate, top_k=1)[0]
+
+        assert comparison.latency_delta_pct == 25.0
+
+
+class TestSummarize:
+    def test_summary_passes_when_all_recalls_meet_threshold(self) -> None:
+        comparisons = compare_reports(
+            _report([_result("sk-01", "semantic", ["a", "b"])]),
+            _report([_result("sk-01", "semantic", ["b", "a"])]),
+            top_k=2,
+        )
+
+        summary = summarize(comparisons, min_recall=0.95)
+
+        assert summary["passed"] is True
+        assert summary["by_mode"]["semantic"]["mean_recall_at_k"] == 1.0
+
+    def test_summary_fails_when_recall_below_threshold(self) -> None:
+        comparisons = compare_reports(
+            _report([_result("sk-01", "semantic", ["a", "b"])]),
+            _report([_result("sk-01", "semantic", ["x", "y"])]),
+            top_k=2,
+        )
+
+        summary = summarize(comparisons, min_recall=0.95)
+
+        assert summary["passed"] is False
+        assert summary["failures"][0]["query_id"] == "sk-01"
+        assert summary["by_mode"]["semantic"]["queries_below_min_recall"] == ["sk-01"]
+
+
+class TestOutput:
+    def test_build_output_is_json_serializable(self) -> None:
+        comparisons = compare_reports(
+            _report([_result("sk-01", "keyword", ["a"])]),
+            _report([_result("sk-01", "keyword", ["a"])]),
+            top_k=1,
+        )
+
+        output = build_output(
+            Path("results/float32.json"),
+            Path("results/int8.json"),
+            comparisons,
+            top_k=1,
+            min_recall=0.95,
+        )
+
+        assert output["summary"]["passed"] is True
+        assert "sk-01" in json.dumps(output)
+
+    def test_format_summary_includes_pass_fail(self) -> None:
+        comparisons = compare_reports(
+            _report([_result("sk-01", "keyword", ["a"])]),
+            _report([_result("sk-01", "keyword", ["a"])]),
+            top_k=1,
+        )
+        output = build_output(Path("baseline.json"), Path("candidate.json"), comparisons, top_k=1, min_recall=0.95)
+
+        text = format_summary(output)
+
+        assert "QUANTIZATION RECALL COMPARISON" in text
+        assert "PASS" in text
+
+    def test_load_report_rejects_invalid_shape(self, monkeypatch) -> None:
+        class FakePath:
+            def open(self, encoding: str):
+                assert encoding == "utf-8"
+                return self
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self, *_args, **_kwargs):
+                return "{}"
+
+            def __str__(self) -> str:
+                return "fake.json"
+
+        monkeypatch.setattr(json, "load", lambda _f: {})
+
+        try:
+            load_report(FakePath())  # type: ignore[arg-type]
+        except ValueError as exc:
+            assert "results list" in str(exc)
+        else:
+            raise AssertionError("ValueError not raised")

--- a/scripts/benchmark/tests/test_compare_quantization.py
+++ b/scripts/benchmark/tests/test_compare_quantization.py
@@ -32,6 +32,12 @@ def _result(query_id: str, mode: str, ids: list[str], latency_ms: float = 10.0) 
     }
 
 
+def _error_result(query_id: str, mode: str, error: str) -> dict:
+    result = _result(query_id, mode, [])
+    result["error"] = error
+    return result
+
+
 def _report(results: list[dict]) -> dict:
     return {
         "timestamp": "2026-06-05T00:00:00Z",
@@ -109,6 +115,39 @@ class TestSummarize:
         assert summary["failures"][0]["query_id"] == "sk-01"
         assert summary["by_mode"]["semantic"]["queries_below_min_recall"] == ["sk-01"]
 
+    def test_summary_fails_when_baseline_has_error(self) -> None:
+        comparisons = compare_reports(
+            _report([_error_result("sk-01", "semantic", "baseline request failed")]),
+            _report([_result("sk-01", "semantic", ["a", "b"])]),
+            top_k=2,
+        )
+
+        summary = summarize(comparisons, min_recall=0.95)
+
+        assert summary["passed"] is False
+        assert summary["by_mode"]["semantic"]["baseline_error_count"] == 1
+        assert summary["failures"][0]["reasons"] == ["baseline_error", "empty_baseline_top_k_ids"]
+        assert summary["failures"][0]["baseline_error"] == "baseline request failed"
+
+    def test_summary_fails_when_baseline_has_no_top_k_ids(self) -> None:
+        comparisons = compare_reports(
+            _report([_result("sk-01", "semantic", [])]),
+            _report([_result("sk-01", "semantic", ["a", "b"])]),
+            top_k=2,
+        )
+
+        summary = summarize(comparisons, min_recall=0.95)
+
+        assert summary["passed"] is False
+        assert summary["by_mode"]["semantic"]["empty_baseline_result_count"] == 1
+        assert summary["failures"][0]["reasons"] == ["empty_baseline_top_k_ids"]
+
+    def test_summary_fails_when_baseline_has_no_comparisons(self) -> None:
+        summary = summarize([], min_recall=0.95)
+
+        assert summary["passed"] is False
+        assert summary["failures"][0]["reasons"] == ["no_baseline_comparisons"]
+
 
 class TestOutput:
     def test_build_output_is_json_serializable(self) -> None:
@@ -141,6 +180,20 @@ class TestOutput:
 
         assert "QUANTIZATION RECALL COMPARISON" in text
         assert "PASS" in text
+
+    def test_format_summary_includes_baseline_failure_counts(self) -> None:
+        comparisons = compare_reports(
+            _report([_error_result("sk-01", "semantic", "baseline request failed")]),
+            _report([_result("sk-01", "semantic", ["a"])]),
+            top_k=1,
+        )
+        output = build_output(Path("baseline.json"), Path("candidate.json"), comparisons, top_k=1, min_recall=0.95)
+
+        text = format_summary(output)
+
+        assert "baseline_errors=1" in text
+        assert "empty_baselines=1" in text
+        assert "FAIL" in text
 
     def test_load_report_rejects_invalid_shape(self, monkeypatch) -> None:
         class FakePath:


### PR DESCRIPTION
## Summary
- add offline benchmark report comparison for float32 vs int8/scalar-quantized recall@k and latency deltas
- document the #1344 post-#1670 validation checklist and exact commands
- add unit tests for comparison pass/fail behavior

Working as Lambert (Tester).

Closes no issue; supports #1344 validation after #1670 merges.

## Validation
- python3 -m pytest scripts/benchmark/tests -q
- ruff check scripts/benchmark/compare_quantization.py scripts/benchmark/tests/test_compare_quantization.py
- ruff format --check scripts/benchmark/compare_quantization.py scripts/benchmark/tests/test_compare_quantization.py
- python3 scripts/benchmark/compare_quantization.py --baseline results/compare-smoke-baseline.json --candidate results/compare-smoke-candidate.json --top-k 2 --min-recall 0.95
- .squad/scripts/verify.sh

## Remaining blocker
Do not execute the int8/Solr 10 recall and memory validation until #1670 or equivalent bits=7 schema support is present.