### PR TITLE
Harden Solr Security UI backend access

### DIFF
--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -147,11 +147,30 @@ Common local URLs:
 | Search API | `http://localhost/v1/search/` | Protected |
 | Status API | `http://localhost/v1/status/` | Protected |
 | Stats API | `http://localhost/v1/stats/` | Protected |
-| Solr admin | `http://localhost/admin/solr/` | Protected |
-| RabbitMQ management | `http://localhost/admin/rabbitmq/` | Protected |
-| Redis Commander | `http://localhost/admin/redis/` | Protected |
+| Solr admin | `http://localhost/admin/solr/` | Admin-only |
+| Solr 10 Security UI | `http://localhost/admin/solr/ui/` | Admin-only; Solr RBAC also applies |
+| RabbitMQ management | `http://localhost/admin/rabbitmq/` | Admin-only |
+| Redis Commander | `http://localhost/admin/redis/` | Admin-only |
 
 Health, info, version, and auth bootstrap endpoints remain available for operational checks and login flows. Direct host ports (`8080`, `8983`-`8985`, `15672`, `6379`, `2181`-`2183`, `18080`, `8081`, `8085`) are available only when the local `docker/compose.dev-ports.yml` file is loaded.
+
+### Solr 10 Security UI
+
+Solr 10's Admin UI is proxied at `/admin/solr/ui/` so operators can use Solr's built-in security screens instead of manually editing `security.json`.
+
+Security posture:
+- The nginx proxy requires an authenticated Aithena user with role `admin` via `GET /v1/auth/validate-admin`.
+- Non-admin Aithena users cannot open the Solr, RabbitMQ, or Redis admin tools through nginx.
+- Aithena does not bypass Solr authorization. User creation, password changes, and role assignments remain enforced by Solr BasicAuth/RBAC; use a Solr account with the required `security-edit` permission for state-changing security operations.
+- Browser auth cookies are `HttpOnly` and `SameSite=Lax`; Solr still owns CSRF behavior for its UI forms/API calls.
+
+To add or remove Solr users and roles in Solr 10:
+
+1. Sign in to Aithena as an `admin`.
+2. Open **Admin → Infrastructure → Solr Admin** or go directly to `/admin/solr/ui/`.
+3. Authenticate to Solr if prompted.
+4. Open the Solr UI security section.
+5. Use the Solr UI controls to add/remove users and assign roles, then verify the resulting permissions before signing out.
 
 ## GPU Acceleration Setup (v1.17.0)
 

--- a/src/nginx/default.conf
+++ b/src/nginx/default.conf
@@ -34,8 +34,9 @@ server {
     }
 
     location /admin/solr/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
@@ -53,8 +54,9 @@ server {
     }
 
     location /solr/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
@@ -67,8 +69,9 @@ server {
     }
 
     location /admin/rabbitmq/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
@@ -84,8 +87,9 @@ server {
     }
 
     location /admin/redis/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
@@ -106,6 +110,16 @@ server {
         proxy_set_header Authorization $http_authorization;
     }
 
