### PR TITLE
Rewrite solr-init CLI flags for Solr 10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -730,6 +730,31 @@ services:
           MAX_WAIT=120
           ZK_HOST="$${ZK_HOST:-zoo1:2181,zoo2:2181,zoo3:2181}"
           SOLR_URL="http://solr:8983"
+
+          solr_major_version() {
+            local version="$${SOLR_VERSION:-9}"
+            printf '%s\n' "$${version%%.*}"
+          }
+
+          solr_10_cli() {
+            [ "$$(solr_major_version)" -ge 10 ] 2>/dev/null
+          }
+
+          solr_zk_host_flag() {
+            if solr_10_cli; then printf '%s\n' "--zk-host"; else printf '%s\n' "-z"; fi
+          }
+
+          solr_credentials_flag() {
+            if solr_10_cli; then printf '%s\n' "--credentials"; else printf '%s\n' "-u"; fi
+          }
+
+          solr_name_flag() {
+            if solr_10_cli; then printf '%s\n' "--name"; else printf '%s\n' "-n"; fi
+          }
+
+          solr_dir_flag() {
+            if solr_10_cli; then printf '%s\n' "--dir"; else printf '%s\n' "-d"; fi
+          }
           EXPECTED_NODES="$${SOLR_EXPECTED_NODES:-3}"
 
           echo "[solr-init] Waiting for Solr to be reachable..."
@@ -762,16 +787,16 @@ services:
           if echo "$$AUTH_RESP" | grep -qi 'No authentication'; then
             echo "[solr-init] Bootstrapping Solr security..."
             # Seed an empty security.json so "solr auth enable" can update it
-            echo '{}' > /tmp/empty-security.json
-            solr zk cp file:/tmp/empty-security.json zk:/security.json -z "$$ZK_HOST"
+            echo '{}' > /opt/solr/empty-security.json
+            solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
             sleep 2
 
             # Create admin user with hashed password (also creates default RBAC rules)
             solr auth enable --type basicAuth \
-              -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
+              "$$(solr_credentials_flag)" "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
               --block-unknown false \
               --solr-include-file /dev/null \
-              -z "$$ZK_HOST"
+              "$$(solr_zk_host_flag)" "$$ZK_HOST"
 
             # Poll for auth readiness instead of blind sleep
             echo "[solr-init] Waiting for auth to propagate..."
@@ -826,7 +851,7 @@ services:
 
           # --- books collection (multilingual-e5-base, 768D) ---
           CONFIGSET_DIR="/configsets/books"
-          if [ "$${SOLR_VERSION:-9}" = "9" ]; then
+          if [ "$$(solr_major_version)" = "9" ]; then
             CONFIGSET_DIR="/var/solr/books-configset-solr9"
             mkdir -p "$$CONFIGSET_DIR"
             cp -R /configsets/books/. "$$CONFIGSET_DIR"/
@@ -839,8 +864,8 @@ services:
           fi
 
           echo "[solr-init] Uploading configset..."
-          if ! solr zk ls /configs -z "$$ZK_HOST" | grep -qx 'books'; then
-            solr zk upconfig -z "$$ZK_HOST" -n books -d "$$CONFIGSET_DIR"
+          if ! solr zk ls /configs "$$(solr_zk_host_flag)" "$$ZK_HOST" | grep -qx 'books'; then
+            solr zk upconfig "$$(solr_zk_host_flag)" "$$ZK_HOST" "$$(solr_name_flag)" books "$$(solr_dir_flag)" "$$CONFIGSET_DIR"
           fi
 
           echo "[solr-init] Creating collection (shards=$$NUM_SHARDS, replicas=$$REPLICATION_FACTOR)..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -787,8 +787,8 @@ services:
           if echo "$$AUTH_RESP" | grep -qi 'No authentication'; then
             echo "[solr-init] Bootstrapping Solr security..."
             # Seed an empty security.json so "solr auth enable" can update it
-            echo '{}' > /var/solr/data/empty-security.json
-            solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
+            echo '{}' > /var/solr/empty-security.json
+            solr zk cp file:/var/solr/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
             sleep 2
 
             # Create admin user with hashed password (also creates default RBAC rules)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -787,8 +787,8 @@ services:
           if echo "$$AUTH_RESP" | grep -qi 'No authentication'; then
             echo "[solr-init] Bootstrapping Solr security..."
             # Seed an empty security.json so "solr auth enable" can update it
