### PR TITLE
Add opt-in Solr 10 runtime overlay

### DIFF
--- a/.github/workflows/solr-image-validation.yml
+++ b/.github/workflows/solr-image-validation.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'src/solr/**'
+      - 'docker/compose.solr10.yml'
       - '.github/workflows/build-containers.yml'
       - '.github/workflows/solr-image-validation.yml'
       - 'tests/test-solr-image-refs.sh'
@@ -31,6 +32,22 @@ jobs:
 
       - name: Validate Solr 10 image references
         run: bash tests/test-solr-image-refs.sh
+
+      - name: Validate opt-in Solr 10 Compose overlay
+        env:
+          ADMIN_API_KEY: ci-admin-api-key
+          AUTH_DB_DIR: .auth-data
+          AUTH_JWT_SECRET: ci-jwt-secret-change-me
+          SOLR_ADMIN_USER: solr_admin
+          SOLR_ADMIN_PASS: SolrAdmin_dev2024!
+          SOLR_READONLY_USER: solr_read
+          SOLR_READONLY_PASS: SolrRead_dev2024!
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker/compose.single-node.yml \
+            -f docker/compose.solr10.yml \
+            config >/dev/null
 
       - name: Build Solr 10 image
         run: |

--- a/docker/compose.solr10.yml
+++ b/docker/compose.solr10.yml
@@ -1,0 +1,33 @@
+# Opt-in Solr 10 runtime overlay.
+#
+# Defaults stay on Solr 9.7. Use this overlay only for Solr 10 validation:
+#   docker compose -f docker-compose.yml -f docker/compose.single-node.yml -f docker/compose.solr10.yml up -d solr solr-init
+
+services:
+  solr:
+    build:
+      args:
+        SOLR_BASE_IMAGE: solr:10
+    environment:
+      SOLR_VERSION: "10"
+
+  solr2:
+    build:
+      args:
+        SOLR_BASE_IMAGE: solr:10
+    environment:
+      SOLR_VERSION: "10"
+
+  solr3:
+    build:
+      args:
+        SOLR_BASE_IMAGE: solr:10
+    environment:
+      SOLR_VERSION: "10"
+
+  solr-init:
+    build:
+      args:
+        SOLR_BASE_IMAGE: solr:10
+    environment:
+      SOLR_VERSION: "10"

--- a/docs/migration/solr-compat-layer.md
+++ b/docs/migration/solr-compat-layer.md
@@ -129,7 +129,7 @@ is ready for use when:
 
 | Variable | Default | Values | Where |
 |----------|---------|--------|-------|
-| `SOLR_VERSION` | `9` | `9`, `10` | `.env.example`, `docker-compose.yml`, opt-in `docker/compose.solr10.yml` |
+| `SOLR_VERSION` | `9` | `9`, `10` | `.env.example`, `docker-compose.yml`, `docker/compose.prod.yml`, opt-in `docker/compose.solr10.yml` |
 
 ---
 
@@ -138,7 +138,7 @@ is ready for use when:
 When switching from Solr 9 to 10:
 
 1. [ ] For validation runs, add `docker/compose.solr10.yml` to `COMPOSE_FILE` so Solr containers build with `SOLR_BASE_IMAGE=solr:10` and run with `SOLR_VERSION=10`
