### PR TITLE
Scaffold Solr 10 document categorizer prototype

### DIFF
--- a/.squad/agents/ash/history.md
+++ b/.squad/agents/ash/history.md
@@ -170,6 +170,12 @@ Reviewed dependabot PR #1562 (Solr 9.7→10.0 version bump). Verdict: **CLOSE** 
 
 This decision establishes the precedent: version bumps are coordinated at epic level when they touch multiple services or schema. Improves reliability and prevents broken intermediate states.
 
+### DocumentCategorizer Prototype Feasibility (#1348, 2026-06-06)
+
+Solr 10 `DocumentCategorizerUpdateProcessorFactory` is feasible for index-time ONNX classification, but it lives in `analysis-extras`, not `language-models`, and requires both `model.onnx` and matching `vocab.txt` in SolrCloud FileStore. Do not enable it in active `solrconfig.xml` until a real model fixture exists.
+
+Safe pattern: keep manual `category_s` untouched; write classifier output to separate fields such as `topic_category_s` and `document_sentiment_s`. A disabled scaffold is acceptable, but no accuracy/performance claims should be made without a labeled corpus and measured indexing/JVM validation.
+
 ### Solr 10 Combined Query / Hybrid Search Evaluation (#1349, 2026-06-06)
 
 **Finding:** Solr 10.0.0 does not include a native RRF/combined-query handler. SOLR-17319 / Apache Solr PR #3418 is merged on mainline after the 10.0.0 tag and adds `CombinedQuerySearchHandler` + `CombinedQueryComponent` for multiple JSON DSL queries with built-in RRF (`combiner.algorithm=rrf`, `combiner.rrf.k`, default 60). This is the first Solr-native fusion feature that maps directly to Aithena's BM25 + kNN + RRF architecture, but only once Aithena's Solr runtime includes it.

--- a/docs/research/solr10-document-categorizer-prototype.md
+++ b/docs/research/solr10-document-categorizer-prototype.md
@@ -1,0 +1,77 @@
+# Solr 10 DocumentCategorizer Prototype Feasibility
+
+**Author:** Ash (Search Engineer)
+**Date:** 2026-06-06
+**Issue:** #1348
+**Status:** Safe scaffold added; runtime classification deferred until model fixture exists
+
+## Verdict
+
+Solr 10 can run ONNX text classifiers at index time through
+`solr.processor.DocumentCategorizerUpdateProcessorFactory`, but Aithena should
+not enable it by default yet.
+
+The current repository can safely carry schema/config/test scaffolding without
+bundling a model. A real runtime prototype still needs a selected ONNX model,
+matching `vocab.txt`, Solr `analysis-extras` enabled, FileStore upload steps, and
+measured validation.
+
+## Current repo fit
+
+- Solr 10 is the default config target (`luceneMatchVersion` 10.0).
+- Runtime Solr modules are currently `extraction,langid`; `analysis-extras` is
+  not enabled.
+- The production indexing path uses `/update/extract` with the `langid` chain.
+- `category_s` is manual/path metadata today, so classifier output must not
+  overwrite it until accuracy is validated.
+- Added disabled output fields:
+  - `topic_category_s`
+  - `document_sentiment_s`
+- Added disabled config scaffold:
+  - `src/solr/books/document-categorizer-prototype.xml`
+
+## Solr 10 requirements
+
+Official Solr 10 OpenNLP tutorial/configuration requires:
+
+1. Start Solr with `analysis-extras`.
+2. Upload `model.onnx` and `vocab.txt` to SolrCloud FileStore.
+3. Configure `DocumentCategorizerUpdateProcessorFactory` with:
+   - `modelFile`
+   - `vocabFile`
+   - `source`
+   - `dest`
+4. Invoke it explicitly with `processor=...` or `update.chain=...`.
+
+The scaffold is deliberately not loaded by `solrconfig.xml`; declaring the
+processor in active config before the module/model files exist can break core
+loading or indexing.
+
+## Use-case evaluation
+
+| Use case | Feasibility | Notes |
+| --- | --- | --- |
+| Topic classification | Feasible after model selection | Keep output in `topic_category_s`; do not replace `category_s` until validated. |
+| Sentiment analysis for ranking | Feasible as a separate experiment | Store in `document_sentiment_s`; only boost after relevance testing. |
+| Language detection upgrade | Not a drop-in replacement | Current `langid` writes `language_detected_s`; OpenNLP language detection needs a different processor/model and parity tests. |
+
+## Validation still required
+
+Do not claim accuracy or performance until these run with real data:
+
+1. Select a small multilingual ONNX classifier compatible with Aithena content.
+2. Upload the model/vocab to Solr FileStore in a disposable Solr 10 collection.
+3. Index a labeled fixture corpus through the categorizer chain.
+4. Measure per-document indexing latency and JVM memory with/without the chain.
+5. Compare predicted labels against the fixture; document precision/recall.
+6. Decide whether topic labels should influence facets/ranking or stay metadata-only.
+
+## Follow-up implementation path
+
+1. Add an opt-in compose/profile overlay that appends `analysis-extras` to
+   `SOLR_MODULES`.
+2. Add a model fixture download/upload script that is never run implicitly and
+   never commits model binaries.
+3. Convert `document-categorizer-prototype.xml` into active `solrconfig.xml`
+   only after CI/local fixtures exist.
+4. Ungate `TestPhase3DocumentCategorization` with real assertions.

