### PR TITLE
test: expand Phase 2 Solr validation

### DIFF
--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -38,6 +38,11 @@
 
 ## Learnings
 
+### 2026-06-06T21:10:43.987+00:00 — #1356 Phase 2 Validation
+- Phase 2 coverage now has static preflight checks for single-node SolrCloud topology, production Overseer-disabled wiring, int8 schema memory ratio, and `efSearchScaleFactor` kNN query propagation in `src/solr-search/tests/test_e2e_solr10_phase2.py`.
+- Live Solr 10 runtime checks remain opt-in in `e2e/test_solr10_runtime_compat.py`; use `E2E_SOLR_EXPECTED_MAJOR=10` for fixture-backed checks and add `E2E_SOLR_OVERSEER_DISABLED=1` only when validating production Overseer-disabled mode.
+- Do not claim runtime memory/recall/latency evidence from preflight tests; pair #1356 with #1344/#1354 benchmark reports and live Solr logs before closing quantization quality gates.
+
 ### 2026-06-03 — PR #1623
 - Review cleanup: config reload tests must restore env before final reload; thumbnail tests should distinguish URL/stability metadata from actual image/header retrieval.
 - Single-node upload failure was Python E2E semantic upload (`test_web_api_semantic.py`), not Playwright. The missing proof was endpoint-level disabled-rate-limit behavior for repeated uploads.

--- a/.squad/skills/solr-operations/SKILL.md
+++ b/.squad/skills/solr-operations/SKILL.md
@@ -104,7 +104,7 @@ curl -X POST 'http://localhost:8983/api/collections/books/shards/shard1/replicas
 
 - Static Phase 2 preflight lives in `src/solr-search/tests/test_e2e_solr10_phase2.py`; it validates single-node SolrCloud compose wiring, production Overseer-disabled SolrCloud wiring, int8 schema routing, estimated vector storage ratio, and `efSearchScaleFactor` query propagation without requiring Docker.
 - Live Solr 10 compatibility checks live in `e2e/test_solr10_runtime_compat.py`; set `E2E_SOLR_EXPECTED_MAJOR=10` only when a reachable Solr 10 fixture is running.
-- Production Overseer-disabled runtime validation is opt-in: set `E2E_SOLR_OVERSEER_DISABLED=1` for the pytest property check, or run `tests/solrcloud-overseer-disabled-validation.sh` against the production compose stack for create/delete smoke validation.
+- Production Overseer-disabled runtime validation is opt-in: set `E2E_SOLR_OVERSEER_DISABLED=1` for the pytest property check, or follow `docs/migration/solr-10-production-runbook.md` § 3.4 ("Validate Overseer Disabled Cluster Operations") for the production compose create/delete smoke procedure.
 - Treat quantization memory and recall as evidence-backed gates: preflight can prove schema/config wiring, but release claims need paired float32/int8 benchmark JSON plus memory observations from the same host and corpus.
 
 ### ZK SASL Limitation (v1.14.0+)

--- a/.squad/skills/solr-operations/SKILL.md
+++ b/.squad/skills/solr-operations/SKILL.md
@@ -100,6 +100,13 @@ curl -X POST 'http://localhost:8983/api/collections/books/shards/shard1/replicas
 - Graceful shutdown: `stop_grace_period: 60s`
 - Heap sizing: pair with container memory limits (not same number)
 
+## Pattern 4: Solr 10 Phase 2 Validation
+
+- Static Phase 2 preflight lives in `src/solr-search/tests/test_e2e_solr10_phase2.py`; it validates single-node SolrCloud compose wiring, production Overseer-disabled SolrCloud wiring, int8 schema routing, estimated vector storage ratio, and `efSearchScaleFactor` query propagation without requiring Docker.
+- Live Solr 10 compatibility checks live in `e2e/test_solr10_runtime_compat.py`; set `E2E_SOLR_EXPECTED_MAJOR=10` only when a reachable Solr 10 fixture is running.
+- Production Overseer-disabled runtime validation is opt-in: set `E2E_SOLR_OVERSEER_DISABLED=1` for the pytest property check, or run `tests/solrcloud-overseer-disabled-validation.sh` against the production compose stack for create/delete smoke validation.
+- Treat quantization memory and recall as evidence-backed gates: preflight can prove schema/config wiring, but release claims need paired float32/int8 benchmark JSON plus memory observations from the same host and corpus.
+
 ### ZK SASL Limitation (v1.14.0+)
 SASL DIGEST-MD5 from Solr to ZK is broken (Solr 9.7 + Java 17 + ZK 3.9). Use Docker network isolation + ZK digest ACLs instead.
 