-2. [ ] For final cutover, update `src/solr/Dockerfile` default `SOLR_BASE_IMAGE` from `solr:9.7` to `solr:10`
+2. [ ] For final cutover, update `src/solr/Dockerfile` default `SOLR_BASE_IMAGE` from `solr:9.7` to `solr:10` after the Solr 10 runtime overlay has been validated
 3. [ ] Update `src/solr/books/solrconfig.xml` `luceneMatchVersion` to `10.0`
 4. [ ] Verify CLI commands in `docker-compose.yml` use double-dash syntax
 5. [ ] Upload the updated `books` configset and re-index all data (required after

--- a/docs/migration/solr-compat-layer.md
+++ b/docs/migration/solr-compat-layer.md
@@ -129,7 +129,7 @@ is ready for use when:
 
 | Variable | Default | Values | Where |
 |----------|---------|--------|-------|
-| `SOLR_VERSION` | `9` | `9`, `10` | `.env.example`, `docker-compose.yml` |
+| `SOLR_VERSION` | `9` | `9`, `10` | `.env.example`, `docker-compose.yml`, opt-in `docker/compose.solr10.yml` |
 
 ---
 
@@ -137,8 +137,8 @@ is ready for use when:
 
 When switching from Solr 9 to 10:
 
-1. [ ] Set `SOLR_VERSION=10` in `.env`
-2. [ ] Update `src/solr/Dockerfile` to `FROM solr:10`
+1. [ ] For validation runs, add `docker/compose.solr10.yml` to `COMPOSE_FILE` so Solr containers build with `SOLR_BASE_IMAGE=solr:10` and run with `SOLR_VERSION=10`
+2. [ ] For final cutover, update `src/solr/Dockerfile` default `SOLR_BASE_IMAGE` from `solr:9.7` to `solr:10`
 3. [ ] Update `src/solr/books/solrconfig.xml` `luceneMatchVersion` to `10.0`
 4. [ ] Verify CLI commands in `docker-compose.yml` use double-dash syntax
 5. [ ] Upload the updated `books` configset and re-index all data (required after

--- a/src/solr-search/tests/test_e2e_solr10_bootstrap.py
+++ b/src/solr-search/tests/test_e2e_solr10_bootstrap.py
@@ -20,6 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 COMPOSE_PATH = REPO_ROOT / "docker-compose.yml"
 COMPOSE_PROD_PATH = REPO_ROOT / "docker" / "compose.prod.yml"
 E2E_COMPOSE_PATH = REPO_ROOT / "docker" / "compose.e2e.yml"
+SOLR10_COMPOSE_PATH = REPO_ROOT / "docker" / "compose.solr10.yml"
 SOLR_INIT_SCRIPT_PATH = REPO_ROOT / "docker" / "solr-init.sh"
 SECURITY_JSON_PATH = REPO_ROOT / "src" / "solr" / "security.json"
 MANAGED_SCHEMA_PATH = REPO_ROOT / "src" / "solr" / "books" / "managed-schema.xml"
@@ -77,6 +78,29 @@ class TestSolr10SafePreflight:
                 assert env.get("SOLR_VERSION") == "${SOLR_VERSION:-9}", (
                     f"{compose_path.name}:{service_name} must default SOLR_VERSION to 9 "
                     "while allowing Solr 10 E2E runs via environment override"
+                )
+
+    @pytest.mark.e2e
+    @pytest.mark.solr10
+    def test_solr10_compose_overlay_is_explicit_opt_in(self) -> None:
+        """The runtime slice must keep defaults on Solr 9 and isolate Solr 10 behind an overlay."""
+        overlay_services = _load_yaml(SOLR10_COMPOSE_PATH).get("services", {})
+        assert set(overlay_services) == {*CLUSTER_SOLR_SERVICES, "solr-init"}
+
+        for service_name, service in overlay_services.items():
+            env = _service_env(service)
+            build_args = service.get("build", {}).get("args", {})
+            assert env.get("SOLR_VERSION") == "10", f"{service_name} must opt into Solr 10 CLI behavior"
+            assert build_args.get("SOLR_BASE_IMAGE") == "solr:10", (
+                f"{service_name} must build from the Solr 10 base image only via the opt-in overlay"
+            )
+
+        for compose_path in (COMPOSE_PATH, COMPOSE_PROD_PATH):
+            services = _load_yaml(compose_path).get("services", {})
+            for service_name in (*CLUSTER_SOLR_SERVICES, "solr-init"):
+                build_args = services[service_name].get("build", {}).get("args", {})
+                assert build_args.get("SOLR_BASE_IMAGE") != "solr:10", (
+                    f"{compose_path.name}:{service_name} must not force Solr 10 in the default runtime"
                 )
 
     @pytest.mark.e2e

--- a/tests/test-solr-image-refs.sh
+++ b/tests/test-solr-image-refs.sh
@@ -23,8 +23,21 @@ grep -q 'tag_suffix: "-solr10"' .github/workflows/build-containers.yml ||
 grep -q 'SOLR_BASE_IMAGE=solr:10' .github/workflows/build-containers.yml ||
   fail "build-containers.yml must build the Solr image with SOLR_BASE_IMAGE=solr:10"
 
+grep -q 'docker/compose.solr10.yml' .github/workflows/solr-image-validation.yml ||
+  fail "solr-image-validation.yml must validate the opt-in Solr 10 Compose overlay"
+
+grep -Eq '^[[:space:]]*SOLR_BASE_IMAGE:[[:space:]]*solr:10$' docker/compose.solr10.yml ||
+  fail "docker/compose.solr10.yml must opt Solr builds into solr:10"
+
+grep -Eq '^[[:space:]]*SOLR_VERSION:[[:space:]]*"10"$' docker/compose.solr10.yml ||
+  fail "docker/compose.solr10.yml must opt Solr runtime into SOLR_VERSION=10"
+
 if grep -Eq '^[[:space:]]*image:[[:space:]]*ghcr\.io/jmservera/aithena-solr:' docker-compose.yml docker/*.yml; then
   fail "compose must not consume the experimental Solr 10 image before issue #1337 lands"
 fi
 
-echo "OK: Solr 10 image references are wired for CI and isolated from runtime compose"
+if grep -Eq '^[[:space:]]*SOLR_VERSION:[[:space:]]*"10"$' docker-compose.yml docker/compose.prod.yml; then
+  fail "default runtime compose files must not force SOLR_VERSION=10 before cutover"
+fi
+
+echo "OK: Solr 10 image references are wired for CI and isolated behind the opt-in Compose overlay"


### PR DESCRIPTION
## Summary
Working as Brett (Infrastructure Architect).

Refs #1335.
Related: #1341 (already closed by Solr 10 CI scaffold).

- add `docker/compose.solr10.yml` as an explicit opt-in overlay that builds Solr containers with `SOLR_BASE_IMAGE=solr:10` and sets `SOLR_VERSION=10`
- keep default compose/prod runtime on Solr 9.7; this is a safe validation slice, not the final Dockerfile default cutover
- add CI/static validation for the overlay and update migration notes

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Validation
- `bash tests/test-solr-image-refs.sh`
- `AUTH_DB_DIR=.auth-data AUTH_JWT_SECRET=ci-jwt-secret-change-me ADMIN_API_KEY=ci-admin-api-key SOLR_ADMIN_USER=solr_admin SOLR_ADMIN_PASS=SolrAdmin_dev2024! SOLR_READONLY_USER=solr_read SOLR_READONLY_PASS=SolrRead_dev2024! docker compose -f docker-compose.yml -f docker/compose.single-node.yml -f docker/compose.solr10.yml config >/dev/null`
- `cd src/solr-search && uv run pytest tests/test_e2e_solr10_bootstrap.py tests/test_solr_init_script.py --tb=short -q --no-cov`
- `.squad/scripts/verify.sh` (1154 passed, 21 skipped)
