### PR TITLE
Clarify benchmark readiness after Solr quantization fix

### DIFF
--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -87,3 +87,8 @@
 - **Prevention:** Future embeddings-server Dockerfiles include post-sync version verification; fails build immediately if versions drift
 - **For next release:** Smoke tests remain essential for runtime validation; build-time verification is now the defensive layer for transitive-dependency issues
 - **Pattern:** Any service using `uv sync --inexact` should include Python version-check step to fail early
+
+### 2026-06-06T09:36:46.687+00:00 — #1354 Post-#1670 Benchmark Reassessment
+- #1670 removes the Solr 10 scalar-quantization schema blocker (`bits=7`), so #1344/#1354 tooling can advance past preflight.
+- Do not close #1354 from tool-only validation: benchmark claims still require paired Solr 9.7/Solr 10 or float32/int8 runs on the same host, same representative corpus, captured benchmark JSON, `docker stats`, corpus size, and failed query IDs.
+- Safe local validation without a production corpus is limited to benchmark unit tests, comparator tests, schema/preflight checks, and mocked harness behavior; never fabricate latency, recall, throughput, or memory numbers from these checks.

--- a/scripts/benchmark/QUANTIZATION_VALIDATION_PLAN.md
+++ b/scripts/benchmark/QUANTIZATION_VALIDATION_PLAN.md
@@ -3,6 +3,7 @@
 **Document:** Comprehensive validation checklist for int8 scalar quantization with Solr 10-supported scalar bits
 **Version:** 1.0
 **Created:** 2026-06-05
+**Updated:** 2026-06-06T09:36:46.687+00:00
 **By:** Bishop (Vector Search & Data Science Specialist)
 
 ## Overview
@@ -446,4 +447,4 @@ Before attaching to #1344:
 
 ---
 
-**Status:** Ready to execute post-#1670 merge | **Author:** Bishop | **Version:** 1.0
+**Status:** #1670 merged; ready for controlled same-corpus execution | **Author:** Bishop | **Version:** 1.0

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -123,7 +123,7 @@ Aggregate (per mode and category):
 
 ## Scalar Quantization Validation (#1344)
 
-Use this workflow after PR #1670 (Solr 10 `bits=7` compatibility) merges and the same corpus can be indexed twice. It avoids hardware-intensive runs by reusing the existing 30-query suite and comparing top-k agreement between a float32 reference collection and an int8/scalar-quantized candidate collection.
+Use this workflow now that PR #1670 (Solr 10 `bits=7` compatibility) has merged, once the same representative corpus can be indexed twice in a controlled environment. It avoids fabricating performance claims by reusing the existing 30-query suite and comparing top-k agreement between a float32 reference collection and an int8/scalar-quantized candidate collection.
 
 ### Validation checklist
 
@@ -168,7 +168,7 @@ python3 scripts/benchmark/compare_quantization.py \
   --output results/benchmark-1344-quantization-comparison.json
 ```
 
-**Remaining blocker:** do not execute the int8/Solr 10 validation until #1670 is merged or equivalent `bits=7` schema support is present in the target environment.
+**Remaining blocker:** do not publish pass/fail performance or memory claims until the float32 and int8 runs have been executed on the same host, with the same corpus, and with captured benchmark JSON plus `docker stats` evidence.
 
 ## Running Tests
 

--- a/scripts/benchmark/pre_flight_check.py
+++ b/scripts/benchmark/pre_flight_check.py
@@ -131,7 +131,7 @@ def check_docker_compose() -> CheckResult:
         )
 
     try:
-        result = subprocess.run([docker_path, "compose", "--version"], capture_output=True, text=True, timeout=5)  # noqa: S603
+        result = subprocess.run([docker_path, "compose", "version"], capture_output=True, text=True, timeout=5)  # noqa: S603
         if result.returncode == 0:
             version = result.stdout.strip()
             return CheckResult(

--- a/scripts/benchmark/quantization_validation_config.json
+++ b/scripts/benchmark/quantization_validation_config.json
@@ -3,6 +3,7 @@
     "version": "1.0",
     "created_by": "Bishop (Vector Search & Data Science Specialist)",
     "created_at": "2026-06-05",
+    "updated_at": "2026-06-06T09:36:46.687+00:00",
     "purpose": "Configuration for scalar quantization (int8) benchmark validation #1344",
     "schema_prerequisite": "Solr 10 ScalarQuantizedDenseVectorField uses supported bits (4 or 7) and Solr 9 staging rewrites bits 4/7 to vectorEncoding=BYTE"
   },
@@ -264,13 +265,13 @@
       "root_cause_analysis_if_blocker"
     ]
   },
-  "blocker_resolution": {
-    "current_state": "PR #1670 is held by directive (not merged)",
-    "current_schema_bits": 8,
-    "current_schema_compatibility": "Invalid for Solr 10 (only supports bits 4 or 7); works for Solr 9",
-    "required_schema_fix": "bits=\"7\" for Solr 10; Solr 9 compat rewrite to DenseVectorField vectorEncoding=BYTE",
-    "action_required": "Await Ripley directive or PR #1670 approval",
-    "post_merge_status": "This plan executable with no code changes; schema already updated"
+  "readiness_status": {
+    "current_state": "PR #1670 has merged; Solr 10 scalar quantization schema now uses supported bits=7",
+    "current_schema_bits": 7,
+    "current_schema_compatibility": "Valid for Solr 10; Solr 9 staging rewrites supported scalar bits to DenseVectorField vectorEncoding=BYTE",
+    "schema_fix": "bits=\"7\" for Solr 10; Solr 9 compat rewrite to DenseVectorField vectorEncoding=BYTE",
+    "action_required": "Execute paired float32 and int8 benchmark phases only in a controlled environment with the same representative corpus",
+    "remaining_blocker": "Benchmark JSON, docker stats memory samples, corpus size, and failed query IDs are still required before publishing memory, latency, or recall conclusions"
   },
   "notes": {
     "idempotency": "index_test_corpus.py deduplicates by Solr unique key; safe to re-run both phases",

--- a/scripts/benchmark/tests/test_pre_flight_check.py
+++ b/scripts/benchmark/tests/test_pre_flight_check.py
@@ -1,0 +1,26 @@
+"""Tests for benchmark pre-flight checks."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pre_flight_check import check_docker_compose  # noqa: E402
+
+
+@patch("pre_flight_check.shutil.which")
+def test_docker_compose_check_uses_version_subcommand(mock_which: MagicMock, monkeypatch) -> None:
+    mock_which.return_value = "/usr/bin/docker"
+    mock_run = MagicMock(return_value=MagicMock(returncode=0, stdout="Docker Compose version v2.40.3\n"))
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    result = check_docker_compose()
+
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == ["/usr/bin/docker", "compose", "version"]
+    assert result.passed is True
+    assert "Docker Compose version v2.40.3" in result.message


### PR DESCRIPTION
## Summary
- update benchmark docs/config to reflect #1670 has merged
- clarify that #1354 still needs controlled same-corpus benchmark evidence before performance/memory claims
- fix pre-flight Docker Compose version probing and add a regression test
- append Lambert QA learning to history

Refs #1354
Refs #1344

## Validation
- python3 -m pytest scripts/benchmark/tests -q
- python3 scripts/benchmark/pre_flight_check.py --json
- python3 -m ruff check scripts/benchmark/pre_flight_check.py scripts/benchmark/tests/test_pre_flight_check.py
- python3 -m ruff format --check scripts/benchmark/pre_flight_check.py scripts/benchmark/tests/test_pre_flight_check.py
- .squad/scripts/verify.sh