+    location = /_admin_auth {
+        internal;
+        proxy_pass http://solr-search:8080/v1/auth/validate-admin;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Authorization $http_authorization;
+    }
+
     location @auth_error {
         default_type application/json;
         # Allow the 401 JSON response to be displayed inside the PDF viewer
@@ -119,6 +133,13 @@ server {
 
     location @auth_redirect {
         return 302 /?redirect=$request_uri;
+    }
+
+    location @auth_forbidden {
+        default_type application/json;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        return 403 '{"detail":"Admin access required"}';
     }
 
     location = /v1/auth/login {

--- a/src/nginx/default.conf
+++ b/src/nginx/default.conf
@@ -137,6 +137,7 @@ server {
 
     location @auth_forbidden {
         default_type application/json;
+        add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         return 403 '{"detail":"Admin access required"}';

--- a/src/nginx/default.conf.template
+++ b/src/nginx/default.conf.template
@@ -34,12 +34,9 @@ server {
     }
 
     location /admin/solr/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
-        # Inject Solr BasicAuth so authenticated portal users reach the Solr UI
-        # without re-entering credentials (SSO). The JWT is already validated by
-        # auth_request above; this only adds the Solr service credential.
-        proxy_set_header Authorization "Basic ${SOLR_BASIC_AUTH}";
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
@@ -57,9 +54,9 @@ server {
     }
 
     location /solr/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
-        proxy_set_header Authorization "Basic ${SOLR_BASIC_AUTH}";
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
@@ -72,8 +69,9 @@ server {
     }
 
     location /admin/rabbitmq/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
@@ -93,8 +91,9 @@ server {
     }
 
     location /admin/redis/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
@@ -115,6 +114,16 @@ server {
         proxy_set_header Authorization $http_authorization;
     }
 
+    location = /_admin_auth {
+        internal;
+        proxy_pass http://solr-search:8080/v1/auth/validate-admin;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Authorization $http_authorization;
+    }
+
     location @auth_error {
         default_type application/json;
         # Allow the 401 JSON response to be displayed inside the PDF viewer
@@ -128,6 +137,14 @@ server {
 
     location @auth_redirect {
         return 302 /?redirect=$request_uri;
+    }
+
+    location @auth_forbidden {
+        default_type application/json;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        return 403 '{"detail":"Admin access required"}';
     }
 
     location = /v1/auth/login {

--- a/src/nginx/ssl.conf.template
+++ b/src/nginx/ssl.conf.template
@@ -48,9 +48,9 @@ server {
     }
 
     location /admin/solr/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
-        proxy_set_header Authorization "Basic ${SOLR_BASIC_AUTH}";
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
@@ -68,9 +68,9 @@ server {
     }
 
     location /solr/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
-        proxy_set_header Authorization "Basic ${SOLR_BASIC_AUTH}";
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
@@ -83,8 +83,9 @@ server {
     }
 
     location /admin/rabbitmq/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
@@ -104,8 +105,9 @@ server {
     }
 
     location /admin/redis/ {
-        auth_request /_auth;
+        auth_request /_admin_auth;
         error_page 401 = @auth_redirect;
+        error_page 403 = @auth_forbidden;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
@@ -119,6 +121,16 @@ server {
     location = /_auth {
         internal;
         proxy_pass http://solr-search:8080/v1/auth/validate;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Authorization $http_authorization;
+    }
+
+    location = /_admin_auth {
+        internal;
+        proxy_pass http://solr-search:8080/v1/auth/validate-admin;
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";
         proxy_set_header X-Original-URI $request_uri;
@@ -140,6 +152,15 @@ server {
 
     location @auth_redirect {
         return 302 /?redirect=$request_uri;
+    }
+
+    location @auth_forbidden {
+        default_type application/json;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        return 403 '{"detail":"Admin access required"}';
     }
 
     location = /v1/auth/login {

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -819,6 +819,22 @@ def auth_validate(request: Request, response: Response) -> dict[str, Any]:
     return {"authenticated": True, "user": user.to_dict()}
 
 
+@app.get("/v1/auth/validate-admin/", include_in_schema=False, name="auth_validate_admin_v1_slash")
+@app.get("/v1/auth/validate-admin", name="auth_validate_admin_v1")
+def auth_validate_admin(request: Request, response: Response) -> dict[str, Any]:
+    """Validate a browser session for nginx-proxied admin tools.
+
+    This endpoint is intentionally JWT/cookie-only (no ADMIN_API_KEY fallback)
+    because nginx auth_request uses it to protect browser-accessible UIs such
+    as Solr's Security UI. Machine API keys must not grant browser UI access.
+    """
+    validation = auth_validate(request, response)
+    user = validation["user"]
+    if user["role"] != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return {"authenticated": True, "admin": True, "user": user}
+
+
 @app.post("/v1/auth/logout/", include_in_schema=False, name="auth_logout_v1_slash")
 @app.post("/v1/auth/logout", name="auth_logout_v1")
 def auth_logout(request: Request, response: Response) -> dict[str, str]:
@@ -3923,6 +3939,7 @@ def admin_infrastructure() -> dict[str, Any]:
             "name": "solr",
             "status": "up" if solr_up else "down",
             "admin_url": "/admin/solr/",
+            "security_ui_url": "/admin/solr/ui/",
             "description": "Full-text search engine",
         },
         {
@@ -3956,6 +3973,18 @@ def admin_infrastructure() -> dict[str, Any]:
     return {
         "services": services,
         "connections": connections,
+        "solr_admin_url": "/admin/solr/",
+        "solr_security_ui": {
+            "url": "/admin/solr/ui/",
+            "admin_url": "/admin/solr/",
+            "auth_check_url": "/v1/auth/validate-admin",
+            "required_aithena_role": "admin",
+            "state_changing_operations": (
+                "Handled by Solr's Security UI and Solr RBAC; Aithena only gates proxy access."
+            ),
+        },
+        "rabbitmq_admin_url": "/admin/rabbitmq/",
+        "redis_admin_url": "/admin/redis/",
     }
 
 

--- a/src/solr-search/tests/test_admin_api.py
+++ b/src/solr-search/tests/test_admin_api.py
@@ -358,6 +358,14 @@ class TestInfrastructure:
         assert "rabbitmq_amqp" in data["connections"]
         assert "rabbitmq_mgmt" in data["connections"]
         assert "embeddings" in data["connections"]
+        assert data["solr_admin_url"] == "/admin/solr/"
+        assert data["rabbitmq_admin_url"] == "/admin/rabbitmq/"
+        assert data["redis_admin_url"] == "/admin/redis/"
+
+        security_ui = data["solr_security_ui"]
+        assert security_ui["url"] == "/admin/solr/ui/"
+        assert security_ui["auth_check_url"] == "/v1/auth/validate-admin"
+        assert security_ui["required_aithena_role"] == "admin"
 
     def test_infrastructure_some_down(self):
         def selective_tcp(host, port, timeout=2.0):

--- a/src/solr-search/tests/test_auth.py
+++ b/src/solr-search/tests/test_auth.py
@@ -130,6 +130,29 @@ def test_validate_accepts_cookie_auth(client: TestClient, seeded_user: Authentic
     assert response.json()["authenticated"] is True
 
 
+def test_validate_admin_accepts_admin_session(client: TestClient, seeded_user: AuthenticatedUser) -> None:
+    token = create_access_token(seeded_user, settings.auth_jwt_secret, settings.auth_jwt_ttl_seconds)
+
+    response = client.get("/v1/auth/validate-admin", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "authenticated": True,
+        "admin": True,
+        "user": {"id": seeded_user.id, "username": seeded_user.username, "role": "admin"},
+    }
+
+
+def test_validate_admin_rejects_non_admin_session(client: TestClient) -> None:
+    non_admin = AuthenticatedUser(id=7, username="reader", role="viewer")
+    token = create_access_token(non_admin, settings.auth_jwt_secret, settings.auth_jwt_ttl_seconds)
+
+    response = client.get("/v1/auth/validate-admin", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Admin access required"}
+
+
 def test_me_returns_current_user_info(client: TestClient, seeded_user: AuthenticatedUser) -> None:
     token = create_access_token(seeded_user, settings.auth_jwt_secret, settings.auth_jwt_ttl_seconds)
 

--- a/src/solr-search/tests/test_nginx_limits.py
+++ b/src/solr-search/tests/test_nginx_limits.py
@@ -24,6 +24,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 REPO_ROOT = Path(__file__).resolve().parents[3]  # src/solr-search/tests -> repo root
 NGINX_CONF = REPO_ROOT / "src" / "nginx" / "default.conf"
 NGINX_CONF_TEMPLATE = REPO_ROOT / "src" / "nginx" / "default.conf.template"
+NGINX_SSL_CONF_TEMPLATE = REPO_ROOT / "src" / "nginx" / "ssl.conf.template"
+NGINX_ADMIN_AUTH_CONFIGS = (NGINX_CONF, NGINX_CONF_TEMPLATE, NGINX_SSL_CONF_TEMPLATE)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -140,20 +142,24 @@ class TestNginxProxyTimeouts:
 class TestNginxAdminToolAuth:
     """Ensure browser-accessible infrastructure UIs require admin sessions."""
 
+    @pytest.mark.parametrize("conf_path", NGINX_ADMIN_AUTH_CONFIGS, ids=lambda path: path.name)
     @pytest.mark.parametrize("location", ["/admin/solr/", "/solr/", "/admin/rabbitmq/", "/admin/redis/"])
-    def test_admin_tool_locations_use_admin_auth_request(self, location: str) -> None:
-        block = _location_block(NGINX_CONF.read_text(), location)
+    def test_admin_tool_locations_use_admin_auth_request(self, conf_path: Path, location: str) -> None:
+        block = _location_block(conf_path.read_text(), location)
         assert "auth_request /_admin_auth;" in block
         assert "error_page 403 = @auth_forbidden;" in block
+        assert "proxy_set_header Authorization" not in block
 
-    def test_admin_auth_subrequest_uses_validate_admin_endpoint(self) -> None:
-        block = _location_block(NGINX_CONF.read_text(), "= /_admin_auth")
+    @pytest.mark.parametrize("conf_path", NGINX_ADMIN_AUTH_CONFIGS, ids=lambda path: path.name)
+    def test_admin_auth_subrequest_uses_validate_admin_endpoint(self, conf_path: Path) -> None:
+        block = _location_block(conf_path.read_text(), "= /_admin_auth")
         assert "proxy_pass http://solr-search:8080/v1/auth/validate-admin;" in block
         assert "proxy_pass_request_body off;" in block
         assert "proxy_set_header Cookie $http_cookie;" in block
 
-    def test_admin_forbidden_response_keeps_security_headers(self) -> None:
-        block = _location_block(NGINX_CONF.read_text(), "@auth_forbidden")
+    @pytest.mark.parametrize("conf_path", NGINX_ADMIN_AUTH_CONFIGS, ids=lambda path: path.name)
+    def test_admin_forbidden_response_keeps_security_headers(self, conf_path: Path) -> None:
+        block = _location_block(conf_path.read_text(), "@auth_forbidden")
         assert 'add_header X-Frame-Options "DENY" always;' in block
         assert 'add_header X-Content-Type-Options "nosniff" always;' in block
         assert 'add_header Referrer-Policy "strict-origin-when-cross-origin" always;' in block

--- a/src/solr-search/tests/test_nginx_limits.py
+++ b/src/solr-search/tests/test_nginx_limits.py
@@ -152,6 +152,12 @@ class TestNginxAdminToolAuth:
         assert "proxy_pass_request_body off;" in block
         assert "proxy_set_header Cookie $http_cookie;" in block
 
+    def test_admin_forbidden_response_keeps_security_headers(self) -> None:
+        block = _location_block(NGINX_CONF.read_text(), "@auth_forbidden")
+        assert 'add_header X-Frame-Options "DENY" always;' in block
+        assert 'add_header X-Content-Type-Options "nosniff" always;' in block
+        assert 'add_header Referrer-Policy "strict-origin-when-cross-origin" always;' in block
+
 
 class TestNginxBodySizeParser:
     """Unit tests for the _parse_body_size_mb helper itself."""

--- a/src/solr-search/tests/test_nginx_limits.py
+++ b/src/solr-search/tests/test_nginx_limits.py
@@ -63,6 +63,17 @@ def _parse_timeouts(conf_text: str) -> dict[str, int]:
     return timeouts
 
 
+def _location_block(conf_text: str, location: str) -> str:
+    """Return a simple one-level nginx location block body for static config tests."""
+    marker = f"location {location} {{"
+    start = conf_text.find(marker)
+    assert start != -1, f"location {location} not found"
+    body_start = start + len(marker)
+    end = conf_text.find("\n    }", body_start)
+    assert end != -1, f"location {location} is not closed"
+    return conf_text[body_start:end]
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -124,6 +135,22 @@ class TestNginxProxyTimeouts:
         assert connect_timeout <= 30, (
             f"proxy_connect_timeout ({connect_timeout}s) is too high — connections to local services should be fast"
         )
+
+
+class TestNginxAdminToolAuth:
+    """Ensure browser-accessible infrastructure UIs require admin sessions."""
+
+    @pytest.mark.parametrize("location", ["/admin/solr/", "/solr/", "/admin/rabbitmq/", "/admin/redis/"])
+    def test_admin_tool_locations_use_admin_auth_request(self, location: str) -> None:
+        block = _location_block(NGINX_CONF.read_text(), location)
+        assert "auth_request /_admin_auth;" in block
+        assert "error_page 403 = @auth_forbidden;" in block
+
+    def test_admin_auth_subrequest_uses_validate_admin_endpoint(self) -> None:
+        block = _location_block(NGINX_CONF.read_text(), "= /_admin_auth")
+        assert "proxy_pass http://solr-search:8080/v1/auth/validate-admin;" in block
+        assert "proxy_pass_request_body off;" in block
+        assert "proxy_set_header Cookie $http_cookie;" in block
 
 
 class TestNginxBodySizeParser:


### PR DESCRIPTION
## Summary
- Add `/v1/auth/validate-admin` for nginx auth_request on browser admin tools.
- Require Aithena admin role for `/admin/solr/`, `/solr/`, RabbitMQ, and Redis proxy surfaces.
- Publish the Solr Security UI backend contract from `/v1/admin/infrastructure` and document the operator flow.

Working as Parker (Backend Dev). Kane security constraints preserved: no Solr auth bypass, admin-only proxy gating, Solr RBAC remains authoritative for user/role mutations.

Closes #1350

## Tests
- `uv run pytest tests/test_auth.py tests/test_admin_api.py tests/test_nginx_limits.py --tb=short -q --no-cov`
- `.squad/scripts/verify.sh`
- pre-commit hook: solr-search ruff + pytest (1131 passed, 21 skipped)