### PR TITLE
docs: record Bishop quantization validation learning

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -11,3 +11,4 @@
 
 ## Learnings
 - Semantic E2E coverage should index parent PDFs via Solr `/update/extract`, then enqueue the same file paths to `shortembeddings` so document-indexer produces chunk docs with vectors before asserting `/v1/search` semantic and hybrid ranking.
+- 2026-06-06T09:36:46.687+00:00: For #1344 scalar quantization closure, validate against `dev` when #1670 is only merged there; schema/preflight/unit checks can prove bits=7 wiring, but recall@10 and memory savings still require same-corpus float32 vs int8 runtime benchmark artifacts.

--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -11,4 +11,4 @@
 
 ## Learnings
 - Semantic E2E coverage should index parent PDFs via Solr `/update/extract`, then enqueue the same file paths to `shortembeddings` so document-indexer produces chunk docs with vectors before asserting `/v1/search` semantic and hybrid ranking.
-- 2026-06-06T09:36:46.687+00:00: For #1344 scalar quantization closure, validate against `dev` when #1670 is only merged there; schema/preflight/unit checks can prove bits=7 wiring, but recall@10 and memory savings still require same-corpus float32 vs int8 runtime benchmark artifacts.
+- **2026-06-06:** For #1344 scalar quantization closure, validate against `dev` when #1670 is only merged there; schema/preflight/unit checks can prove bits=7 wiring, but recall@10 and memory savings still require same-corpus float32 vs int8 runtime benchmark artifacts.


### PR DESCRIPTION
## Summary
- append Bishop history learning from #1344 reassessment after #1670 merged
- record that dev is the validation base while main lacks #1670
- note that schema/preflight/unit checks are not a substitute for same-corpus recall/memory benchmark artifacts

## Validation
- .squad/scripts/verify.sh => no changed services detected

Relates to #1344.