### PR TITLE
Add Solr 10 image CI scaffold

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -65,6 +65,12 @@ jobs:
           - image: solr-search
             context: .
             dockerfile: ./src/solr-search/Dockerfile
+          - image: solr
+            context: ./src/solr
+            dockerfile: ./src/solr/Dockerfile
+            tag_suffix: "-solr10"
+            extra_build_args: |
+              SOLR_BASE_IMAGE=solr:10
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,19 @@ jobs:
       - name: Validate Compose security posture
         run: bash tests/test-compose-security.sh
 
+  solr-image-reference-regression:
+    name: Solr image reference regression
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate Solr 10 image wiring
+        run: bash tests/test-solr-image-refs.sh
+
   all-tests-passed:
     name: All tests passed
     if: always()
@@ -287,6 +300,7 @@ jobs:
       - embeddings-server-tests
       - python-lint
       - compose-security-regression
+      - solr-image-reference-regression
     steps:
       - name: Evaluate results
         env:
@@ -298,13 +312,14 @@ jobs:
           EMBEDDINGS_RESULT: ${{ needs.embeddings-server-tests.result }}
           LINT_RESULT: ${{ needs.python-lint.result }}
           COMPOSE_SECURITY_RESULT: ${{ needs.compose-security-regression.result }}
+          SOLR_IMAGE_REFS_RESULT: ${{ needs.solr-image-reference-regression.result }}
           BUILD_NEEDED: ${{ needs.changes.outputs.build }}
         run: |
           if [ "$CHANGES_RESULT" = "failure" ] || [ "$CHANGES_RESULT" = "cancelled" ]; then
             echo "❌ Change detection failed"
             exit 1
           fi
-          for result in "$INDEXER_RESULT" "$SEARCH_RESULT" "$UI_RESULT" "$LISTER_RESULT" "$EMBEDDINGS_RESULT" "$LINT_RESULT" "$COMPOSE_SECURITY_RESULT"; do
+          for result in "$INDEXER_RESULT" "$SEARCH_RESULT" "$UI_RESULT" "$LISTER_RESULT" "$EMBEDDINGS_RESULT" "$LINT_RESULT" "$COMPOSE_SECURITY_RESULT" "$SOLR_IMAGE_REFS_RESULT"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "❌ One or more required jobs failed"
               exit 1

--- a/.github/workflows/solr-image-validation.yml
+++ b/.github/workflows/solr-image-validation.yml
@@ -1,0 +1,73 @@
+name: Solr Image Validation
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths:
+      - 'src/solr/**'
+      - '.github/workflows/build-containers.yml'
+      - '.github/workflows/solr-image-validation.yml'
+      - 'tests/test-solr-image-refs.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  solr10-image:
+    name: Build and smoke Solr 10 image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate Solr 10 image references
+        run: bash tests/test-solr-image-refs.sh
+
+      - name: Build Solr 10 image
+        run: |
+          docker build \
+            --build-arg SOLR_BASE_IMAGE=solr:10 \
+            --build-arg VERSION=ci-solr10 \
+            --build-arg GIT_COMMIT="${GITHUB_SHA}" \
+            --build-arg BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -t aithena-solr:solr10-ci \
+            src/solr
+
+      - name: Smoke test Solr 10 container
+        run: |
+          container_id="$(docker run -d -e SOLR_MODULES=extraction,langid -p 8983:8983 aithena-solr:solr10-ci solr-foreground)"
+          cleanup() {
+            docker logs "$container_id" || true
+            docker rm -f "$container_id" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          for attempt in {1..60}; do
+            if curl -fsS 'http://localhost:8983/solr/admin/info/system?wt=json' > solr-system.json; then
+              break
+            fi
+            echo "[$attempt/60] Waiting for Solr 10..."
+            sleep 5
+          done
+
+          test -s solr-system.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path("solr-system.json").read_text(encoding="utf-8"))
+          lucene = data.get("lucene", {})
+          version = str(lucene.get("solr-spec-version") or lucene.get("solr-impl-version") or "")
+          if not version.startswith("10."):
+              raise SystemExit(f"Expected Solr 10.x from /admin/info/system, got {version!r}")
+          print(f"Solr version validated: {version}")
+          PY

--- a/src/solr/Dockerfile
+++ b/src/solr/Dockerfile
@@ -1,8 +1,13 @@
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
+ARG SOLR_BASE_IMAGE=solr:9.7
 
-FROM solr:9.7
+FROM ${SOLR_BASE_IMAGE}
+
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tests/test-solr-image-refs.sh
+++ b/tests/test-solr-image-refs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Validate that Solr 10 image support stays wired into CI without forcing the
+# runtime cutover before solr-init compatibility has landed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+grep -Eq '^ARG SOLR_BASE_IMAGE=solr:9\.7$' src/solr/Dockerfile ||
+  fail "src/solr/Dockerfile must keep Solr 9.7 as the default base until the Solr 10 cutover"
+
+grep -Eq '^FROM \$\{SOLR_BASE_IMAGE\}$' src/solr/Dockerfile ||
+  fail "src/solr/Dockerfile must build from SOLR_BASE_IMAGE"
+
+grep -q 'tag_suffix: "-solr10"' .github/workflows/build-containers.yml ||
+  fail "build-containers.yml must publish a Solr 10 suffixed image"
+
+grep -q 'SOLR_BASE_IMAGE=solr:10' .github/workflows/build-containers.yml ||
+  fail "build-containers.yml must build the Solr image with SOLR_BASE_IMAGE=solr:10"
+
+if grep -Eq '^[[:space:]]*image:[[:space:]]*ghcr\.io/jmservera/aithena-solr:' docker-compose.yml docker/*.yml; then
+  fail "compose must not consume the experimental Solr 10 image before issue #1337 lands"
+fi
+
+echo "OK: Solr 10 image references are wired for CI and isolated from runtime compose"


### PR DESCRIPTION
## Summary
- Adds a Solr image entry to the reusable container build workflow tagged with `-solr10` and built using `SOLR_BASE_IMAGE=solr:10`.
- Makes `src/solr/Dockerfile` base-image configurable while keeping `solr:9.7` as the runtime default until the Solr init CLI cutover is complete.
- Adds a Solr 10 image validation workflow plus a shell regression test to ensure CI wiring stays isolated from Compose runtime usage.

Working as Brett (Infrastructure Architect).

Closes #1341
Refs #1335
Refs #1337

## Dependency note
#1335 should not flip the default Compose/runtime Solr image to Solr 10 until #1337 Solr init CLI compatibility is merged/validated. This PR starts the safe #1341 slice by building and smoking the Solr 10 image without changing runtime defaults.

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Validation
- `bash tests/test-solr-image-refs.sh`
- workflow YAML parsed with PyYAML
- `.squad/scripts/verify.sh`
- Docker build/smoke: `SOLR_BASE_IMAGE=solr:10`; `/admin/info/system` reported `Solr version: 10.0.0`