### PR TITLE
chore: move MCP config to root

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,5 @@
 {
-	"servers": {
+	"mcpServers": {
 		"io-github-upstash-context7": {
 			"type": "stdio",
 			"command": "npx",
@@ -9,14 +9,14 @@
 		},
 		"cognitionai-deepwiki": {
 			"type": "http",
-			"url": "https://mcp.deepwiki.com/mcp",
+			"url": "https://mcp.deepwiki.com/mcp"
 		},
 		"microsoft-playwright-mcp": {
 			"type": "stdio",
 			"command": "npx",
 			"args": [
 				"@playwright/mcp@latest"
-			],
+			]
 		}
 	}
 }


### PR DESCRIPTION
Moves the MCP server configuration from VS Code's workspace-specific path to the root .mcp.json file and keeps the Playwright MCP server entry.\n\nCloses no issue.