### PR TITLE
Narrow RabbitMQ pre-release deprecation allowlist

### DIFF
--- a/e2e/pre-release-allowlist.txt
+++ b/e2e/pre-release-allowlist.txt
@@ -36,7 +36,6 @@ deprecation:*sun.misc.Unsafe::arrayBaseOffset will be removed in a future releas
 # deprecated_features.permit.management_metrics_collection flag. Keep the
 # exact notice visible as info; unrelated RabbitMQ deprecations remain warnings.
 deprecation:*management_metrics_collection*=info
-deprecation:*will not be permitted by default in a future minor*RabbitMQ version*removed from a future major*RabbitMQ version*=info
 
 # Connection retries during startup are normal for Docker Compose orchestration
 connection:*retrying*=ignore

--- a/e2e/pre-release-allowlist.txt
+++ b/e2e/pre-release-allowlist.txt
@@ -36,7 +36,7 @@ deprecation:*sun.misc.Unsafe::arrayBaseOffset will be removed in a future releas
 # deprecated_features.permit.management_metrics_collection flag. Keep the
 # exact notice visible as info; unrelated RabbitMQ deprecations remain warnings.
 deprecation:*management_metrics_collection*=info
-deprecation:*will not be permitted by default in a future minor version of RabbitMQ*removed from a future major version*=info
+deprecation:*will not be permitted by default in a future minor*RabbitMQ version*removed from a future major*RabbitMQ version*=info
 
 # Connection retries during startup are normal for Docker Compose orchestration
 connection:*retrying*=ignore

--- a/e2e/pre-release-check.sh
+++ b/e2e/pre-release-check.sh
@@ -239,13 +239,28 @@ scan_crashes() {
 # --- Category 2: Deprecation warnings ---
 scan_deprecations() {
   LINE_NUM=0
+  LAST_DEPRECATION_SVC=""
+  LAST_DEPRECATION_LC_LINE=""
+  LAST_DEPRECATION_LINE=0
   while IFS= read -r line; do
     LINE_NUM=$((LINE_NUM + 1))
     svc="$(extract_service "$line")"
     lc_line="$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')"
     case "$lc_line" in
       *"deprecated"*|*"will be removed"*|*"no longer supported"*|*"end of life"*|*"end-of-life"*)
-        add_finding "deprecation" "warning" "${svc:-unknown}" "$line" "$LINE_NUM"
+        severity="warning"
+        if [ "${svc:-unknown}" = "$LAST_DEPRECATION_SVC" ] \
+          && [ $((LINE_NUM - LAST_DEPRECATION_LINE)) -le 2 ]; then
+          case "$LAST_DEPRECATION_LC_LINE:$lc_line" in
+            *"deprecated features:"*"management_metrics_collection"*:*"will not be permitted by default in a future minor"*"rabbitmq version"*"removed from a future major"*"rabbitmq version"*)
+              severity="info"
+              ;;
+          esac
+        fi
+        add_finding "deprecation" "$severity" "${svc:-unknown}" "$line" "$LINE_NUM"
+        LAST_DEPRECATION_SVC="${svc:-unknown}"
+        LAST_DEPRECATION_LC_LINE="$lc_line"
+        LAST_DEPRECATION_LINE="$LINE_NUM"
         ;;
     esac
   done < "$LOG_FILE"

--- a/tests/test-pre-release-check.sh
+++ b/tests/test-pre-release-check.sh
@@ -143,7 +143,7 @@ assert_json_field "severity=warning" "$tmpdir/out.json" 0 "severity" "warning"
 echo "Test 8: RabbitMQ management metrics deprecation stays info-only"
 cat > "$tmpdir/rabbitmq-deprecation.txt" <<'EOF'
 rabbitmq-1 | 2026-06-03 [warning] Deprecated features: `management_metrics_collection`.
-rabbitmq-1 | 2026-06-03 [warning] Its use will not be permitted by default in a future minor version of RabbitMQ and the feature will be removed from a future major version; actual versions to be determined.
+rabbitmq-1 | 2026-06-03 [warning] Its use will not be permitted by default in a future minor RabbitMQ version and the feature will be removed from a future major RabbitMQ version; actual versions to be determined.
 rabbitmq-1 | 2026-06-03 [warning]     "deprecated_features.permit.management_metrics_collection = true"
 EOF
 sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/rabbitmq-deprecation.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?

--- a/tests/test-pre-release-check.sh
+++ b/tests/test-pre-release-check.sh
@@ -154,6 +154,18 @@ assert_json_field "severity[1]=info" "$tmpdir/out.json" 1 "severity" "info"
 assert_json_field "severity[2]=info" "$tmpdir/out.json" 2 "severity" "info"
 
 # -------------------------------------------------------
+echo "Test 8b: Other RabbitMQ deprecation follow-up lines remain warnings"
+cat > "$tmpdir/rabbitmq-other-deprecation.txt" <<'EOF'
+rabbitmq-1 | 2026-06-03 [warning] Deprecated features: `some_other_feature`.
+rabbitmq-1 | 2026-06-03 [warning] Its use will not be permitted by default in a future minor RabbitMQ version and the feature will be removed from a future major RabbitMQ version; actual versions to be determined.
+EOF
+sh "$ANALYZER" --allowlist "$ALLOWLIST" "$tmpdir/rabbitmq-other-deprecation.txt" > "$tmpdir/out.json" 2>/dev/null; rc=$?
+assert_exit "exit code 2 (unrelated RabbitMQ warning)" 2 "$rc"
+assert_json_count "2 warning findings" "$tmpdir/out.json" 2
+assert_json_field "severity[0]=warning" "$tmpdir/out.json" 0 "severity" "warning"
+assert_json_field "severity[1]=warning" "$tmpdir/out.json" 1 "severity" "warning"
+
+# -------------------------------------------------------
 echo "Test 9: --max-errors threshold allows some errors"
 cat > "$tmpdir/multi.txt" <<'EOF'
 app1  | 2024-01-01 FATAL: db connect failed


### PR DESCRIPTION
## Summary
- Closes #1707
- Working as Brett (Infrastructure Architect)
- Match the current RabbitMQ management_metrics_collection notice wording: "future minor RabbitMQ version" / "future major RabbitMQ version"
- Keep the allowlist narrow so unrelated deprecation warnings still surface

## Validation
- sh tests/test-pre-release-check.sh
- exact RabbitMQ log-line analyzer check
- .squad/scripts/verify.sh