### PR TITLE
Fix pre-release auth failure classification

### DIFF
--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -50,6 +50,7 @@ Brett owns Docker Compose, Solr/SolrCloud, ZooKeeper, Redis, RabbitMQ, nginx, CI
 
 ## Learnings
 
+- **2026-06-06T09:36:46.687+00:00 — Pre-release auth-pattern overmatch:** Issue #1686 showed that the log analyzer's broad `auth*fail` security glob matched `TestAuthor ... Thumbnail generation failed`. Keep security patterns phrase-based (`auth failed`, `authentication failed`, `authorization failed`) so benign filenames/authors do not become release-blocking security errors while real auth failures still fail.
 - **2026-06-04 — Squad upgrade and zizmor configuration:** Squad v0.9.4 upgrade completes coordinator refresh, workflow/skill sync, and template refresh smoothly. Opened PR #1650 (brett-5). Generated `squad-*` workflows triggered zizmor code-scanning alerts; resolved by configuring zizmor-action to exclude generated workflow basenames via repository-owned input list (brett-6, c7be8d0). User directive: project does not control upstream Squad workflows, so generated security noise should be ignored.
 - **2026-06-04 — Solr readiness auth:** Solr readiness probes must validate `SOLR_ADMIN_USER` and `SOLR_ADMIN_PASS` before constructing curl credentials; missing installer-exported `.env` values should produce explicit CI errors, not opaque 401 retry loops.
 - **2026-06-04 — ZooKeeper exposure:** CI/production overlays must keep ZooKeeper ports unpublished while preserving Solr auth env wiring for init and health checks. Add compose config regression tests for both.

--- a/.squad/decisions/inbox/brett-pre-release-validation.md
+++ b/.squad/decisions/inbox/brett-pre-release-validation.md
@@ -1,0 +1,22 @@
+# Decision: Narrow pre-release auth failure classification
+
+**Author:** Brett (Infrastructure Architect)  
+**Date:** 2026-06-06T09:36:46.687+00:00  
+**Status:** Proposed for Scribe merge  
+**Related:** #1686
+
+## Context
+
+Pre-release validation run 27053636169 reported a release-blocking `security` error for `document-indexer-1`. The underlying log line was a benign thumbnail warning for a corrupt fixture PDF under a `TestAuthor` path:
+
+`TestAuthor ... Thumbnail generation failed ... Failed to open file`
+
+The analyzer classified it as security because the shell glob `auth*fail` matched `Author` followed later by `failed`.
+
+## Decision
+
+Pre-release security classification should use phrase-level authentication failure patterns, not broad substring globs. The analyzer now matches explicit phrases such as `auth failed`, `auth failure`, `auth error`, `authentication failed`, and `authorization failed/failure`.
+
+## Rationale
+
+This keeps real authentication and authorization failures release-blocking while preventing benign author names, filenames, or log fields from tripping the security gate. The fix is narrower than adding an allowlist for the corrupt PDF fixture because it addresses the classifier bug without hiding future file-open or thumbnail problems.

--- a/e2e/pre-release-check.sh
+++ b/e2e/pre-release-check.sh
@@ -363,7 +363,7 @@ scan_security() {
         # ZK non-TLS quorum is expected in dev/CI — downgrade to warning
         add_finding "security" "warning" "${svc:-unknown}" "$line" "$LINE_NUM"
         ;;
-      *"insecure"*|*"certificate"*"error"*|*"certificate"*"expired"*|*"certificate"*"invalid"*|*"tls"*"error"*|*"tls"*"fail"*|*"ssl"*"error"*|*"auth"*"fail"*|*"authentication failed"*|*"unauthorized"*|*"permission denied"*)
+      *"insecure"*|*"certificate"*"error"*|*"certificate"*"expired"*|*"certificate"*"invalid"*|*"tls"*"error"*|*"tls"*"fail"*|*"ssl"*"error"*|*"auth failed"*|*"auth failure"*|*"auth error"*|*"authentication failed"*|*"authorization failed"*|*"authorization failure"*|*"unauthorized"*|*"permission denied"*)
         add_finding "security" "error" "${svc:-unknown}" "$line" "$LINE_NUM"
         ;;
       *"self-signed"*|*"insecure mode"*|*"without tls"*|*"no ssl"*)

