### PR TITLE
Harden admin infrastructure URL handling

### DIFF
--- a/src/aithena-ui/src/__tests__/AdminInfrastructurePage.test.tsx
+++ b/src/aithena-ui/src/__tests__/AdminInfrastructurePage.test.tsx
@@ -272,6 +272,54 @@ describe('AdminInfrastructurePage', () => {
     expect(redisLink).toHaveAttribute('href', '/custom/redis-commander/');
   });
 
+  it('falls back from unsafe API-provided admin URLs', async () => {
+    const unsafeData = {
+      ...mockInfrastructure,
+      solr_admin_url: 'javascript:alert(1)',
+      services: mockInfrastructure.services.map((service) => ({
+        ...service,
+        admin_url:
+          service.name === 'solr' ? '/\\evil.example/' : `https://evil.example/${service.name}/`,
+      })),
+    };
+    vi.stubGlobal('fetch', createMockFetch({ data: unsafeData }));
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Solr Admin')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Solr Admin').closest('a')).toHaveAttribute('href', '/admin/solr/');
+    expect(screen.getByText('RabbitMQ Management').closest('a')).toHaveAttribute(
+      'href',
+      '/admin/rabbitmq/'
+    );
+    expect(screen.getByText('Redis Commander').closest('a')).toHaveAttribute(
+      'href',
+      '/admin/redis/'
+    );
+  });
+
+  it('redacts sensitive URL details in the connection table', async () => {
+    const sensitiveData = {
+      ...mockInfrastructure,
+      services: [
+        {
+          name: 'embeddings-server',
+          url: 'https://embed-user:embed-pass@embeddings.example/v1/embeddings?token=secret#frag',
+          status: 'up',
+          type: 'embeddings',
+        },
+      ],
+    };
+    vi.stubGlobal('fetch', createMockFetch({ data: sensitiveData }));
+    renderPage();
+
+    await screen.findByText('https://embeddings.example/v1/embeddings');
+    expect(screen.queryByText(/embed-pass/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/token=secret/)).not.toBeInTheDocument();
+  });
+
   it('falls back to legacy URL when service admin_url is null', async () => {
     const nullAdminUrlData = {
       ...mockInfrastructure,

--- a/src/aithena-ui/src/__tests__/SecurityPage.test.tsx
+++ b/src/aithena-ui/src/__tests__/SecurityPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildSolrSecurityUrl } from '../hooks/useAdminInfrastructure';
+import { buildSolrSecurityUrl, safeAdminUrl } from '../hooks/useAdminInfrastructure';
 import SecurityPage from '../pages/SecurityPage';
 import { IntlWrapper } from './test-intl-wrapper';
 
@@ -46,6 +46,13 @@ describe('SecurityPage', () => {
     expect(buildSolrSecurityUrl('/admin/solr')).toBe('/admin/solr/ui/#/~security');
   });
 
+  it('rejects untrusted Solr admin URLs when building security links', () => {
+    expect(buildSolrSecurityUrl('javascript:alert(1)')).toBe('/admin/solr/ui/#/~security');
+    expect(buildSolrSecurityUrl('https://evil.example/solr/')).toBe('/admin/solr/ui/#/~security');
+    expect(buildSolrSecurityUrl('/\\evil.example/')).toBe('/admin/solr/ui/#/~security');
+    expect(safeAdminUrl('https://evil.example/solr/', '/admin/solr/')).toBe('/admin/solr/');
+  });
+
   it('renders the Solr security CTA and app user link', async () => {
     vi.stubGlobal('fetch', mockFetch(infrastructureResponse));
     renderPage();
@@ -68,6 +75,21 @@ describe('SecurityPage', () => {
       'href',
       '/admin/solr/ui/#/~security'
     );
+  });
+
+  it('falls back to the proxied Security UI link for malicious API URLs', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        ...infrastructureResponse,
+        solr_admin_url: 'javascript:alert(1)',
+        services: [{ ...infrastructureResponse.services[0], admin_url: 'https://evil.example/' }],
+      })
+    );
+    renderPage();
+
+    const link = await screen.findByRole('link', { name: /open solr security ui/i });
+    expect(link).toHaveAttribute('href', '/admin/solr/ui/#/~security');
   });
 
   it('warns when Solr is reported down', async () => {

--- a/src/aithena-ui/src/__tests__/useAdminInfrastructure.test.ts
+++ b/src/aithena-ui/src/__tests__/useAdminInfrastructure.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { useAdminInfrastructure } from '../hooks/useAdminInfrastructure';
+import { redactUrlForDisplay, useAdminInfrastructure } from '../hooks/useAdminInfrastructure';
 
 function mockFetchResponse(body: unknown, status = 200) {
   return Promise.resolve({
@@ -22,6 +22,7 @@ describe('useAdminInfrastructure', () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
+
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -163,5 +164,18 @@ describe('useAdminInfrastructure', () => {
       await vi.advanceTimersByTimeAsync(100);
     });
     expect(result.current.loading).toBe(false);
+  });
+});
+
+describe('redactUrlForDisplay', () => {
+  it('strips query strings and fragments from root-relative URLs', () => {
+    expect(redactUrlForDisplay('/admin/solr?token=secret#debug')).toBe('/admin/solr');
+    expect(redactUrlForDisplay('/?token=secret#debug')).toBe('/');
+  });
+
+  it('strips credentials, query strings, and fragments from protocol-relative URLs', () => {
+    expect(redactUrlForDisplay('//user:secret@solr.example:8983/solr/?token=secret#debug')).toBe(
+      '//solr.example:8983/solr/'
+    );
   });
 });

--- a/src/aithena-ui/src/hooks/useAdminInfrastructure.ts
+++ b/src/aithena-ui/src/hooks/useAdminInfrastructure.ts
@@ -140,7 +140,28 @@ export function redactUrlForDisplay(candidate: string | null | undefined): strin
   if (hasUnsafeUrlCharacters(value)) return '—';
 
   if (value.startsWith('/') && !value.startsWith('//')) {
-    return value;
+    try {
+      const parsed = new URL(value, 'http://localhost');
+      return parsed.pathname;
+    } catch {
+      return '—';
+    }
+  }
+
+  if (value.startsWith('//')) {
+    try {
+      const parsed = new URL(value, 'http://localhost');
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return '—';
+      }
+      parsed.username = '';
+      parsed.password = '';
+      parsed.search = '';
+      parsed.hash = '';
+      return `//${parsed.host}${parsed.pathname}`;
+    } catch {
+      return '—';
+    }
   }
 
   try {

--- a/src/aithena-ui/src/hooks/useAdminInfrastructure.ts
+++ b/src/aithena-ui/src/hooks/useAdminInfrastructure.ts
@@ -102,10 +102,65 @@ export function getServiceAdminUrl(
   fallbackUrl: string
 ): string {
   const service = data?.services.find((item) => item.name === serviceName);
-  return service?.admin_url ?? service?.url ?? fallbackUrl;
+  return safeAdminUrl(service?.admin_url ?? service?.url, fallbackUrl);
 }
 
 export function buildSolrSecurityUrl(solrAdminUrl: string): string {
-  const base = solrAdminUrl.endsWith('/') ? solrAdminUrl : `${solrAdminUrl}/`;
+  const safeSolrAdminUrl = safeAdminUrl(solrAdminUrl, '/admin/solr/');
+  const base = safeSolrAdminUrl.endsWith('/') ? safeSolrAdminUrl : `${safeSolrAdminUrl}/`;
   return `${base}ui/#/~security`;
+}
+
+export function safeAdminUrl(candidate: string | null | undefined, fallbackUrl: string): string {
+  const value = candidate?.trim();
+  if (!value) return fallbackUrl;
+
+  if (hasUnsafeUrlCharacters(value) || typeof window === 'undefined') {
+    return fallbackUrl;
+  }
+
+  try {
+    const parsed = new URL(value, window.location.origin);
+    if (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      parsed.origin === window.location.origin
+    ) {
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    }
+  } catch {
+    // fall through to the safe fallback
+  }
+
+  return fallbackUrl;
+}
+
+export function redactUrlForDisplay(candidate: string | null | undefined): string {
+  const value = candidate?.trim();
+  if (!value) return '—';
+  if (hasUnsafeUrlCharacters(value)) return '—';
+
+  if (value.startsWith('/') && !value.startsWith('//')) {
+    return value;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return '—';
+    }
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return value.includes('@') ? '—' : value;
+  }
+}
+
+function hasUnsafeUrlCharacters(value: string): boolean {
+  return [...value].some((char) => {
+    const codePoint = char.codePointAt(0);
+    return char === '\\' || codePoint === undefined || codePoint < 32 || codePoint === 127;
+  });
 }

--- a/src/aithena-ui/src/pages/AdminInfrastructurePage.tsx
+++ b/src/aithena-ui/src/pages/AdminInfrastructurePage.tsx
@@ -1,6 +1,11 @@
 import { useIntl } from 'react-intl';
 import { Database, ExternalLink, MessageSquare, Server, RefreshCw } from 'lucide-react';
-import { useAdminInfrastructure, type ServiceEndpoint } from '../hooks/useAdminInfrastructure';
+import {
+  redactUrlForDisplay,
+  safeAdminUrl,
+  useAdminInfrastructure,
+  type ServiceEndpoint,
+} from '../hooks/useAdminInfrastructure';
 
 /* ── Sub-components ───────────────────────────────────────────────────── */
 
@@ -31,12 +36,13 @@ function ServiceCard({ icon, title, description, url }: ServiceCardProps) {
 function ConnectionRow({ service }: { service: ServiceEndpoint }) {
   const normalizedStatus = service.status.trim().toLowerCase();
   const isHealthy = normalizedStatus === 'connected' || normalizedStatus === 'up';
+  const endpoint = redactUrlForDisplay(service.admin_url ?? service.url);
 
   return (
     <tr>
       <td className="infra-service-name">{service.name}</td>
       <td>{service.type ?? service.description ?? '—'}</td>
-      <td>{service.admin_url ?? service.url ?? '—'}</td>
+      <td>{endpoint}</td>
       <td>
         <span className={`infra-badge ${isHealthy ? 'infra-badge--ok' : 'infra-badge--error'}`}>
           {service.status}
@@ -60,9 +66,10 @@ function AdminInfrastructurePage() {
     legacyUrl: string | undefined,
     fallbackUrl: string
   ) =>
-    data?.services.find((service) => service.name === serviceName)?.admin_url ??
-    legacyUrl ??
-    fallbackUrl;
+    safeAdminUrl(
+      data?.services.find((service) => service.name === serviceName)?.admin_url ?? legacyUrl,
+      fallbackUrl
+    );
 
   const solrUrl = resolveServiceAdminUrl('solr', data?.solr_admin_url, '/admin/solr/');
   const rabbitmqUrl = resolveServiceAdminUrl(

--- a/src/solr-search/main.py
+++ b/src/solr-search/main.py
@@ -3903,6 +3903,23 @@ def admin_logs(
 # ---------------------------------------------------------------------------
 
 
+def _redact_url_for_admin_display(raw_url: str) -> str:
+    """Return a browser-safe URL display value without credentials or request data."""
+    parsed = urlparse(raw_url)
+    if not parsed.netloc:
+        display_value = raw_url.split("?", 1)[0].split("#", 1)[0]
+        return "—" if "@" in display_value else display_value
+
+    hostname = parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    try:
+        port = f":{parsed.port}" if parsed.port else ""
+    except ValueError:
+        port = ""
+    return parsed._replace(netloc=f"{hostname}{port}", params="", query="", fragment="").geturl()
+
+
 @app.get(
     "/v1/admin/infrastructure/",
     include_in_schema=False,
@@ -3966,8 +3983,10 @@ def admin_infrastructure() -> dict[str, Any]:
         "solr": f"{solr_host}:{solr_port}",
         "redis": f"{settings.redis_host}:{settings.redis_port}",
         "rabbitmq_amqp": f"{settings.rabbitmq_host}:{settings.rabbitmq_port}",
-        "rabbitmq_mgmt": (f"http://{settings.rabbitmq_host}:{settings.rabbitmq_management_port}"),
-        "embeddings": settings.embeddings_url,
+        "rabbitmq_mgmt": _redact_url_for_admin_display(
+            f"http://{settings.rabbitmq_host}:{settings.rabbitmq_management_port}"
+        ),
+        "embeddings": _redact_url_for_admin_display(settings.embeddings_url),
     }
 
     return {

--- a/src/solr-search/tests/test_admin_api.py
+++ b/src/solr-search/tests/test_admin_api.py
@@ -367,6 +367,38 @@ class TestInfrastructure:
         assert security_ui["auth_check_url"] == "/v1/auth/validate-admin"
         assert security_ui["required_aithena_role"] == "admin"
 
+    def test_infrastructure_redacts_sensitive_connection_urls(self):
+        original_embeddings_url = settings.embeddings_url
+        object.__setattr__(
+            settings,
+            "embeddings_url",
+            "https://embed-user:embed-pass@embeddings.example/v1/embeddings?token=secret#frag",
+        )
+        try:
+            with (
+                patch("main._tcp_check", return_value=True),
+                patch("main._rabbitmq_management_check", return_value=True),
+                patch("main._embeddings_available", return_value=True),
+            ):
+                client = get_client()
+                resp = client.get("/v1/admin/infrastructure")
+        finally:
+            object.__setattr__(settings, "embeddings_url", original_embeddings_url)
+
+        assert resp.status_code == 200
+        connections = resp.json()["connections"]
+        assert connections["embeddings"] == "https://embeddings.example/v1/embeddings"
+        assert "embed-pass" not in json.dumps(connections)
+        assert "token=secret" not in json.dumps(connections)
+
+    def test_infrastructure_redacts_protocol_relative_urls(self):
+        from main import _redact_url_for_admin_display
+
+        assert (
+            _redact_url_for_admin_display("//embed-user:embed-pass@embeddings.example/v1?token=secret#frag")
+            == "//embeddings.example/v1"
+        )
+
     def test_infrastructure_some_down(self):
         def selective_tcp(host, port, timeout=2.0):
             return host != settings.redis_host


### PR DESCRIPTION
## Summary
- Redact credentials/query/fragment from admin infrastructure connection URLs before returning/displaying them.
- Constrain Solr Security/Admin UI links to same-origin proxy paths and fall back from `javascript:`, cross-origin, protocol-relative, and backslash-normalized URLs.
- Add backend and UI regression tests for credential redaction and unsafe admin URL fallback.

Working as Kane (Security Engineer).
Refs #1358.

## Audit evidence
- Reviewed Solr 10 auth/security surfaces: `src/solr/security.json`, Solr init CLI compatibility, opt-in Solr 10 compose overlay, Security UI/admin infrastructure proxy, and Solr 10 test scaffolding/docs.
- No changes made to #1670; branch is from `origin/dev`.

## Validation
- `.squad/scripts/verify.sh` ✅
- `python3 -m bandit -q -c .bandit -r src/solr-search src/document-indexer -f json` ✅ 0 findings
- `bash tests/test-compose-security.sh` ✅
- `bash tests/test-solr-image-refs.sh && python3 -m pytest e2e/test_solr10_runtime_compat.py -q --tb=short` ✅ 2 passed, 3 skipped until live Solr 10 fixture
- Targeted UI/backend tests ✅

## Remaining #1358 blockers
- Final Solr 10 image/runtime candidate and container CVE scan when `solr:10` is available in CI/runtime.
- Owner-held #1670 scalar quantization follow-up must land before final live audit; not merged here.
- Live Solr 10 auth/RBAC checks on final candidate: unauth admin blocking, health/metrics posture, admin mutation, readonly/search non-mutation, and Security UI proxy/RBAC behavior.