### PR TITLE
Improve buildall failure reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,19 @@ jobs:
       - name: Validate Solr 10 image wiring
         run: bash tests/test-solr-image-refs.sh
 
+  buildall-failure-reporting-regression:
+    name: buildall failure reporting regression
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate buildall failure reporting
+        run: bash tests/test-buildall-failure-reporting.sh
+
   all-tests-passed:
     name: All tests passed
     if: always()
@@ -302,6 +315,7 @@ jobs:
       - python-lint
       - compose-security-regression
       - solr-image-reference-regression
+      - buildall-failure-reporting-regression
     steps:
       - name: Evaluate results
         env:
@@ -314,13 +328,14 @@ jobs:
           LINT_RESULT: ${{ needs.python-lint.result }}
           COMPOSE_SECURITY_RESULT: ${{ needs.compose-security-regression.result }}
           SOLR_IMAGE_REFS_RESULT: ${{ needs.solr-image-reference-regression.result }}
+          BUILDALL_RESULT: ${{ needs.buildall-failure-reporting-regression.result }}
           BUILD_NEEDED: ${{ needs.changes.outputs.build }}
         run: |
           if [ "$CHANGES_RESULT" = "failure" ] || [ "$CHANGES_RESULT" = "cancelled" ]; then
             echo "❌ Change detection failed"
             exit 1
           fi
-          for result in "$INDEXER_RESULT" "$SEARCH_RESULT" "$UI_RESULT" "$LISTER_RESULT" "$EMBEDDINGS_RESULT" "$LINT_RESULT" "$COMPOSE_SECURITY_RESULT" "$SOLR_IMAGE_REFS_RESULT"; do
+          for result in "$INDEXER_RESULT" "$SEARCH_RESULT" "$UI_RESULT" "$LISTER_RESULT" "$EMBEDDINGS_RESULT" "$LINT_RESULT" "$COMPOSE_SECURITY_RESULT" "$SOLR_IMAGE_REFS_RESULT" "$BUILDALL_RESULT"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "❌ One or more required jobs failed"
               exit 1

--- a/.squad/agents/brett/history.md
+++ b/.squad/agents/brett/history.md
@@ -97,3 +97,4 @@ Related: #1686, #1695, #1696
 ### 2026-06-06 — Workflow Consolidation Follow-up (Issue #1449)
 - Phase 1 consolidation is already merged on `dev`; keep later release/heartbeat workflow rewrites deferred instead of changing required release gates during v2.5.1 cleanup.
 - `squad-ci.yml` is a manual-dispatch placeholder with no required-check or release behavior; removing it is safe dead-code cleanup and preserves CI/release semantics.
+- **2026-06-07T10:39:19.545+00:00 — buildall failure reporting:** Keep `buildall.sh` bounded to preparation/build failure handling: capture each `uv sync` and Compose build step in `.test-artifacts/buildall-{step}-{timestamp}.log`, continue checking all Python prep steps, then skip Compose when prep failed and summarize failing steps with log paths.