--- a/src/solr-search/tests/test_e2e_solr10_phase3.py
+++ b/src/solr-search/tests/test_e2e_solr10_phase3.py
@@ -22,6 +22,7 @@ pytestmark = [pytest.mark.e2e, pytest.mark.phase3, pytest.mark.solr10]
 REPO_ROOT = Path(__file__).resolve().parents[3]
 INDEXER_EMBEDDINGS_PATH = REPO_ROOT / "src" / "document-indexer" / "document_indexer" / "embeddings.py"
 SOLR_SCHEMA_PATH = REPO_ROOT / "src" / "solr" / "books" / "managed-schema.xml"
+SOLR_CONFIG_PATH = REPO_ROOT / "src" / "solr" / "books" / "solrconfig.xml"
 DOCUMENT_CATEGORIZER_PROTOTYPE_PATH = REPO_ROOT / "src" / "solr" / "books" / "document-categorizer-prototype.xml"
 DOCUMENT_CATEGORIZER_RESEARCH_PATH = REPO_ROOT / "docs" / "research" / "solr10-document-categorizer-prototype.md"
 
@@ -61,6 +62,7 @@ class TestPhase3ActivePreflight:
         schema = SOLR_SCHEMA_PATH.read_text(encoding="utf-8")
         prototype = DOCUMENT_CATEGORIZER_PROTOTYPE_PATH.read_text(encoding="utf-8")
         research = DOCUMENT_CATEGORIZER_RESEARCH_PATH.read_text(encoding="utf-8")
+        solrconfig = SOLR_CONFIG_PATH.read_text(encoding="utf-8")
 
         assert 'name="topic_category_s"' in schema
         assert 'name="document_sentiment_s"' in schema
@@ -69,6 +71,11 @@ class TestPhase3ActivePreflight:
         assert "vocabFile" in prototype
         assert "analysis-extras" in prototype
         assert "intentionally not included from solrconfig.xml" in prototype
+        assert 'processor="topicCategorizer,sentimentCategorizer"' in prototype
+        assert "DocumentCategorizerUpdateProcessorFactory" not in solrconfig
+        assert "topicCategorizer" not in solrconfig
+        assert "sentimentCategorizer" not in solrconfig
+        assert "document-categorizer-prototype" not in solrconfig
         assert "Do not claim accuracy or performance" in research
         assert "runtime classification deferred" in research
 