-            echo '{}' > /opt/solr/empty-security.json
-            solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
+            echo '{}' > /var/solr/data/empty-security.json
+            solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
             sleep 2
 
             # Create admin user with hashed password (also creates default RBAC rules)

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -643,6 +643,7 @@ services:
       - ./src/solr/books:/configsets/books:ro
       - ./src/solr/add-conf-overlay.sh:/scripts/add-conf-overlay.sh:ro
     environment:
+      SOLR_VERSION: ${SOLR_VERSION:-9}
       SOLR_SECURITY_MANAGER_ENABLED: "false"
       SOLR_ADMIN_USER: ${SOLR_ADMIN_USER:?Set SOLR_ADMIN_USER}
       SOLR_ADMIN_PASS: ${SOLR_ADMIN_PASS:?Set SOLR_ADMIN_PASS}
@@ -660,6 +661,31 @@ services:
 
           ZK_HOST="zoo1:2181,zoo2:2181,zoo3:2181"
           SOLR_URL="http://solr:8983"
+
+          solr_major_version() {
+            local version="$${SOLR_VERSION:-9}"
+            printf '%s\n' "$${version%%.*}"
+          }
+
+          solr_10_cli() {
+            [ "$$(solr_major_version)" -ge 10 ] 2>/dev/null
+          }
+
+          solr_zk_host_flag() {
+            if solr_10_cli; then printf '%s\n' "--zk-host"; else printf '%s\n' "-z"; fi
+          }
+
+          solr_credentials_flag() {
+            if solr_10_cli; then printf '%s\n' "--credentials"; else printf '%s\n' "-u"; fi
+          }
+
+          solr_name_flag() {
+            if solr_10_cli; then printf '%s\n' "--name"; else printf '%s\n' "-n"; fi
+          }
+
+          solr_dir_flag() {
+            if solr_10_cli; then printf '%s\n' "--dir"; else printf '%s\n' "-d"; fi
+          }
 
           # Wait for Solr to be reachable (with or without auth)
           until curl -fsS -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" "$$SOLR_URL/solr/admin/info/system" >/dev/null 2>&1 || curl -fsS "$$SOLR_URL/solr/admin/info/system" >/dev/null 2>&1; do
@@ -680,15 +706,15 @@ services:
           AUTH_RESP=$$(curl -sS "$$SOLR_URL/solr/admin/authentication" 2>/dev/null || true)
           if echo "$$AUTH_RESP" | grep -qi 'No authentication'; then
             echo "Bootstrapping Solr security..."
-            echo '{}' > /tmp/empty-security.json
-            solr zk cp file:/tmp/empty-security.json zk:/security.json -z "$$ZK_HOST"
+            echo '{}' > /opt/solr/empty-security.json
+            solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
             sleep 2
 
             solr auth enable --type basicAuth \
-              -u "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
+              "$$(solr_credentials_flag)" "$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASS" \
               --block-unknown false \
               --solr-include-file /dev/null \
-              -z "$$ZK_HOST"
+              "$$(solr_zk_host_flag)" "$$ZK_HOST"
 
             echo "Waiting for Solr to load security config..."
             sleep 5
@@ -733,7 +759,7 @@ services:
           fi
 
           CONFIGSET_DIR="/configsets/books"
-          if [ "$${SOLR_VERSION:-9}" = "9" ]; then
+          if [ "$$(solr_major_version)" = "9" ]; then
             CONFIGSET_DIR="/var/solr/books-configset-solr9"
             mkdir -p "$$CONFIGSET_DIR"
             cp -R /configsets/books/. "$$CONFIGSET_DIR"/
@@ -745,8 +771,8 @@ services:
               "$$CONFIGSET_DIR/managed-schema.xml"
           fi
 
-          if ! solr zk ls /configs -z "$$ZK_HOST" | grep -q 'books'; then
-            solr zk upconfig -z "$$ZK_HOST" -n books -d "$$CONFIGSET_DIR"
+          if ! solr zk ls /configs "$$(solr_zk_host_flag)" "$$ZK_HOST" | grep -q 'books'; then
+            solr zk upconfig "$$(solr_zk_host_flag)" "$$ZK_HOST" "$$(solr_name_flag)" books "$$(solr_dir_flag)" "$$CONFIGSET_DIR"
           fi
 
           if ! curl -fsS -u "$$SOLR_AUTH_USER:$$SOLR_AUTH_PASS" "$$SOLR_URL/solr/admin/collections?action=LIST&wt=json" | grep -q '"books"'; then

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -706,8 +706,8 @@ services:
           AUTH_RESP=$$(curl -sS "$$SOLR_URL/solr/admin/authentication" 2>/dev/null || true)
           if echo "$$AUTH_RESP" | grep -qi 'No authentication'; then
             echo "Bootstrapping Solr security..."