--- a/buildall.sh
+++ b/buildall.sh
@@ -51,7 +51,7 @@ record_failure() {
 }
 
 print_failure_summary() {
-  echo ""
+  echo "" >&2
   echo "Build failed with ${#FAILURES[@]} failure(s):" >&2
   local failure label status log_file
   for failure in "${FAILURES[@]}"; do

--- a/buildall.sh
+++ b/buildall.sh
@@ -34,6 +34,58 @@ echo "Building version ${VERSION}"
 echo "Git commit: ${GIT_COMMIT}"
 echo "Build date: ${BUILD_DATE}"
 
+ARTIFACT_DIR="${BUILDALL_ARTIFACT_DIR:-${SCRIPT_DIR}/.test-artifacts}"
+BUILDALL_LOG_TIMESTAMP="${BUILDALL_LOG_TIMESTAMP:-$(date -u +"%Y%m%dT%H%M%SZ")}"
+FAILURES=()
+
+safe_log_name() {
+  local name="$1"
+  printf '%s' "$name" | tr -c '[:alnum:]_.-' '_'
+}
+
+record_failure() {
+  local label="$1"
+  local status="$2"
+  local log_file="$3"
+  FAILURES+=("${label}|${status}|${log_file}")
+}
+
+print_failure_summary() {
+  echo ""
+  echo "Build failed with ${#FAILURES[@]} failure(s):" >&2
+  local failure label status log_file
+  for failure in "${FAILURES[@]}"; do
+    IFS='|' read -r label status log_file <<< "$failure"
+    echo "  - ${label} exited with status ${status}" >&2
+    echo "    log: ${log_file}" >&2
+  done
+}
+
+run_logged() {
+  local label="$1"
+  local log_slug="$2"
+  local workdir="$3"
+  shift 3
+
+  mkdir -p "$ARTIFACT_DIR"
+  local log_file="${ARTIFACT_DIR}/buildall-$(safe_log_name "$log_slug")-${BUILDALL_LOG_TIMESTAMP}.log"
+
+  echo "Running ${label}"
+  echo "  log: ${log_file}"
+  if (
+    cd "$workdir"
+    "$@"
+  ) > "$log_file" 2>&1; then
+    echo "  ✅ ${label} succeeded"
+    return 0
+  else
+    local status=$?
+    echo "  ❌ ${label} failed (exit ${status})"
+    record_failure "$label" "$status" "$log_file"
+    return 1
+  fi
+}
+
 discover_python_service_dirs() {
   find src -mindepth 2 -maxdepth 2 -type f -name pyproject.toml -print \
     | while IFS= read -r pyproject_file; do
@@ -53,11 +105,21 @@ for service_dir in "${python_service_dirs[@]}"; do
     continue
   fi
 
-  echo "Running uv sync in ${service_dir}"
-  (
-    cd "${service_dir}"
-    uv sync
-  )
+  service_name="$(basename "$service_dir")"
+  run_logged "uv sync in ${service_dir}" "$service_name" "${SCRIPT_DIR}/${service_dir}" uv sync || true
 done
 
-docker compose up --build -d
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  echo "Skipping Docker Compose because service preparation failed." >&2
+  print_failure_summary
+  exit 1
+fi
+
+run_logged "docker compose up --build -d" "compose" "$SCRIPT_DIR" docker compose up --build -d || true
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  print_failure_summary
+  exit 1
+fi
+
+echo "Build completed successfully."

--- a/tests/test-buildall-failure-reporting.sh
+++ b/tests/test-buildall-failure-reporting.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Verifies buildall.sh reports the failing service and retains per-step logs.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SANDBOX="$ROOT/.test-artifacts/buildall-failure-test.$$"
+
+cleanup() {
+  local status=$?
+  if [ "$status" -eq 0 ]; then
+    rm -rf "$SANDBOX"
+  else
+    echo "Retained artifacts: $SANDBOX"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$SANDBOX/repo/src/service-a" "$SANDBOX/repo/src/service-b" "$SANDBOX/bin"
+cp "$ROOT/buildall.sh" "$SANDBOX/repo/buildall.sh"
+printf 'test-version\n' > "$SANDBOX/repo/VERSION"
+
+for service in service-a service-b; do
+  touch "$SANDBOX/repo/src/$service/pyproject.toml"
+  touch "$SANDBOX/repo/src/$service/Dockerfile"
+done
+
+cat > "$SANDBOX/bin/uv" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$PWD" in
+  */service-b)
+    echo "simulated uv failure for service-b" >&2
+    exit 42
+    ;;
+  *)
+    echo "simulated uv success for ${PWD##*/}"
+    ;;
+esac
+SH
+chmod +x "$SANDBOX/bin/uv"
+
+cat > "$SANDBOX/bin/docker" <<'SH'
+#!/usr/bin/env bash
+echo "docker should not run after a service preparation failure" >&2
+exit 99
+SH
+chmod +x "$SANDBOX/bin/docker"
+
+OUTPUT="$SANDBOX/output.txt"
+if PATH="$SANDBOX/bin:$PATH" BUILDALL_LOG_TIMESTAMP="20260102T030405Z" \
+  bash "$SANDBOX/repo/buildall.sh" > "$OUTPUT" 2>&1; then
+  fail "buildall.sh should fail when an individual service sync fails"
+fi
+
+grep -Fq "uv sync in src/service-b failed (exit 42)" "$OUTPUT" ||
+  fail "output should name the failing service and exit status"
+
+grep -Fq "Skipping Docker Compose because service preparation failed." "$OUTPUT" ||
+  fail "output should explain Docker Compose was skipped"
+
+LOG="$SANDBOX/repo/.test-artifacts/buildall-service-b-20260102T030405Z.log"
+[ -f "$LOG" ] || fail "expected service-b log at $LOG"
+
+grep -Fq "simulated uv failure for service-b" "$LOG" ||
+  fail "service log should contain the command failure output"
+
+if grep -Fq "docker should not run" "$OUTPUT"; then
+  fail "docker compose should not run after a service preparation failure"
+fi
+
+cat > "$SANDBOX/bin/uv" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "simulated uv success for ${PWD##*/}"
+SH
+chmod +x "$SANDBOX/bin/uv"
+
+cat > "$SANDBOX/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 $2 $3 $4" != "compose up --build -d" ]; then
+  echo "unexpected docker arguments: $*" >&2
+  exit 2
+fi
+echo "simulated compose failure" >&2
+exit 77
+SH
+chmod +x "$SANDBOX/bin/docker"
+
+COMPOSE_OUTPUT="$SANDBOX/compose-output.txt"
+if PATH="$SANDBOX/bin:$PATH" BUILDALL_LOG_TIMESTAMP="20260102T030406Z" \
+  bash "$SANDBOX/repo/buildall.sh" > "$COMPOSE_OUTPUT" 2>&1; then
+  fail "buildall.sh should fail when Docker Compose fails"
+fi
+
+grep -Fq "docker compose up --build -d failed (exit 77)" "$COMPOSE_OUTPUT" ||
+  fail "output should report Docker Compose failure and exit status"
+
+COMPOSE_LOG="$SANDBOX/repo/.test-artifacts/buildall-compose-20260102T030406Z.log"
+[ -f "$COMPOSE_LOG" ] || fail "expected Compose log at $COMPOSE_LOG"
+
+grep -Fq "simulated compose failure" "$COMPOSE_LOG" ||
+  fail "Compose log should contain command failure output"
+
+echo "OK: buildall.sh reports failed steps and saves per-step logs"


### PR DESCRIPTION
## Summary
- add per-step buildall logs under `.test-artifacts/buildall-{step}-{timestamp}.log`
- continue Python service prep checks, summarize failures, and skip Compose when prep fails
- add CI-covered regression test for service prep and Compose failures

Refs #1452
Working as Brett (Infrastructure Architect). Parker support/review requested by routing context.

## Validation
- `bash -n buildall.sh tests/test-buildall-failure-reporting.sh`
- `bash tests/test-buildall-failure-reporting.sh`
- `.squad/scripts/verify.sh`

## Scope
Bounded to `buildall.sh` failure handling/reporting; no Dockerfile consolidation, env-file, CLI wrapper, test orchestration, or documentation scatter changes.