--- a/src/solr-search/tests/test_e2e_solr10_phase3.py
+++ b/src/solr-search/tests/test_e2e_solr10_phase3.py
@@ -21,6 +21,9 @@ pytestmark = [pytest.mark.e2e, pytest.mark.phase3, pytest.mark.solr10]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 INDEXER_EMBEDDINGS_PATH = REPO_ROOT / "src" / "document-indexer" / "document_indexer" / "embeddings.py"
+SOLR_SCHEMA_PATH = REPO_ROOT / "src" / "solr" / "books" / "managed-schema.xml"
+DOCUMENT_CATEGORIZER_PROTOTYPE_PATH = REPO_ROOT / "src" / "solr" / "books" / "document-categorizer-prototype.xml"
+DOCUMENT_CATEGORIZER_RESEARCH_PATH = REPO_ROOT / "docs" / "research" / "solr10-document-categorizer-prototype.md"
 
 
 def _load_indexer_embeddings_module() -> ModuleType:
@@ -52,6 +55,22 @@ class TestPhase3ActivePreflight:
         assert "score" in search_service.SOLR_FIELD_LIST
         assert "category" in search_service.FACET_FIELDS
         assert "language" in search_service.FACET_FIELDS
+
+    def test_phase3_document_categorizer_scaffold_is_disabled_by_default(self) -> None:
+        """DocumentCategorizer scaffold is present but not loaded without a model fixture."""
+        schema = SOLR_SCHEMA_PATH.read_text(encoding="utf-8")
+        prototype = DOCUMENT_CATEGORIZER_PROTOTYPE_PATH.read_text(encoding="utf-8")
+        research = DOCUMENT_CATEGORIZER_RESEARCH_PATH.read_text(encoding="utf-8")
+
+        assert 'name="topic_category_s"' in schema
+        assert 'name="document_sentiment_s"' in schema
+        assert "DocumentCategorizerUpdateProcessorFactory" in prototype
+        assert "modelFile" in prototype
+        assert "vocabFile" in prototype
+        assert "analysis-extras" in prototype
+        assert "intentionally not included from solrconfig.xml" in prototype
+        assert "Do not claim accuracy or performance" in research
+        assert "runtime classification deferred" in research
 
 
 class TestPhase3LanguageModels:

--- a/src/solr/books/document-categorizer-prototype.xml
+++ b/src/solr/books/document-categorizer-prototype.xml
@@ -12,6 +12,11 @@
   - Validate labels, latency, JVM memory, and indexing throughput before enabling.
 -->
 <prototype>
+  <!--
+    To enable after validation, move these updateProcessor definitions and the
+    chain below into solrconfig.xml, then invoke with:
+    update.chain=document-categorizer-prototype
+  -->
   <updateProcessor class="solr.processor.DocumentCategorizerUpdateProcessorFactory" name="topicCategorizer">
     <str name="modelFile">models/topic/model.onnx</str>
     <str name="vocabFile">models/topic/vocab.txt</str>
@@ -27,14 +32,7 @@
     <str name="dest">document_sentiment_s</str>
   </updateProcessor>
 
-  <updateRequestProcessorChain name="document-categorizer-prototype">
-    <processor class="solr.processor.DocumentCategorizerUpdateProcessorFactory">
-      <str name="modelFile">models/topic/model.onnx</str>
-      <str name="vocabFile">models/topic/vocab.txt</str>
-      <str name="source">content</str>
-      <str name="source">title_t</str>
-      <str name="dest">topic_category_s</str>
-    </processor>
+  <updateRequestProcessorChain name="document-categorizer-prototype" processor="topicCategorizer,sentimentCategorizer">
     <processor class="solr.LogUpdateProcessorFactory"/>
     <processor class="solr.DistributedUpdateProcessorFactory"/>
     <processor class="solr.RunUpdateProcessorFactory"/>