-            echo '{}' > /var/solr/data/empty-security.json
-            solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
+            echo '{}' > /var/solr/empty-security.json
+            solr zk cp file:/var/solr/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
             sleep 2
 
             solr auth enable --type basicAuth \

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -706,8 +706,8 @@ services:
           AUTH_RESP=$$(curl -sS "$$SOLR_URL/solr/admin/authentication" 2>/dev/null || true)
           if echo "$$AUTH_RESP" | grep -qi 'No authentication'; then
             echo "Bootstrapping Solr security..."
-            echo '{}' > /opt/solr/empty-security.json
-            solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
+            echo '{}' > /var/solr/data/empty-security.json
+            solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$$(solr_zk_host_flag)" "$$ZK_HOST"
             sleep 2
 
             solr auth enable --type basicAuth \

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -771,7 +771,7 @@ services:
               "$$CONFIGSET_DIR/managed-schema.xml"
           fi
 
-          if ! solr zk ls /configs "$$(solr_zk_host_flag)" "$$ZK_HOST" | grep -q 'books'; then
+          if ! solr zk ls /configs "$$(solr_zk_host_flag)" "$$ZK_HOST" | grep -qx 'books'; then
             solr zk upconfig "$$(solr_zk_host_flag)" "$$ZK_HOST" "$$(solr_name_flag)" books "$$(solr_dir_flag)" "$$CONFIGSET_DIR"
           fi
 