--- a/e2e/pre-release-check.sh
+++ b/e2e/pre-release-check.sh
@@ -363,7 +363,7 @@ scan_security() {
         # ZK non-TLS quorum is expected in dev/CI — downgrade to warning
         add_finding "security" "warning" "${svc:-unknown}" "$line" "$LINE_NUM"
         ;;
-      *"insecure"*|*"certificate"*"error"*|*"certificate"*"expired"*|*"certificate"*"invalid"*|*"tls"*"error"*|*"tls"*"fail"*|*"ssl"*"error"*|*"auth failed"*|*"auth failure"*|*"auth error"*|*"authentication failed"*|*"authorization failed"*|*"authorization failure"*|*"unauthorized"*|*"permission denied"*)
+      *"insecure"*|*"certificate"*"error"*|*"certificate"*"expired"*|*"certificate"*"invalid"*|*"tls"*"error"*|*"tls"*"fail"*|*"ssl"*"error"*|*"auth failed"*|*"auth failure"*|*"auth error"*|*"authentication failed"*|*"authentication failure"*|*"authorization failed"*|*"authorization failure"*|*"unauthorized"*|*"permission denied"*)
         add_finding "security" "error" "${svc:-unknown}" "$line" "$LINE_NUM"
         ;;
       *"self-signed"*|*"insecure mode"*|*"without tls"*|*"no ssl"*)

--- a/tests/test-pre-release-check.sh
+++ b/tests/test-pre-release-check.sh
@@ -249,6 +249,25 @@ assert_exit "exit code 0 (accepted ZK/Solr config)" 0 "$rc"
 assert_json_count "0 findings (accepted config posture)" "$tmpdir/out.json" 0
 
 # -------------------------------------------------------
+echo "Test 17: Author paths with failed file opens are not auth failures"
+cat > "$tmpdir/author-file-open.txt" <<'EOF'
+document-indexer-1   | {"timestamp": "2026-06-06T05:25:03.503125+00:00", "level": "WARNING", "service": "document-indexer", "name": "document_indexer.thumbnail", "message": "Thumbnail generation failed for /data/documents/TestAuthor/TestAuthor - Corrupt Index (2024).pdf: Failed to open file '/data/documents/TestAuthor/TestAuthor - Corrupt Index (2024).pdf'.", "logger": "document_indexer.thumbnail"}
+EOF
+sh "$ANALYZER" "$tmpdir/author-file-open.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 0 (benign thumbnail warning)" 0 "$rc"
+assert_no_category "no security findings" "$tmpdir/out.json" "security"
+
+# -------------------------------------------------------
+echo "Test 18: Explicit auth failures are still security errors"
+cat > "$tmpdir/auth-failed.txt" <<'EOF'
+api-1 | 2026-06-06 auth failed for service account
+EOF
+sh "$ANALYZER" "$tmpdir/auth-failed.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 1 (security error)" 1 "$rc"
+assert_json_field "category=security" "$tmpdir/out.json" 0 "category" "security"
+assert_json_field "severity=error" "$tmpdir/out.json" 0 "severity" "error"
+
+# -------------------------------------------------------
 echo ""
 echo "========================================"
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test-pre-release-check.sh
+++ b/tests/test-pre-release-check.sh
@@ -268,6 +268,16 @@ assert_json_field "category=security" "$tmpdir/out.json" 0 "category" "security"
 assert_json_field "severity=error" "$tmpdir/out.json" 0 "severity" "error"
 
 # -------------------------------------------------------
+echo "Test 19: Explicit authentication failures are still security errors"
+cat > "$tmpdir/authentication-failure.txt" <<'EOF'
+api-1 | 2026-06-06 authentication failure for service account
+EOF
+sh "$ANALYZER" "$tmpdir/authentication-failure.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 1 (security error)" 1 "$rc"
+assert_json_field "category=security" "$tmpdir/out.json" 0 "category" "security"
+assert_json_field "severity=error" "$tmpdir/out.json" 0 "severity" "error"
+
+# -------------------------------------------------------
 echo ""
 echo "========================================"
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- Narrow the pre-release analyzer auth-failure security pattern to explicit auth/authorization failure phrases.
- Add regression coverage for the corrupt PDF `TestAuthor ... generation failed` thumbnail line.
- Record Brett learning and a proposed decision for Scribe merge.

Working as Brett (Infrastructure Architect).

Closes #1686

## Validation
- `sh tests/test-pre-release-check.sh`
- Replayed `e2e/pre-release-check.sh --allowlist e2e/pre-release-allowlist.txt` against run 27053636169 single-node and distributed compose logs: errors dropped from 1 to 0 in both; remaining findings are warnings/info.
- `.squad/scripts/verify.sh`