--- a/e2e/test_solr10_runtime_compat.py
+++ b/e2e/test_solr10_runtime_compat.py
@@ -22,6 +22,7 @@ sys.path.append(str(SOLR_SEARCH_TESTS_DIR))
 from solr10_gates import assert_supported_solr10_scalar_bits  # noqa: E402
 
 EXPECTED_MAJOR_ENV = "E2E_SOLR_EXPECTED_MAJOR"
+OVERSEER_DISABLED_ENV = "E2E_SOLR_OVERSEER_DISABLED"
 SOLR_READY_TIMEOUT = int(os.environ.get("E2E_SOLR_READY_TIMEOUT", "90"))
 SOLR_READY_TEST_TIMEOUT = SOLR_READY_TIMEOUT + 60
 
@@ -32,6 +33,12 @@ def _require_expected_solr10() -> None:
     expected = os.environ.get(EXPECTED_MAJOR_ENV)
     if expected != "10":
         pytest.skip(f"Set {EXPECTED_MAJOR_ENV}=10 to enable Solr 10 runtime compatibility checks")
+
+
+def _require_overseer_disabled_fixture() -> None:
+    _require_expected_solr10()
+    if os.environ.get(OVERSEER_DISABLED_ENV) != "1":
+        pytest.skip(f"Set {OVERSEER_DISABLED_ENV}=1 when the Solr 10 fixture should have Overseer disabled")
 
 
 def _solr_admin_url(solr_url: str, path: str) -> str:
@@ -119,6 +126,10 @@ def _response(status_code: int, body: str = "") -> requests.Response:
     response.status_code = status_code
     response._content = body.encode()
     return response
+
+
+def _zero_vector(dimensions: int = 768) -> str:
+    return "[" + ",".join("0" for _ in range(dimensions)) + "]"
 
 
 @pytest.fixture(scope="session")
@@ -243,6 +254,42 @@ def test_live_solr_major_version_is_10(solr_system_info: dict[str, Any]) -> None
     """The opt-in Solr 10 fixture must actually run Solr 10."""
     version = str(solr_system_info.get("lucene", {}).get("solr-spec-version", ""))
     assert version.startswith("10."), f"Expected Solr 10.x, got {version!r}"
+
+
+@pytest.mark.timeout(SOLR_READY_TEST_TIMEOUT)
+def test_live_solr10_accepts_efsearch_scale_factor_query(
+    solr_url: str,
+    solr_auth: tuple[str, str],
+    solr_books_collection_ready: dict[str, Any],
+) -> None:
+    """Solr 10 must accept efSearchScaleFactor in kNN local params for Phase 2 tuning."""
+    response = _request_live_solr10(
+        "GET",
+        f"{solr_url}/select",
+        auth=solr_auth,
+        params={
+            "q": f"{{!knn f=embedding_v topK=1 efSearchScaleFactor=2}}{_zero_vector()}",
+            "rows": "1",
+            "fl": "id,score",
+            "wt": "json",
+        },
+    )
+
+    response.raise_for_status()
+    body = response.json()
+    assert body.get("responseHeader", {}).get("status") == 0
+
+
+def test_live_solr10_overseer_disabled_system_property(
+    solr_url: str,
+    solr_auth: tuple[str, str],
+) -> None:
+    """Production SolrCloud validation can assert the Overseer-disabled runtime property."""
+    _require_overseer_disabled_fixture()
+    body = _get_live_solr10_json(_solr_admin_url(solr_url, "admin/info/properties"), auth=solr_auth)
+    properties = body.get("system.properties") or body.get("systemProperties") or {}
+
+    assert str(properties.get("solr.cloud.overseer.enabled")).lower() == "false"
 
 
 @pytest.mark.timeout(SOLR_READY_TEST_TIMEOUT)

--- a/src/solr-search/tests/test_e2e_solr10_phase2.py
+++ b/src/solr-search/tests/test_e2e_solr10_phase2.py
@@ -18,11 +18,14 @@ import pytest
 import yaml
 from solr10_gates import assert_supported_solr10_scalar_bits
 