--- a/docker/solr-init.sh
+++ b/docker/solr-init.sh
@@ -87,8 +87,8 @@ AUTH_RESP=$(curl -sS "${SOLR_URL}/solr/admin/authentication" 2>/dev/null || true
 if echo "${AUTH_RESP}" | grep -qi 'No authentication'; then
   echo "Bootstrapping Solr security..."
   # Seed an empty security.json so "solr auth enable" can update it
-  echo '{}' > /opt/solr/empty-security.json
-  solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$(solr_zk_host_flag)" "${ZK_HOST}"
+  echo '{}' > /var/solr/data/empty-security.json
+  solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$(solr_zk_host_flag)" "${ZK_HOST}"
   sleep 2
 
   # Create admin user with hashed password (also creates default RBAC rules)

--- a/docker/solr-init.sh
+++ b/docker/solr-init.sh
@@ -87,8 +87,8 @@ AUTH_RESP=$(curl -sS "${SOLR_URL}/solr/admin/authentication" 2>/dev/null || true
 if echo "${AUTH_RESP}" | grep -qi 'No authentication'; then
   echo "Bootstrapping Solr security..."
   # Seed an empty security.json so "solr auth enable" can update it
-  echo '{}' > /var/solr/data/empty-security.json
-  solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$(solr_zk_host_flag)" "${ZK_HOST}"
+  echo '{}' > /tmp/empty-security.json
+  solr zk cp file:/tmp/empty-security.json zk:/security.json "$(solr_zk_host_flag)" "${ZK_HOST}"
   sleep 2
 
   # Create admin user with hashed password (also creates default RBAC rules)

--- a/docker/solr-init.sh
+++ b/docker/solr-init.sh
@@ -34,6 +34,31 @@ NUM_SHARDS="${SOLR_NUM_SHARDS:-1}"
 REPLICATION_FACTOR="${SOLR_REPLICATION_FACTOR:-1}"
 EXPECTED_NODES="${SOLR_EXPECTED_NODES:-1}"
 
+solr_major_version() {
+  local version="${SOLR_VERSION:-9}"
+  printf '%s\n' "${version%%.*}"
+}
+
+solr_10_cli() {
+  [ "$(solr_major_version)" -ge 10 ] 2>/dev/null
+}
+
+solr_zk_host_flag() {
+  if solr_10_cli; then printf '%s\n' "--zk-host"; else printf '%s\n' "-z"; fi
+}
+
+solr_credentials_flag() {
+  if solr_10_cli; then printf '%s\n' "--credentials"; else printf '%s\n' "-u"; fi
+}
+
+solr_name_flag() {
+  if solr_10_cli; then printf '%s\n' "--name"; else printf '%s\n' "-n"; fi
+}
+
+solr_dir_flag() {
+  if solr_10_cli; then printf '%s\n' "--dir"; else printf '%s\n' "-d"; fi
+}
+
 # ── Wait for Solr to be reachable (with or without auth) ─────────────────────
 echo "Waiting for Solr at ${SOLR_URL}..."
 until curl -fsS -u "${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}" \
@@ -63,15 +88,15 @@ if echo "${AUTH_RESP}" | grep -qi 'No authentication'; then
   echo "Bootstrapping Solr security..."
   # Seed an empty security.json so "solr auth enable" can update it
   echo '{}' > /opt/solr/empty-security.json
-  solr zk cp file:/opt/solr/empty-security.json zk:/security.json -z "${ZK_HOST}"
+  solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$(solr_zk_host_flag)" "${ZK_HOST}"
   sleep 2
 
   # Create admin user with hashed password (also creates default RBAC rules)
   solr auth enable --type basicAuth \
-    -u "${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}" \
+    "$(solr_credentials_flag)" "${SOLR_ADMIN_USER}:${SOLR_ADMIN_PASS}" \
     --block-unknown false \
     --solr-include-file /dev/null \
-    -z "${ZK_HOST}"
+    "$(solr_zk_host_flag)" "${ZK_HOST}"
 
   echo "Waiting for Solr to load security config..."
   sleep 5
@@ -116,7 +141,7 @@ fi
 
 # ── books collection (multilingual-e5-base, 768D) ────────────────────────────
 CONFIGSET_DIR="/configsets/books"
-if [ "${SOLR_VERSION:-9}" = "9" ]; then
+if [ "$(solr_major_version)" = "9" ]; then
   CONFIGSET_DIR="/var/solr/books-configset-solr9"
   mkdir -p "${CONFIGSET_DIR}"
   cp -R /configsets/books/. "${CONFIGSET_DIR}"/
@@ -128,8 +153,8 @@ if [ "${SOLR_VERSION:-9}" = "9" ]; then
     "${CONFIGSET_DIR}/managed-schema.xml"
 fi
 
-if ! solr zk ls /configs -z "${ZK_HOST}" | grep -qx 'books'; then
-  solr zk upconfig -z "${ZK_HOST}" -n books -d "${CONFIGSET_DIR}"
+if ! solr zk ls /configs "$(solr_zk_host_flag)" "${ZK_HOST}" | grep -qx 'books'; then
+  solr zk upconfig "$(solr_zk_host_flag)" "${ZK_HOST}" "$(solr_name_flag)" books "$(solr_dir_flag)" "${CONFIGSET_DIR}"
 fi
 
 if ! curl -fsS -u "${SOLR_AUTH_USER}:${SOLR_AUTH_PASS}" \

--- a/docker/solr-init.sh
+++ b/docker/solr-init.sh
@@ -87,8 +87,8 @@ AUTH_RESP=$(curl -sS "${SOLR_URL}/solr/admin/authentication" 2>/dev/null || true
 if echo "${AUTH_RESP}" | grep -qi 'No authentication'; then
   echo "Bootstrapping Solr security..."
   # Seed an empty security.json so "solr auth enable" can update it
-  echo '{}' > /tmp/empty-security.json
-  solr zk cp file:/tmp/empty-security.json zk:/security.json "$(solr_zk_host_flag)" "${ZK_HOST}"
+  echo '{}' > /var/solr/empty-security.json
+  solr zk cp file:/var/solr/empty-security.json zk:/security.json "$(solr_zk_host_flag)" "${ZK_HOST}"
   sleep 2
 
   # Create admin user with hashed password (also creates default RBAC rules)

--- a/docs/migration/solr-9-to-10.md
+++ b/docs/migration/solr-9-to-10.md
@@ -298,7 +298,7 @@ Replace all Solr 9 CLI syntax with Solr 10 double-dash equivalents in the `solr-
 
 ```bash
 # Before (Solr 9.7)
-solr zk cp file:/var/solr/data/empty-security.json zk:/security.json -z "$ZK_HOST"
+solr zk cp file:/var/solr/empty-security.json zk:/security.json -z "$ZK_HOST"
 
 solr auth enable --type basicAuth \
   -u "$SOLR_ADMIN_USER:$SOLR_ADMIN_PASS" \
@@ -311,7 +311,7 @@ solr zk upconfig -z "$ZK_HOST" -n books -d /configsets/books
 solr zk ls /configs -z "$ZK_HOST"
 
 # After (Solr 10)
-solr zk cp file:/var/solr/data/empty-security.json zk:/security.json --zk-host "$ZK_HOST"
+solr zk cp file:/var/solr/empty-security.json zk:/security.json --zk-host "$ZK_HOST"
 
 solr auth enable --type basicAuth \
   --credentials "$SOLR_ADMIN_USER:$SOLR_ADMIN_PASS" \

--- a/docs/migration/solr-9-to-10.md
+++ b/docs/migration/solr-9-to-10.md
@@ -298,7 +298,7 @@ Replace all Solr 9 CLI syntax with Solr 10 double-dash equivalents in the `solr-
 
 ```bash
 # Before (Solr 9.7)
-solr zk cp file:/tmp/empty-security.json zk:/security.json -z "$ZK_HOST"
+solr zk cp file:/var/solr/data/empty-security.json zk:/security.json -z "$ZK_HOST"
 
 solr auth enable --type basicAuth \
   -u "$SOLR_ADMIN_USER:$SOLR_ADMIN_PASS" \
@@ -311,7 +311,7 @@ solr zk upconfig -z "$ZK_HOST" -n books -d /configsets/books
 solr zk ls /configs -z "$ZK_HOST"
 
 # After (Solr 10)
-solr zk cp file:/tmp/empty-security.json zk:/security.json --zk-host "$ZK_HOST"
+solr zk cp file:/var/solr/data/empty-security.json zk:/security.json --zk-host "$ZK_HOST"
 
 solr auth enable --type basicAuth \
   --credentials "$SOLR_ADMIN_USER:$SOLR_ADMIN_PASS" \

--- a/docs/migration/solr-compat-layer.md
+++ b/docs/migration/solr-compat-layer.md
@@ -36,14 +36,14 @@ names for the detected Solr version.
 
 | Solr 9 | Solr 10 | Affected Files |
 |--------|---------|----------------|
-| `solr zk cp … -z HOST` | `solr zk cp … --zk-host HOST` | `docker-compose.yml:737` |
-| `solr auth enable -u USER:PASS` | `solr auth enable --credentials USER:PASS` | `docker-compose.yml:741-745` |
-| `solr auth enable -z HOST` | `solr auth enable --zk-host HOST` | `docker-compose.yml:745` |
-| `solr zk ls … -z HOST` | `solr zk ls … --zk-host HOST` | `docker-compose.yml:791` |
-| `solr zk upconfig -z HOST -n NAME -d DIR` | `solr zk upconfig --zk-host HOST --name NAME --dir DIR` | `docker-compose.yml:792` |
+| `solr zk cp … -z HOST` | `solr zk cp … --zk-host HOST` | `docker-compose.yml`, `docker/compose.prod.yml`, `docker/solr-init.sh` |
+| `solr auth enable -u USER:PASS` | `solr auth enable --credentials USER:PASS` | `docker-compose.yml`, `docker/compose.prod.yml`, `docker/solr-init.sh` |
+| `solr auth enable -z HOST` | `solr auth enable --zk-host HOST` | `docker-compose.yml`, `docker/compose.prod.yml`, `docker/solr-init.sh` |
+| `solr zk ls … -z HOST` | `solr zk ls … --zk-host HOST` | `docker-compose.yml`, `docker/compose.prod.yml`, `docker/solr-init.sh` |
+| `solr zk upconfig -z HOST -n NAME -d DIR` | `solr zk upconfig --zk-host HOST --name NAME --dir DIR` | `docker-compose.yml`, `docker/compose.prod.yml`, `docker/solr-init.sh` |
 
-**Compat approach**: The `solr-init` entrypoint in `docker-compose.yml` reads
-`SOLR_VERSION` and uses version-appropriate CLI flags via shell helper functions.
+**Compat approach**: The `solr-init` entrypoints read `SOLR_VERSION` and use
+version-appropriate CLI flags via shell helper functions.
 
 ### 3. `blockUnknown` Default Change (MEDIUM impact)
 

--- a/docs/migration/solr-compat-layer.md
+++ b/docs/migration/solr-compat-layer.md
@@ -49,9 +49,9 @@ version-appropriate CLI flags via shell helper functions.
 
 | Solr 9 | Solr 10 | Affected Files |
 |--------|---------|----------------|
-| Default: `false` | Default: `true` | `docker-compose.yml:743`, `src/solr/security.json` |
+| Default: `false` | Default: `true` | `docker-compose.yml`, `docker/compose.prod.yml`, `docker/solr-init.sh`, `src/solr/security.json` |
 
-**Current state**: We explicitly set `--block-unknown false` in the CLI and
+**Current state**: We explicitly set `--block-unknown false` in each `solr-init` entrypoint and
 `"blockUnknown": false` in `security.json`. Both are already safe for Solr 10.
 
 **Compat approach**: No code change needed — explicit setting overrides defaults.

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -116,7 +116,7 @@ def test_init_script_does_not_overwrite_admin_roles():
 
     # Verify solr auth enable is used for admin bootstrap
     assert "solr auth enable" in script, "solr-init script missing 'solr auth enable' command"
-    assert "-u" in script, "solr-init script missing -u flag in solr auth enable"
+    assert "solr_credentials_flag" in script, "solr-init script must use credentials compatibility helper"
     assert "SOLR_ADMIN_USER" in script, "solr-init script must reference SOLR_ADMIN_USER"
 
     # Verify there is NO set-user-role call for the admin user

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -231,20 +231,22 @@ def test_solr_init_cli_helpers_translate_flags_for_solr_9_and_10(script_name: st
     ],
 )
 def test_solr_init_security_seed_uses_writable_solr_data_path(script_name: str, script: str):
-    """Solr init must seed security.json in a writable directory (not /opt/solr)."""
+    """Solr 9 init must not seed security.json under unwritable /opt/solr."""
     normalized = script.replace("$$", "$")
 
     seed_lines = [line for line in normalized.splitlines() if "empty-security.json" in line]
 
     assert "/opt/solr/empty-security.json" not in normalized, f"{script_name} must not write under /opt/solr"
     assert seed_lines, f"{script_name} must seed security.json before enabling auth"
-    # Accept either /tmp (always writable) or /var/solr/data (Solr's data directory when available)
-    assert all(
-        "/tmp/empty-security.json" in line or "/var/solr/data/empty-security.json" in line
-        for line in seed_lines
-    ), (
-        f"{script_name} must use a writable directory for seed security.json"
+    assert all("/var/solr/data/empty-security.json" in line for line in seed_lines), (
+        f"{script_name} must only use Solr's writable data directory for the seed security.json"
     )
+    assert "echo '{}' > /var/solr/data/empty-security.json" in normalized, (
+        f"{script_name} must create the seed security.json in Solr's writable data directory"
+    )
+    assert (
+        'solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized
+    ), f"{script_name} must upload the seed security.json from Solr's writable data directory"
 
 
 @pytest.mark.parametrize(

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -230,13 +230,38 @@ def test_solr_init_cli_helpers_translate_flags_for_solr_9_and_10(script_name: st
         ("docker/solr-init.sh", _load_solr_init_shell_script()),
     ],
 )
+def test_solr_init_security_seed_uses_writable_solr_data_path(script_name: str, script: str):
+    """Solr init must seed security.json in a writable directory (not /opt/solr)."""
+    normalized = script.replace("$$", "$")
+
+    seed_lines = [line for line in normalized.splitlines() if "empty-security.json" in line]
+
+    assert "/opt/solr/empty-security.json" not in normalized, f"{script_name} must not write under /opt/solr"
+    assert seed_lines, f"{script_name} must seed security.json before enabling auth"
+    # Accept either /tmp (always writable) or /var/solr/data (Solr's data directory when available)
+    assert all(
+        "/tmp/empty-security.json" in line or "/var/solr/data/empty-security.json" in line
+        for line in seed_lines
+    ), (
+        f"{script_name} must use a writable directory for seed security.json"
+    )
+
+
+@pytest.mark.parametrize(
+    ("script_name", "script"),
+    [
+        ("docker-compose.yml", _load_solr_init_script()),
+        ("docker/compose.prod.yml", _load_compose_prod_init_script()),
+        ("docker/solr-init.sh", _load_solr_init_shell_script()),
+    ],
+)
 def test_solr_init_cli_commands_use_compatibility_helpers(script_name: str, script: str):
     """All solr CLI commands affected by Solr 10 must call version-aware flag helpers."""
     normalized = script.replace("$$", "$")
 
-    assert 'solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized, (
-        f"{script_name} must use the zk-host helper for solr zk cp"
-    )
+    assert (
+        'solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized
+    ), f"{script_name} must use the zk-host helper for solr zk cp"
     assert re.search(
         r'"\$\(solr_credentials_flag\)" "\$[{]?SOLR_ADMIN_USER[}]?:\$[{]?SOLR_ADMIN_PASS[}]?"',
         normalized,

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -238,15 +238,15 @@ def test_solr_init_security_seed_uses_writable_solr_data_path(script_name: str, 
 
     assert "/opt/solr/empty-security.json" not in normalized, f"{script_name} must not write under /opt/solr"
     assert seed_lines, f"{script_name} must seed security.json before enabling auth"
-    assert all("/var/solr/data/empty-security.json" in line for line in seed_lines), (
-        f"{script_name} must only use Solr's writable data directory for the seed security.json"
+    assert all("/var/solr/empty-security.json" in line for line in seed_lines), (
+        f"{script_name} must only use Solr's writable home directory for the seed security.json"
     )
-    assert "echo '{}' > /var/solr/data/empty-security.json" in normalized, (
-        f"{script_name} must create the seed security.json in Solr's writable data directory"
+    assert "echo '{}' > /var/solr/empty-security.json" in normalized, (
+        f"{script_name} must create the seed security.json in Solr's writable home directory"
     )
-    assert (
-        'solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized
-    ), f"{script_name} must upload the seed security.json from Solr's writable data directory"
+    assert 'solr zk cp file:/var/solr/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized, (
+        f"{script_name} must upload the seed security.json from Solr's writable home directory"
+    )
 
 
 @pytest.mark.parametrize(
@@ -261,9 +261,9 @@ def test_solr_init_cli_commands_use_compatibility_helpers(script_name: str, scri
     """All solr CLI commands affected by Solr 10 must call version-aware flag helpers."""
     normalized = script.replace("$$", "$")
 
-    assert (
-        'solr zk cp file:/var/solr/data/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized
-    ), f"{script_name} must use the zk-host helper for solr zk cp"
+    assert 'solr zk cp file:/var/solr/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized, (
+        f"{script_name} must use the zk-host helper for solr zk cp"
+    )
     assert re.search(
         r'"\$\(solr_credentials_flag\)" "\$[{]?SOLR_ADMIN_USER[}]?:\$[{]?SOLR_ADMIN_PASS[}]?"',
         normalized,

--- a/src/solr-search/tests/test_solr_init_script.py
+++ b/src/solr-search/tests/test_solr_init_script.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess  # nosec B404
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -60,6 +62,45 @@ def _load_solr_import_script() -> str:
     """Load scripts/solr-import.sh."""
     with open(SOLR_IMPORT_SCRIPT_PATH, encoding="utf-8") as fh:
         return fh.read()
+
+
+def _load_compose_prod_init_script() -> str:
+    """Extract the inline entrypoint script for the prod solr-init service."""
+    compose_prod = _load_compose(COMPOSE_PROD_PATH)
+    entrypoint = compose_prod.get("services", {}).get("solr-init", {}).get("entrypoint", [])
+    assert len(entrypoint) >= 3, f"Unexpected solr-init entrypoint format in {COMPOSE_PROD_PATH.name}: {entrypoint}"
+    return entrypoint[2]
+
+
+def _extract_cli_helper_functions(script: str) -> str:
+    """Extract version-aware solr CLI flag helpers from a shell script."""
+    normalized = script.replace("$$", "$")
+    match = re.search(
+        r"solr_major_version\(\) \{.*?solr_dir_flag\(\) \{\n.*?\n\s*\}",
+        normalized,
+        re.DOTALL,
+    )
+    assert match, "solr-init script must define Solr CLI compatibility helper functions"
+    return match.group(0)
+
+
+def _evaluate_cli_flags(script: str, solr_version: str) -> list[str]:
+    helpers = _extract_cli_helper_functions(script)
+    command = f"""
+{helpers}
+SOLR_VERSION={solr_version}
+solr_credentials_flag
+solr_zk_host_flag
+solr_name_flag
+solr_dir_flag
+"""
+    result = subprocess.run(  # noqa: S603
+        ["bash", "-ceu", command],  # noqa: S607
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.splitlines()
 
 
 # ---------- 1. Admin role assignment ----------
@@ -151,18 +192,63 @@ def test_block_unknown_explicitly_set_to_false_in_init_scripts():
     """All Solr init scripts must explicitly set --block-unknown false."""
     compose_embedded_script = _load_solr_init_script()
     file_script = _load_solr_init_shell_script()
-    compose_prod = _load_compose(COMPOSE_PROD_PATH)
-    compose_prod_entrypoint = compose_prod.get("services", {}).get("solr-init", {}).get("entrypoint", [])
-    assert len(compose_prod_entrypoint) >= 3, (
-        f"Unexpected solr-init entrypoint format in {COMPOSE_PROD_PATH.name}: {compose_prod_entrypoint}"
-    )
-    compose_prod_script = compose_prod_entrypoint[2]
+    compose_prod_script = _load_compose_prod_init_script()
 
     assert "--block-unknown false" in compose_embedded_script, "docker-compose solr-init must set --block-unknown false"
     assert "--block-unknown false" in file_script, "docker/solr-init.sh must set --block-unknown false"
     assert "--block-unknown false" in compose_prod_script, (
         "docker/compose.prod.yml solr-init must set --block-unknown false"
     )
+
+
+@pytest.mark.parametrize(
+    ("script_name", "script"),
+    [
+        ("docker-compose.yml", _load_solr_init_script()),
+        ("docker/compose.prod.yml", _load_compose_prod_init_script()),
+        ("docker/solr-init.sh", _load_solr_init_shell_script()),
+    ],
+)
+def test_solr_init_cli_helpers_translate_flags_for_solr_9_and_10(script_name: str, script: str):
+    """solr-init must emit Solr 9 flags by default and Solr 10 long flags when requested."""
+    assert _evaluate_cli_flags(script, "9") == ["-u", "-z", "-n", "-d"], (
+        f"{script_name} must preserve Solr 9 CLI flag compatibility"
+    )
+    assert _evaluate_cli_flags(script, "10") == ["--credentials", "--zk-host", "--name", "--dir"], (
+        f"{script_name} must translate solr CLI flags to Solr 10 double-dash syntax"
+    )
+    assert _evaluate_cli_flags(script, "10.0.0") == ["--credentials", "--zk-host", "--name", "--dir"], (
+        f"{script_name} must accept full Solr 10 version strings"
+    )
+
+
+@pytest.mark.parametrize(
+    ("script_name", "script"),
+    [
+        ("docker-compose.yml", _load_solr_init_script()),
+        ("docker/compose.prod.yml", _load_compose_prod_init_script()),
+        ("docker/solr-init.sh", _load_solr_init_shell_script()),
+    ],
+)
+def test_solr_init_cli_commands_use_compatibility_helpers(script_name: str, script: str):
+    """All solr CLI commands affected by Solr 10 must call version-aware flag helpers."""
+    normalized = script.replace("$$", "$")
+
+    assert 'solr zk cp file:/opt/solr/empty-security.json zk:/security.json "$(solr_zk_host_flag)"' in normalized, (
+        f"{script_name} must use the zk-host helper for solr zk cp"
+    )
+    assert re.search(
+        r'"\$\(solr_credentials_flag\)" "\$[{]?SOLR_ADMIN_USER[}]?:\$[{]?SOLR_ADMIN_PASS[}]?"',
+        normalized,
+    ), f"{script_name} must use the credentials helper for solr auth enable"
+    assert re.search(r'solr zk ls /configs "\$\(solr_zk_host_flag\)" "\$[{]?ZK_HOST[}]?"', normalized), (
+        f"{script_name} must use the zk-host helper for solr zk ls"
+    )
+    assert re.search(
+        r'solr zk upconfig "\$\(solr_zk_host_flag\)" "\$[{]?ZK_HOST[}]?" '
+        r'"\$\(solr_name_flag\)" books "\$\(solr_dir_flag\)" "\$[{]?CONFIGSET_DIR[}]?"',
+        normalized,
+    ), f"{script_name} must use compatibility helpers for solr zk upconfig"
 
 
 def test_security_json_explicitly_sets_block_unknown_false():


### PR DESCRIPTION
## Summary
- Adds version-aware solr-init CLI flag helpers for Solr 9/10 compatibility
- Uses Solr 10 double-dash flags for credentials, ZooKeeper host, configset name, and configset dir when `SOLR_VERSION` is 10.x
- Updates dev/prod compose entrypoints and `docker/solr-init.sh`; documents the covered entrypoints
- Adds tests for Solr 9 default flags, Solr 10 long flags, and command helper wiring

Working as Parker (Backend Dev).

Closes #1337

## Validation
- `uv run pytest tests/test_solr_init_script.py -q --tb=short --no-cov`
- `.squad/scripts/verify.sh`
- `docker compose ... config --quiet` for dev/prod compose with dummy required env vars