--- a/src/solr/books/document-categorizer-prototype.xml
+++ b/src/solr/books/document-categorizer-prototype.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Disabled-by-default Solr 10 DocumentCategorizer prototype for issue #1348.
+
+  This file is intentionally not included from solrconfig.xml. Loading
+  solr.processor.DocumentCategorizerUpdateProcessorFactory requires the Solr
+  analysis-extras module and real ONNX/vocab files in SolrCloud FileStore.
+
+  Runtime prerequisites:
+  - Start Solr with SOLR_MODULES including analysis-extras.
+  - Upload a validated ONNX model and matching vocab.txt to FileStore.
+  - Validate labels, latency, JVM memory, and indexing throughput before enabling.
+-->
+<prototype>
+  <updateProcessor class="solr.processor.DocumentCategorizerUpdateProcessorFactory" name="topicCategorizer">
+    <str name="modelFile">models/topic/model.onnx</str>
+    <str name="vocabFile">models/topic/vocab.txt</str>
+    <str name="source">content</str>
+    <str name="source">title_t</str>
+    <str name="dest">topic_category_s</str>
+  </updateProcessor>
+
+  <updateProcessor class="solr.processor.DocumentCategorizerUpdateProcessorFactory" name="sentimentCategorizer">
+    <str name="modelFile">models/sentiment/model.onnx</str>
+    <str name="vocabFile">models/sentiment/vocab.txt</str>
+    <str name="source">content</str>
+    <str name="dest">document_sentiment_s</str>
+  </updateProcessor>
+
+  <updateRequestProcessorChain name="document-categorizer-prototype">
+    <processor class="solr.processor.DocumentCategorizerUpdateProcessorFactory">
+      <str name="modelFile">models/topic/model.onnx</str>
+      <str name="vocabFile">models/topic/vocab.txt</str>
+      <str name="source">content</str>
+      <str name="source">title_t</str>
+      <str name="dest">topic_category_s</str>
+    </processor>
+    <processor class="solr.LogUpdateProcessorFactory"/>
+    <processor class="solr.DistributedUpdateProcessorFactory"/>
+    <processor class="solr.RunUpdateProcessorFactory"/>
+  </updateRequestProcessorChain>
+</prototype>

--- a/src/solr/books/managed-schema.xml
+++ b/src/solr/books/managed-schema.xml
@@ -518,6 +518,10 @@
   <field name="file_path_s" type="string" multiValued="false" indexed="true" stored="true"/>
   <field name="folder_path_s" type="string" multiValued="false" indexed="true" stored="true"/>
   <field name="category_s" type="string" multiValued="false" indexed="true" stored="true"/>
+  <!-- Disabled-by-default Solr 10 DocumentCategorizer prototype output fields.
+       Keep separate from manual category_s until an ONNX model fixture is validated. -->
+  <field name="topic_category_s" type="string" multiValued="false" indexed="true" stored="true"/>
+  <field name="document_sentiment_s" type="string" multiValued="false" indexed="true" stored="true"/>
   <field name="file_size_l" type="plong" multiValued="false" indexed="true" stored="true"/>
   <field name="language_detected_s" type="string" multiValued="false" indexed="true" stored="true"/>
   <field name="series_s" type="string" multiValued="false" indexed="true" stored="true"/>


### PR DESCRIPTION
## Summary
- Working as Ash (Search Engineer) for #1348.
- Documents Solr 10 DocumentCategorizer feasibility and why runtime classification stays disabled until a real ONNX/vocab fixture exists.
- Adds safe output fields (`topic_category_s`, `document_sentiment_s`) and a non-loaded config scaffold; no model binaries or external downloads.
- Adds active preflight coverage that the scaffold remains disabled-by-default.

Refs #1348 — leaving the issue open for the model/runtime validation task.

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Validation
- `python3` XML parse for `managed-schema.xml` and `document-categorizer-prototype.xml`
- `uv run pytest tests/test_e2e_solr10_phase3.py --tb=short -q --no-cov` (3 passed, 6 skipped)
- `.squad/scripts/verify.sh` (1172 passed, 21 skipped)