+from search_service import build_knn_params
+
 pytestmark = [pytest.mark.e2e, pytest.mark.phase2, pytest.mark.solr10]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MANAGED_SCHEMA_PATH = REPO_ROOT / "src" / "solr" / "books" / "managed-schema.xml"
 SINGLE_NODE_COMPOSE_PATH = REPO_ROOT / "docker" / "compose.single-node.yml"
+PROD_COMPOSE_PATH = REPO_ROOT / "docker" / "compose.prod.yml"
 
 
 class ComposeSafeLoader(yaml.SafeLoader):
@@ -85,6 +88,33 @@ class TestPhase2ActivePreflight:
         assert solr_search_env.get("ZOOKEEPER_HOSTS") == "zoo1:2181"
         assert "zoo1" in services["solr"]["depends_on"]
 
+    def test_phase2_single_node_overlay_keeps_only_one_active_solr_node(self) -> None:
+        """Single-node mode must route all Solr workload to the primary SolrCloud node."""
+        compose = _load_yaml(SINGLE_NODE_COMPOSE_PATH)
+        services = compose["services"]
+
+        assert services["zoo2"]["profiles"] == ["distributed-only"]
+        assert services["zoo3"]["profiles"] == ["distributed-only"]
+        assert services["solr2"]["profiles"] == ["distributed-only"]
+        assert services["solr3"]["profiles"] == ["distributed-only"]
+        assert set(services["solr-init"]["depends_on"]) == {"solr"}
+        assert services["solr-init"]["environment"]["SOLR_NUM_SHARDS"] == "${SOLR_NUM_SHARDS:-1}"
+        assert services["solr-init"]["environment"]["SOLR_REPLICATION_FACTOR"] == "${SOLR_REPLICATION_FACTOR:-1}"
+
+    def test_phase2_production_solrcloud_overseer_disabled_is_wired(self) -> None:
+        """Production SolrCloud must keep 3 nodes while disabling the legacy Overseer queue."""
+        compose = _load_yaml(PROD_COMPOSE_PATH)
+        services = compose["services"]
+
+        for service_name in ("zoo1", "zoo2", "zoo3", "solr", "solr2", "solr3"):
+            assert service_name in services
+            assert "distributed-only" not in services[service_name].get("profiles", [])
+
+        for service_name in ("solr", "solr2", "solr3"):
+            env = _service_env(services[service_name])
+            assert "-Dsolr.cloud.overseer.enabled=${SOLR_CLOUD_OVERSEER_ENABLED:-false}" in env["SOLR_OPTS"]
+            assert env["ZK_HOST"] == "zoo1:2181,zoo2:2181,zoo3:2181"
+
     def test_phase2_int8_schema_and_app_config_are_wired(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Quantization wiring can be validated without executing Solr benchmarks."""
         schema = ET.parse(MANAGED_SCHEMA_PATH).getroot()  # nosec B314
@@ -100,6 +130,35 @@ class TestPhase2ActivePreflight:
         assert config.settings.vector_quantization == "int8"
         assert config.settings.knn_field == "embedding_byte_v"
         assert config.settings.book_embedding_field == "embedding_byte_v"
+
+    def test_phase2_int8_vector_storage_estimate_meets_memory_reduction_gate(self) -> None:
+        """Schema-level int8 storage should meet the Phase 2 ≥3.5× memory-reduction gate."""
+        schema = ET.parse(MANAGED_SCHEMA_PATH).getroot()  # nosec B314
+        field_types = {field_type.attrib.get("name"): field_type.attrib for field_type in schema.findall("fieldType")}
+        float_vector = field_types["knn_vector_768"]
+        byte_vector = field_types["knn_vector_768_byte"]
+
+        assert int(float_vector["vectorDimension"]) == int(byte_vector["vectorDimension"]) == 768
+        assert_supported_solr10_scalar_bits(byte_vector["bits"])
+
+        float32_bytes_per_vector = int(float_vector["vectorDimension"]) * 4
+        signed_byte_bytes_per_vector = int(byte_vector["vectorDimension"])
+        assert float32_bytes_per_vector / signed_byte_bytes_per_vector >= 3.5
+
+    @pytest.mark.parametrize("scale_factor", [2.0, 5.0])
+    def test_phase2_efsearch_scale_factor_changes_solr_knn_query(self, scale_factor: float) -> None:
+        """The Solr 10 efSearchScaleFactor tuning parameter must reach the kNN local params."""
+        default_params = build_knn_params([0.5], top_k=10, knn_field="embedding_v")
+        tuned_params = build_knn_params(
+            [0.5],
+            top_k=10,
+            knn_field="embedding_v",
+            ef_search_scale_factor=scale_factor,
+        )
+
+        assert "efSearchScaleFactor" not in default_params["q"]
+        assert f"efSearchScaleFactor={scale_factor:g}" in tuned_params["q"]
+        assert tuned_params["rows"] == 10
 
 
 class TestPhase2StandaloneMode:

--- a/src/solr-search/tests/test_e2e_solr10_phase2.py
+++ b/src/solr-search/tests/test_e2e_solr10_phase2.py
@@ -73,6 +73,10 @@ def _reload_config(monkeypatch: pytest.MonkeyPatch, **env: str):
     return importlib.reload(config)
 
 
+def _estimated_scalar_vector_bytes(dimensions: int, bits: object) -> int:
+    return (dimensions * int(str(bits)) + 7) // 8
+
+
 class TestPhase2ActivePreflight:
     """Issue #1356 checks that can run before #1670/#1344 land."""
 
@@ -141,9 +145,21 @@ class TestPhase2ActivePreflight:
         assert int(float_vector["vectorDimension"]) == int(byte_vector["vectorDimension"]) == 768
         assert_supported_solr10_scalar_bits(byte_vector["bits"])
 
+        dimensions = int(byte_vector["vectorDimension"])
         float32_bytes_per_vector = int(float_vector["vectorDimension"]) * 4
-        signed_byte_bytes_per_vector = int(byte_vector["vectorDimension"])
-        assert float32_bytes_per_vector / signed_byte_bytes_per_vector >= 3.5
+        quantized_bytes_per_vector = _estimated_scalar_vector_bytes(dimensions, byte_vector["bits"])
+        assert float32_bytes_per_vector / quantized_bytes_per_vector >= 3.5
+
+    @pytest.mark.parametrize(
+        ("bits", "expected_bytes"),
+        [
+            ("4", 384),
+            ("7", 672),
+        ],
+    )
+    def test_phase2_scalar_vector_byte_estimate_uses_supported_bits(self, bits: str, expected_bytes: int) -> None:
+        """The memory estimate must track Solr 10 scalar bits, not assume full bytes."""
+        assert _estimated_scalar_vector_bytes(768, bits) == expected_bytes
 
     @pytest.mark.parametrize("scale_factor", [2.0, 5.0])
     def test_phase2_efsearch_scale_factor_changes_solr_knn_query(self, scale_factor: float) -> None:


### PR DESCRIPTION
## Summary
- Refs #1356
- Working as Lambert (Tester)
- Add active Phase 2 preflight coverage for single-node SolrCloud wiring, production Overseer-disabled wiring, int8 vector storage ratio, and efSearchScaleFactor kNN query propagation
- Add opt-in live Solr 10 checks for efSearchScaleFactor acceptance and Overseer-disabled runtime property
- Document reusable Phase 2 Solr validation workflow in Lambert history and the solr-operations skill

## Validation
- .squad/scripts/verify.sh ✅ (solr-search: 1177 passed, 21 skipped; coverage 89.02%)
- Focused: uv run pytest tests/test_e2e_solr10_phase2.py --tb=short -q --no-cov ✅ (7 passed, 5 skipped)
- Focused: PYTHONPATH=src/solr-search/tests uv run pytest e2e/test_solr10_runtime_compat.py --tb=short -q --no-cov ✅ (9 passed, 6 skipped)

## Remaining live evidence needed
- True standalone/no-ZK runtime is still not shipped; current supported small topology is single-node SolrCloud.
- Runtime int8 memory/recall/latency claims still require #1344/#1354 benchmark evidence on the same host/corpus.
- Live opt-in commands: E2E_SOLR_EXPECTED_MAJOR=10 PYTHONPATH=src/solr-search/tests uv run pytest e2e/test_solr10_runtime_compat.py --tb=short -q --no-cov; add E2E_SOLR_OVERSEER_DISABLED=1 for production Overseer-disabled fixtures.