### PR TITLE
Clean up stale v2.5 docs guidance

### DIFF
--- a/.copilot/skills/prd-writing-aithena/SKILL.md
+++ b/.copilot/skills/prd-writing-aithena/SKILL.md
@@ -193,7 +193,7 @@ Phase 4: Cleanup (Week 6)
 **Format:** Links to related PRDs, decisions, skills
 
 **Example:**
-- Related PRD: `docs/prd/admin-react-migration.md` (Phase 1 API endpoints support pre-release validation)
+- Related PRD: `docs/prd/completed/admin-react-migration.md` (Phase 1 API endpoints support pre-release validation)
 - Skill: `phase-gated-execution` (Admin React migration will use 4-phase model)
 - Skill: `milestone-wave-execution` (12-issue Admin React migration will use waves)
 - Decision: `.squad/decisions.md` (Pre-release containers approved 2026-03-25)
@@ -262,6 +262,6 @@ At release time (e.g., v1.16.0 release):
 ## References
 
 - **Pre-Release Containers PRD:** `docs/prd/pre-release-containers.md` (v1.16.0, 5 issues)
-- **Admin React Migration PRD:** `docs/prd/admin-react-migration.md` (v2.0, 12 issues)
+- **Admin React Migration PRD:** `docs/prd/completed/admin-react-migration.md` (v2.0, 12 issues)
 - **Related skills:** phase-gated-execution, milestone-wave-execution, release-gate
 - **Decision tracker:** `.squad/decisions.md` (all approved PRDs logged here)

--- a/.squad/agents/newt/history.md
+++ b/.squad/agents/newt/history.md
@@ -17,11 +17,11 @@
 
 **Release baseline:** Docs-first gates are enforced since v0.8.0. v1.x shipped infra, ops, quality, admin, CI, embeddings, and docs releases. Tests grew from ~467 (v1.4.0) to 1,939 (v1.15.0); drops or unexplained jumps require investigation.
 
-**Current state (2026-06):** v2.2.1 shipped. v2.3.0 is maintenance/infrastructure hardening: milestone exists, target 2026-06-11, notes/manuals prepared in #1645/#1647, validation in #1648, final evidence pending implementation/tests. v2.5 is Solr 10 research.
+**Current state (2026-06):** v2.5.0 shipped as the Solr 10 infrastructure release. Post-v2.5 follow-up tracks include evidence-gated quantization, topology hardening, and docs/source-of-truth cleanup.
 
 **Active PRDs / product tracks:**
 1. **Pre-Release Containers (v1.16+)** — RC workflow before main merge; manual/auto triggers; production compose validation.
-2. **Admin React Migration (v2.0)** — Streamlit → React `/admin/*`; unify auth; remove docker.sock exposure; phase-gated API/UI/tests/removal.
+2. **Admin React Migration (v2.0, completed)** — Streamlit → React `/admin/*`; shipped in v2.0.0 and archived at `docs/prd/completed/admin-react-migration.md`.
 3. **Infrastructure hardening (v2.3.0)** — publish operator responsibilities for ZooKeeper/Solr posture and accepted risks.
 
 ## Product Patterns
@@ -91,3 +91,5 @@
 Triaged remaining v2.5.1 board items. All issues now assigned or in-progress. Remaining work blocked on external dependencies: external corpus, hardware, model/runtime fixtures, benchmark execution, or broader design planning. Recommended Ralph idle until external unblocking.
 
 Related: v2.5.1 board, v2.5 epic
+
+15. **2026-06-07 — Docs consistency cleanup:** Release notes, manuals, test reports, and topology docs must align to shipped code, not planned issue titles. For v2.5, the shipped source of truth is single-node SolrCloud (not ZooKeeper-free standalone), `blockUnknown=false` compatibility posture, Solr 10 HNSW names `hnswM`/`hnswEfConstruction`, and evidence-gated int8 quantization (#1344).

--- a/.squad/decisions/inbox/newt-docs-consistency-cleanup.md
+++ b/.squad/decisions/inbox/newt-docs-consistency-cleanup.md
@@ -1,0 +1,21 @@
+# Decision: Docs Must Describe Shipped v2.5 Behavior
+
+**Author:** Newt (Product Manager)
+**Date:** 2026-06-07T14:53:54Z
+**Status:** Proposed
+**Related:** #1452, #1344, v2.5.0 docs audit
+
+## Context
+
+The pending-work audit found several v2.5 documents describing planned or issue-title behavior that diverged from the shipped code and migration runbooks. Conflicts included ZooKeeper-free standalone mode, `blockUnknown=true`, non-runtime HNSW parameter names, and overconfident quantization claims.
+
+## Decision
+
+When release documentation conflicts, operator-facing docs must be reconciled to the shipped code/runtime and current migration runbooks. Future planned hardening or optimization should be named as follow-up work, not documented as already shipped behavior.
+
+## Current v2.5 Source of Truth
+
+- Lightweight Solr deployments use single-node SolrCloud (`docker/compose.single-node.yml`), not true ZooKeeper-free standalone/core mode.
+- Aithena v2.5 explicitly keeps `blockUnknown=false`; moving to `true` requires a dedicated hardening change.
+- Solr 10 HNSW names are `hnswM` and `hnswEfConstruction`; Solr 9 compatibility rewrites them during rollback/support windows.
+- int8 quantization remains evidence-gated for production and should point to #1344-style benchmark evidence.

--- a/.squad/decisions/inbox/newt-docs-consistency-cleanup.md
+++ b/.squad/decisions/inbox/newt-docs-consistency-cleanup.md
@@ -1,9 +1,9 @@
 # Decision: Docs Must Describe Shipped v2.5 Behavior
 
-**Author:** Newt (Product Manager)
-**Date:** 2026-06-07T14:53:54Z
-**Status:** Proposed
-**Related:** #1452, #1344, v2.5.0 docs audit
+Author: Newt (Product Manager)
+Date: 2026-06-07
+Status: Proposed
+Related: #1452, #1344, v2.5.0 docs audit
 
 ## Context
 

--- a/.squad/skills/prd-writing-aithena/SKILL.md
+++ b/.squad/skills/prd-writing-aithena/SKILL.md
@@ -193,7 +193,7 @@ Phase 4: Cleanup (Week 6)
 **Format:** Links to related PRDs, decisions, skills
 
 **Example:**
-- Related PRD: `docs/prd/admin-react-migration.md` (Phase 1 API endpoints support pre-release validation)
+- Related PRD: `docs/prd/completed/admin-react-migration.md` (Phase 1 API endpoints support pre-release validation)
 - Skill: `phase-gated-execution` (Admin React migration will use 4-phase model)
 - Skill: `milestone-wave-execution` (12-issue Admin React migration will use waves)
 - Decision: `.squad/decisions.md` (Pre-release containers approved 2026-03-25)
@@ -262,6 +262,6 @@ At release time (e.g., v1.16.0 release):
 ## References
 
 - **Pre-Release Containers PRD:** `docs/prd/pre-release-containers.md` (v1.16.0, 5 issues)
-- **Admin React Migration PRD:** `docs/prd/admin-react-migration.md` (v2.0, 12 issues)
+- **Admin React Migration PRD:** `docs/prd/completed/admin-react-migration.md` (v2.0, 12 issues)
 - **Related skills:** phase-gated-execution, milestone-wave-execution, release-gate
 - **Decision tracker:** `.squad/decisions.md` (all approved PRDs logged here)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A multilingual book library search engine that indexes PDFs using **Apache Solr** for full-text search, extracts metadata (author, date, language) from filenames and folder names, and supports keyword, semantic, and hybrid search via embeddings.
 
-**Current Release:** v2.2.1 — Maintenance patch for prod-overlay volume migration safety and test reliability.  
-**Development:** v2.5 milestone active. All PRs target `dev` branch; releases merge `dev` → `main`.  
-**[View Milestones](https://github.com/jmservera/aithena/milestones)** | **[Latest Release Notes](docs/release-notes/v2.2.1.md)**
+**Current Release:** v2.5.0 — Solr 10 runtime migration, enhanced embeddings infrastructure, and security hardening.
+**Development:** Post-v2.5 follow-up and validation work continues on `dev`; releases merge `dev` → `main`.
+**[View Milestones](https://github.com/jmservera/aithena/milestones)** | **[Latest Release Notes](docs/release-notes/v2.5.0.md)**
 
 ## What It Does
 
@@ -98,6 +98,8 @@ See [Release Process Overview](#release-process-overview) below for full details
 
 ### Release Notes (newest first)
 
+- [v2.5.0 Release Notes](docs/release-notes/v2.5.0.md) — Solr 10 runtime migration, embeddings infrastructure, and security hardening
+- [v2.3.0 Release Notes](docs/release-notes/v2.3.0.md) — Infrastructure hardening and release validation noise reduction
 - [v2.2.1 Release Notes](docs/release-notes/v2.2.1.md) — Maintenance patch superseding v2.2.0
 - [v2.2.0 Release Notes](docs/release-notes/v2.2.0.md) — Prod overlay volume migration and test reliability
 - [v2.1.0 Release Notes](docs/release-notes/v2.1.0.md) — Configurable search architecture, single-node topology
@@ -407,10 +409,10 @@ See `src/document-indexer/tests/test_metadata.py` for test cases and real librar
 
 ### Project Phases
 
-**Phase 1** (in progress): Core Solr indexing pipeline, metadata extraction, schema  
-**Phase 2**: FastAPI search API, React search UI with faceting, PDF viewer  
-**Phase 3**: Embeddings indexing, hybrid search (keyword + semantic), similar books  
-**Phase 4**: PDF upload, file watcher, admin dashboard, production hardening  
+**Phase 1** (in progress): Core Solr indexing pipeline, metadata extraction, schema
+**Phase 2**: FastAPI search API, React search UI with faceting, PDF viewer
+**Phase 3**: Embeddings indexing, hybrid search (keyword + semantic), similar books
+**Phase 4**: PDF upload, file watcher, admin dashboard, production hardening
 
 Current branch: `dev`
 

--- a/docs/admin-manual.md
+++ b/docs/admin-manual.md
@@ -2,7 +2,7 @@
 
 This manual covers deployment, configuration, monitoring, and troubleshooting for Aithena. If you are looking for end-user instructions, start with the [User Manual](user-manual.md). For the latest release features, see the [latest changelog](../CHANGELOG.md).
 
-**v1.15.0 / v1.16.0 / v1.17.0 / v1.18.0 / v1.19.0 / v2.0.0 / v2.2.0 / v2.2.1 / v2.3.0 / v2.5.0 operator note:** v1.15.0 includes admin portal enhancements (sidebar navigation, per-service log viewer, Solr SSO passthrough), critical bug fixes (document indexer OOM on large PDFs, thumbnail write failures), build-time dependency installation, and volume permission hardening. v1.16.0 adds search UI bug fixes, similar-books endpoint fix, admin dashboard pagination, nginx thumbnail routing fix, RabbitMQ deprecation warning fix, CI smoke test timeout fix, and a new pre-release container workflow. v1.17.0 introduces GPU acceleration for embeddings (opt-in via environment variables), security dependency updates (`requests`, `picomatch`), and comprehensive GPU documentation. v1.18.0 adds folder path facets for hierarchical search filtering, a comprehensive backup and disaster recovery system, stress-testing infrastructure, PDF embedded viewer fix, collections UI consistency fix, and CI/CD hardening. v1.18.1 patches the Solr auth role assignment to align with Solr 9.7 defaults and fixes the installer when run from the repo root. v1.19.0 adds configurable Solr topology (shards and replication factor), suppresses deprecation warnings from Solr 9.7 Security Manager and RabbitMQ 4.x, and includes 38+ dependency updates. **v2.0.0 is a major release:** replaces the Streamlit admin dashboard with a React SPA at `/admin/`, removes the `aithena-admin` container image, adds admin REST API endpoints, overhauled installer with GPU auto-detection and SSL, Solr 9/10 compatibility layer, and 119 integration tests + 38 accessibility tests. **v2.2.0** completes the prod-overlay volume migration work, fixes the Solr-init replication factor cap on single-node deployments, resolves a chronic CI E2E 429 rate-limit failure, and fixes a CodeQL security alert in the installer. **v2.2.1** is the follow-up maintenance patch for the 2.2.x line: it removes the remaining prod-overlay bind-mount overrides, preserves the single-node Solr safety guard, and improves release/test reliability. **v2.3.0** is an infrastructure hardening release: enforces host-level Redis memory overcommit, documents ZooKeeper security posture constraints, and improves pre-release validation. **v2.5.0 is a major infrastructure release:** upgrades the search engine from Apache Solr 9 to Apache Solr 10, introduces a ZooKeeper-free standalone deployment mode, integrates the Solr 10 Security UI into the admin portal, and rewrites the `solr-init` bootstrap for Solr 10 APIs. Operators upgrading from v2.3.0 must migrate HNSW schema parameters and follow the Solr 10 migration runbook before restarting the stack. See the [v1.15.0 Deployment Updates](#deployment-updates-for-v1150), [v1.16.0 Deployment Updates](#deployment-updates-for-v1160), [v1.17.0 Deployment Updates](#deployment-updates-for-v1170), [v1.18.0 Deployment Updates](#deployment-updates-for-v1180), [v1.18.1 Deployment Updates](#deployment-updates-for-v1181), [v1.19.0 Deployment Updates](#deployment-updates-for-v1190), [v2.0.0 Deployment Updates](#deployment-updates-for-v200), [v2.2.0 Deployment Updates](#deployment-updates-for-v220), [v2.2.1 Deployment Updates](#deployment-updates-for-v221), [v2.3.0 Deployment Updates](#deployment-updates-for-v230), and [v2.5.0 Deployment Updates](#deployment-updates-for-v250) sections below.
+**v1.15.0 / v1.16.0 / v1.17.0 / v1.18.0 / v1.19.0 / v2.0.0 / v2.2.0 / v2.2.1 / v2.3.0 / v2.5.0 operator note:** v1.15.0 includes admin portal enhancements (sidebar navigation, per-service log viewer, Solr SSO passthrough), critical bug fixes (document indexer OOM on large PDFs, thumbnail write failures), build-time dependency installation, and volume permission hardening. v1.16.0 adds search UI bug fixes, similar-books endpoint fix, admin dashboard pagination, nginx thumbnail routing fix, RabbitMQ deprecation warning fix, CI smoke test timeout fix, and a new pre-release container workflow. v1.17.0 introduces GPU acceleration for embeddings (opt-in via environment variables), security dependency updates (`requests`, `picomatch`), and comprehensive GPU documentation. v1.18.0 adds folder path facets for hierarchical search filtering, a comprehensive backup and disaster recovery system, stress-testing infrastructure, PDF embedded viewer fix, collections UI consistency fix, and CI/CD hardening. v1.18.1 patches the Solr auth role assignment to align with Solr 9.7 defaults and fixes the installer when run from the repo root. v1.19.0 adds configurable Solr topology (shards and replication factor), suppresses deprecation warnings from Solr 9.7 Security Manager and RabbitMQ 4.x, and includes 38+ dependency updates. **v2.0.0 is a major release:** replaces the Streamlit admin dashboard with a React SPA at `/admin/`, removes the `aithena-admin` container image, adds admin REST API endpoints, overhauled installer with GPU auto-detection and SSL, Solr 9/10 compatibility layer, and 119 integration tests + 38 accessibility tests. **v2.2.0** completes the prod-overlay volume migration work, fixes the Solr-init replication factor cap on single-node deployments, resolves a chronic CI E2E 429 rate-limit failure, and fixes a CodeQL security alert in the installer. **v2.2.1** is the follow-up maintenance patch for the 2.2.x line: it removes the remaining prod-overlay bind-mount overrides, preserves the single-node Solr safety guard, and improves release/test reliability. **v2.3.0** is an infrastructure hardening release: enforces host-level Redis memory overcommit, documents ZooKeeper security posture constraints, and improves pre-release validation. **v2.5.0 is a major infrastructure release:** upgrades the search engine from Apache Solr 9 to Apache Solr 10, keeps lightweight deployments on single-node SolrCloud (one Solr node plus ZooKeeper), integrates the Solr 10 Security UI into the admin portal, and rewrites the `solr-init` bootstrap for Solr 10 APIs. Operators upgrading from v2.3.0 must migrate HNSW schema parameters and follow the Solr 10 migration runbook before restarting the stack. See the [v1.15.0 Deployment Updates](#deployment-updates-for-v1150), [v1.16.0 Deployment Updates](#deployment-updates-for-v1160), [v1.17.0 Deployment Updates](#deployment-updates-for-v1170), [v1.18.0 Deployment Updates](#deployment-updates-for-v1180), [v1.18.1 Deployment Updates](#deployment-updates-for-v1181), [v1.19.0 Deployment Updates](#deployment-updates-for-v1190), [v2.0.0 Deployment Updates](#deployment-updates-for-v200), [v2.2.0 Deployment Updates](#deployment-updates-for-v220), [v2.2.1 Deployment Updates](#deployment-updates-for-v221), [v2.3.0 Deployment Updates](#deployment-updates-for-v230), and [v2.5.0 Deployment Updates](#deployment-updates-for-v250) sections below.
 
 ## System architecture overview
 
@@ -5449,8 +5449,8 @@ v2.5.0 is a **major infrastructure release that upgrades the Solr search engine 
 1. **Solr 10 base image (#1335)** — The `solr`, `solr2`, and `solr3` container images now run Apache Solr 10.x.
 2. **HNSW schema migration (#1336)** — Vector search field parameters renamed for Solr 10; existing collections require schema migration before upgrading.
 3. **solr-init CLI rewrite (#1337)** — `solr-init` bootstrap uses Solr 10 CLI APIs (`solr create`, `solr config`, `solr auth`); Solr 9 invocations removed.
-4. **blockUnknown default enforcement (#1338)** — Solr 10 defaults `blockUnknown=true`; `security.json` bootstrap now sets this explicitly.
-5. **Standalone Solr mode (#1342)** — New `docker/compose.solr-standalone.yml` enables ZooKeeper-free single-node deployments.
+4. **blockUnknown compatibility posture (#1338, #1663)** — Solr 10 defaults `blockUnknown=true`; Aithena v2.5 explicitly keeps `blockUnknown=false` for current health/metrics compatibility.
+5. **Single-node SolrCloud topology (#1342)** — Lightweight deployments use `docker/compose.single-node.yml` (one Solr node plus ZooKeeper); true ZooKeeper-free standalone/core mode is not shipped in v2.5.
 6. **Security UI integration (#1350)** — Admin portal **Security** page links to Solr 10's built-in Security UI at `/admin/solr/ui/#/~security`.
 7. **PathHierarchyTokenizer verified (#1352)** — Folder path facets confirmed compatible with Solr 10; no schema changes required.
 
@@ -5464,8 +5464,8 @@ HNSW vector field parameter names changed between Solr 9 and Solr 10. **Existing
 
 | Solr 9 Parameter | Solr 10 Parameter |
 |---|---|
-| `hnswMaxConnections` | `maxConnections` |
-| `hnswBeamWidth` | `beamWidth` |
+| `hnswMaxConnections` | `hnswM` |
+| `hnswBeamWidth` | `hnswEfConstruction` |
 
 **Before upgrading to v2.5.0:**
 
@@ -5475,25 +5475,21 @@ HNSW vector field parameter names changed between Solr 9 and Solr 10. **Existing
 
 Do not start the Solr 10 images against an existing Solr 9 data directory without completing this migration.
 
-### Standalone Solr Mode (New)
+### Lightweight Solr Topology
 
-v2.5.0 introduces a ZooKeeper-free standalone deployment option for lightweight single-node installations.
+v2.5.0 does **not** ship true ZooKeeper-free standalone/core mode. For lightweight single-node installations, use the single-node SolrCloud overlay, which runs one Solr node plus ZooKeeper.
 
-**To use standalone mode:**
+**To use single-node SolrCloud:**
 
 ```bash
-# Run the installer and choose "Standalone" when prompted for topology
-python3 -m installer
-# or pass directly:
-python3 -m installer --topology standalone
+# Include the single-node overlay when starting the stack
+COMPOSE_FILE=docker-compose.yml:docker/compose.single-node.yml docker compose up -d
 ```
 
-The installer generates a `start.sh` that includes `docker/compose.solr-standalone.yml` for standalone mode.
-
-**Standalone mode limitations:**
-- No sharding or multi-node replication.
-- Not supported for production deployments with large document counts.
-- Use the SolrCloud topology (default) for HA and distributed search.
+**Single-node SolrCloud limitations:**
+- No high availability; a node outage stops search/indexing.
+- ZooKeeper is still required, but only as a single container in the Compose network.
+- Use the distributed SolrCloud topology (default) for HA and distributed search.
 
 ### Solr 10 Security UI (v2.5)
 
@@ -5523,14 +5519,14 @@ The Aithena admin portal now includes an **Admin → Security** page that provid
 
 ### blockUnknown Security Default
 
-Solr 10 ships with `blockUnknown=true` as the default for the BasicAuth security plugin. Aithena's `security.json` bootstrap now explicitly sets this value.
+Solr 10 ships with `blockUnknown=true` as the default for the BasicAuth security plugin. Aithena v2.5 explicitly keeps `blockUnknown=false` in `security.json` and `solr-init` so current unauthenticated health and metrics permissions continue to work.
 
 **Impact:**
-- Unauthenticated requests to Solr are rejected with HTTP 401.
-- This is the expected behavior and the Aithena stack is designed for it.
-- Operators with custom `security.json` overrides should review them to ensure `blockUnknown` is set explicitly.
+- The Solr API remains protected by RBAC for privileged operations.
+- Health and metrics permissions that intentionally allow unauthenticated probes continue to work.
+- Operators with custom `security.json` overrides should review them to ensure `blockUnknown` is set deliberately.
 
-**No operator action is required** for standard Aithena deployments. The `security.json` bootstrap is handled by `solr-init`.
+Moving to `blockUnknown=true` is the recommended future hardening target, but it should be paired with fully authenticated health/metrics access in a dedicated change.
 
 ### Upgrade Instructions
 
@@ -5595,8 +5591,8 @@ Follow the [v2.3.0 deployment notes](#deployment-updates-for-v230) first, then a
 | Upgrade Solr base image to 10 | `docker-compose.yml` (image tags) | Pull new images before restart. |
 | Migrate HNSW schema parameters | `managed-schema.xml` | **REQUIRED** for upgrades. Follow migration runbook. |
 | Rewrite solr-init bootstrap | `src/solr-init/` | No operator action. Applied on image pull. |
-| `blockUnknown=true` explicit in `security.json` | `src/solr-init/security.json` | No operator action. Bootstrap applies on fresh collections. |
-| Standalone Solr topology | `docker/compose.solr-standalone.yml` | Optional. Choose during installer or pass `--topology standalone`. |
+| `blockUnknown=false` explicit in `security.json` | `src/solr/security.json` and `solr-init` | No operator action for v2.5. Plan a separate hardening change before switching to `true`. |
+| Single-node SolrCloud topology | `docker/compose.single-node.yml` | Optional lightweight topology. Still uses ZooKeeper; true standalone/core mode is not shipped. |
 | Security UI scaffold | `src/aithena-ui/src/admin/Security` | No operator action. Available after pull and restart. |
 
 ### Data Migration
@@ -5622,6 +5618,7 @@ v2.5.0 publishes updated service images with the new release tag:
 ### Known Limitations
 
 - **Solr 10 startup time:** SolrCloud startup can take 45–60 seconds on first boot. `solr-init` retries are built in; increase `--health-retries` in CI if timeout issues arise.
-- **Standalone mode is not HA:** The standalone topology does not support sharding or replication. Use SolrCloud for production deployments.
+- **Single-node SolrCloud is not HA:** The lightweight topology uses one Solr node plus ZooKeeper and does not provide multi-node failover. Use distributed SolrCloud for HA production deployments.
+- **No true standalone/core mode in v2.5:** Do not look for `docker/compose.solr-standalone.yml`; it is not part of the shipped release.
 - **Legacy Solr 9 data directories:** Starting Solr 10 against an unmigrated Solr 9 data directory will result in startup errors. Always follow the migration runbook.
-- **Custom `security.json`:** Operators with custom Solr security configurations should review them against the Solr 10 `blockUnknown` default.
+- **Custom `security.json`:** Operators with custom Solr security configurations should review them against the Solr 10 `blockUnknown` default and the v2.5 compatibility posture.

--- a/docs/deployment-topologies.md
+++ b/docs/deployment-topologies.md
@@ -247,14 +247,14 @@ Change chunking strategy from **400-word passages** to **full pages**:
 - **Implementation:** Modify document-indexer chunk size; re-index required
 - **Timeline:** 1–2 weeks
 
-#### Phase 2: int8 Quantization (Solr 9.7 Ready)
+#### Phase 2: int8 Quantization (Evidence-Gated)
 
-Enable `vectorEncoding="BYTE"` in the schema:
+Aithena includes an optional int8/byte-vector path, but production use remains evidence-gated. Treat it as an optimization candidate until benchmark evidence for your corpus is captured (see issue #1344).
 
-- **Reduction:** 4× per-vector (3,328 bytes → 832 bytes)
-- **Quality loss:** ~1–3% recall@10 (acceptable trade-off)
-- **Implementation:** Schema change + quantization in embeddings-server
-- **Timeline:** 2–3 weeks + re-index
+- **Reduction target:** up to 4× per-vector (3,328 bytes → 832 bytes)
+- **Quality impact:** expected to be corpus-dependent; validate recall@10 before enabling in production
+- **Implementation:** Schema/config change + embeddings pipeline support + full re-index
+- **Timeline:** 2–3 weeks + benchmark/evidence review + re-index
 
 #### Phase 3: Model Downgrade (Optional)
 
@@ -442,9 +442,9 @@ Vector quantization reduces memory footprint and affects hardware budgets.
 | Mode | Dimensions | Per-Vector Size | Total (30K books) | Quality Loss | Solr Version |
 |------|-----------|-----------------|------------------|--------------|------------|
 | **No quantization** (float32) | 768 (e5-base) | 3,328 B | 130–180 GB | None | 9.3+ |
-| **int8 (byte encoding)** | 768 (e5-base) | 832 B | 25–35 GB | ~1–3% | 9.7+ |
-| **Model downgrade** (e5-small) | 384 | 1,664 B (float32) | 65–90 GB | ~5% relative | 9.3+ |
-| **e5-small + int8** | 384 | 416 B | 13–18 GB | ~5% + ~1–3% | 9.7+ |
+| **int8 (byte encoding)** | 768 (e5-base) | 832 B | 25–35 GB | Evidence required; corpus-dependent | Optional; validate via #1344 before production |
+| **Model downgrade** (e5-small) | 384 | 1,664 B (float32) | 65–90 GB | ~5% relative (benchmark before production) | 9.3+ |
+| **e5-small + int8** | 384 | 416 B | 13–18 GB | Combined impact requires evidence | Optional; validate via #1344 before production |
 | **ScalarQuantized (int4)** | 768 | 416 B | 13–18 GB | ~2–5% | 10.0+ (future) |
 
 ### Recommended Combinations
@@ -452,8 +452,8 @@ Vector quantization reduces memory footprint and affects hardware budgets.
 **For 32 GB Single-Node (Scenario B):**
 ```
 Page-level chunking: 54M → 9M vectors
-int8 quantization: 768D × 832 B = 7.5 GB HNSW
-Total: ~32 GB (with OS + JVM + text headroom)
+int8 quantization candidate: 768D × 832 B = 7.5 GB HNSW
+Total target: ~32 GB (requires #1344-style recall and memory evidence before production)
 ```
 
 **For 64 GB Single-Node (Scenario D, maximum comfort):**
@@ -466,7 +466,7 @@ Total: ~48 GB (with OS + JVM + text headroom)
 **For Distributed (any scale):**
 ```
 No quantization required; memory per node is 2–8 GB for Solr
-Recommend: int8 for indexing performance (less memory → faster disk I/O)
+Consider int8 only after corpus-specific benchmark evidence; float32 remains the conservative default
 ```
 
 ---

--- a/docs/prd/completed/admin-react-migration.md
+++ b/docs/prd/completed/admin-react-migration.md
@@ -1,12 +1,16 @@
-# PRD: Admin Portal Migration — Streamlit to React (v2.0)
+# Completed PRD: Admin Portal Migration — Streamlit to React (v2.0)
 
 | Field | Value |
 |---|---|
 | **Author** | Newt (Product Manager) |
 | **Requested by** | Juanma (jmservera) |
-| **Status** | Draft |
+| **Status** | Completed — shipped in v2.0.0 |
 | **Target release** | v2.0 |
-| **Last updated** | 2025-07-18 |
+| **Last updated** | 2026-06-07 |
+
+---
+
+> **Completion note (2026-06-07):** This PRD is archived as completed. The React admin portal shipped in v2.0.0, and the legacy Streamlit admin service/image was removed from the release payload (see `CHANGELOG.md` v2.0.0).
 
 ---
 

--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -236,7 +236,7 @@ curl -s "http://localhost/admin/solr/api/v2/node/properties" | jq '.error.code'
 - **#1339** — `[v2.5] Verify wt=json response writer`
 - **#1340** — `[v2.5] Update E2E tests for Solr 10`
 - **#1341** — `[v2.5] Update CI/CD for Solr 10 image builds`
-- **#1342** — `[v2.5] Implement standalone Solr mode` (closed; shipped docs/code use single-node SolrCloud, not ZooKeeper-free standalone/core mode)
+- **#1342** — `[v2.5] Implement lightweight Solr topology` — Shipped as single-node SolrCloud (`docker/compose.single-node.yml`), not ZooKeeper-free standalone/core mode.
 - **#1350** — `[v2.5] Implement simplified Security UI`
 - **#1352** — `[v2.5] Verify PathHierarchyTokenizer behavior`
 - **#1353** — `[v2.5] Update documentation for Solr 10`

--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -5,16 +5,16 @@ _Prepared by:_ Newt (Product Manager)
 
 ## Summary
 
-Aithena v2.5.0 is a major infrastructure release that upgrades the Solr search engine from version 9 to version 10. This release brings Solr 10's improved performance, updated security architecture, and a new standalone (ZooKeeper-free) deployment mode to Aithena. Key changes include a rewritten `solr-init` bootstrap process, HNSW vector schema migration, an integrated Solr 10 Security UI in the admin portal, and a comprehensive Solr 9→10 migration runbook. Operators upgrading from v2.3.0 must follow the migration runbook to ensure schema compatibility before starting the Solr 10 stack.
+Aithena v2.5.0 is a major infrastructure release that upgrades the Solr search engine from version 9 to version 10. This release brings Solr 10's improved performance and updated security architecture to Aithena while keeping the shipped lightweight topology as single-node SolrCloud (Solr + ZooKeeper). Key changes include a rewritten `solr-init` bootstrap process, HNSW vector schema migration, an integrated Solr 10 Security UI in the admin portal, and a comprehensive Solr 9→10 migration runbook. Operators upgrading from v2.3.0 must follow the migration runbook to ensure schema compatibility before starting the Solr 10 stack.
 
 ### Highlights
 
 1. **Solr 10 base image upgrade (#1335)** — Core search infrastructure upgraded from Apache Solr 9 to Apache Solr 10, bringing performance improvements and an updated security architecture.
 2. **HNSW schema parameter migration (#1336)** — Vector search schema parameters updated for Solr 10 compatibility, including renamed HNSW field attributes.
 3. **solr-init CLI rewrite (#1337)** — The `solr-init` bootstrap process rewritten to use Solr 10's updated command-line API; legacy Solr 9 `bin/solr` invocations removed.
-4. **blockUnknown default enforcement (#1338)** — Solr 10 ships `blockUnknown=true` by default; Aithena's `security.json` bootstrap now explicitly sets this value.
+4. **blockUnknown compatibility posture (#1338, #1663)** — Solr 10 defaults `blockUnknown=true`, but Aithena v2.5 explicitly keeps `blockUnknown=false` so current unauthenticated health/metrics permissions continue to work; moving to `true` is deferred to a dedicated hardening change.
 5. **wt=json response writer verification (#1339)** — Solr 10 response writer behavior validated for full compatibility with the `solr-search` service.
-6. **Standalone Solr mode (#1342)** — New lightweight deployment option runs Solr 10 without ZooKeeper, ideal for single-user and development deployments.
+6. **Single-node SolrCloud topology (#1342)** — Lightweight deployments use the existing single-node SolrCloud overlay (one Solr node plus ZooKeeper); true ZooKeeper-free standalone/core mode is not shipped in v2.5.0.
 7. **Simplified Security UI (#1350)** — Integrated Solr 10's built-in Security UI into the Aithena admin portal at **Admin → Security**.
 8. **PathHierarchyTokenizer verification (#1352)** — Folder path facets confirmed working correctly under Solr 10's tokenizer implementation.
 9. **CI/CD and E2E test updates (#1340, #1341)** — Full test suite and container build pipeline updated for Solr 10 images and APIs.
@@ -27,11 +27,11 @@ Aithena v2.5.0 is a major infrastructure release that upgrades the Solr search e
 - **#1335** — `feat(solr): Upgrade Solr base image to 10` — Updates the `solr`, `solr2`, and `solr3` container images to Apache Solr 10.x.
 - **#1336** — `feat(schema): Migrate HNSW schema parameters` — Updates `managed-schema.xml` for Solr 10's renamed vector field attributes; existing collections on Solr 9 require schema migration before upgrading (see Upgrade Instructions).
 - **#1337** — `feat(solr-init): Rewrite solr-init CLI commands` — solr-init bootstrap now uses Solr 10's `solr create`, `solr config`, and `solr auth` CLI APIs; the legacy Solr 9 invocations are removed.
-- **#1338** — `fix(security): Handle blockUnknown default change` — Solr 10 defaults `blockUnknown=true` in the BasicAuth security plugin; Aithena's `security.json` bootstrap explicitly sets this value so behavior is deterministic regardless of Solr version.
+- **#1338 / #1663** — `fix(security): Handle blockUnknown default change` — Solr 10 defaults `blockUnknown=true` in the BasicAuth security plugin; Aithena v2.5 explicitly sets `blockUnknown=false` to preserve the current health/metrics access posture while authenticated health checks remain in place.
 - **#1339** — `fix(api): Verify wt=json response writer` — Confirms that `wt=json` responses from Solr 10 are handled correctly by the `solr-search` service with no API surface changes.
 - **#1340** — `test(e2e): Update E2E tests for Solr 10` — Playwright and integration test suites updated to handle Solr 10 API responses and admin UI changes.
 - **#1341** — `ci: Update CI/CD for Solr 10 image builds` — GitHub Actions workflows updated to build and publish Solr 10 container images.
-- **#1342** — `feat(deployment): Implement standalone Solr mode` — Adds `docker/compose.solr-standalone.yml` for ZooKeeper-free single-node deployments; the installer offers this as a topology option.
+- **#1342** — `feat(deployment): Implement lightweight Solr topology` — Documents and validates the single-node SolrCloud option (`docker/compose.single-node.yml`). ZooKeeper-free standalone/core mode remains unshipped in v2.5.0.
 - **#1350** — `feat(ui): Implement simplified Security UI` — Admin portal **Security** page scaffolds access to Solr 10's built-in Security UI at `/admin/solr/ui/#/~security`.
 - **#1352** — `fix(search): Verify PathHierarchyTokenizer behavior` — Folder path facets confirmed working under Solr 10's PathHierarchyTokenizer implementation; no operator action required.
 - **#1353** — `docs: Update documentation for Solr 10` — Admin manual, user manual, deployment topology docs, and migration runbook updated for Solr 10.
@@ -52,22 +52,22 @@ The HNSW vector field parameter names changed between Solr 9 and Solr 10. Existi
 
 | Solr 9 Parameter | Solr 10 Parameter |
 |---|---|
-| `hnswMaxConnections` | `maxConnections` |
-| `hnswBeamWidth` | `beamWidth` |
+| `hnswMaxConnections` | `hnswM` |
+| `hnswBeamWidth` | `hnswEfConstruction` |
 
-See [docs/migration/solr-10-production-runbook.md](migration/solr-10-production-runbook.md) for the full procedure.
+See [docs/migration/solr-10-production-runbook.md](../migration/solr-10-production-runbook.md) for the full procedure.
 
-### blockUnknown Default Changed (No Operator Action Required)
+### blockUnknown Default Changed (Compatibility Posture Retained)
 
-Solr 10 ships with `blockUnknown=true` as the default for the BasicAuth security plugin, meaning unauthenticated requests to Solr are rejected by default. Aithena's `security.json` bootstrap now explicitly sets this value — **no operator action is required** — but operators maintaining custom `security.json` overrides should review them against the Solr 10 defaults.
+Solr 10 ships with `blockUnknown=true` as the default for the BasicAuth security plugin. Aithena v2.5 explicitly keeps `blockUnknown=false` in `security.json` and `solr-init` so the current unauthenticated health/metrics permissions remain compatible. Operators maintaining custom `security.json` overrides should set the value intentionally and plan any move to `true` alongside fully authenticated health/metrics access.
 
 ### solr-init CLI Commands Rewritten
 
 The `solr-init` container uses entirely new Solr 10 CLI invocations. If you have scripts or automation that call `solr-init` commands directly, update them to use the Solr 10 API equivalents documented in the [Admin Manual](../admin-manual.md#deployment-updates-for-v250).
 
-### Standalone Mode Changes Installer Topology Prompt
+### Lightweight Topology Remains Single-Node SolrCloud
 
-v2.5.0 adds a standalone (no ZooKeeper) topology option to the installer. Fresh installations will be prompted to choose between **SolrCloud** (3-node, default) and **Standalone** (single-node, no ZooKeeper). Existing SolrCloud deployments are unaffected.
+v2.5.0 does **not** ship true standalone/core mode. Lightweight installations should continue to use **Single-Node SolrCloud** (`docker/compose.single-node.yml`), which runs one Solr node plus ZooKeeper. Existing distributed SolrCloud deployments are unaffected.
 
 ---
 
@@ -80,7 +80,7 @@ Operators upgrading from v2.3.0 must complete the schema migration before starti
 **Pre-upgrade checklist:**
 1. Back up Solr volumes before upgrading.
 2. Review HNSW parameter renames (see Breaking Changes above).
-3. Follow the [Solr 10 Migration Runbook](migration/solr-10-production-runbook.md).
+3. Follow the [Solr 10 Migration Runbook](../migration/solr-10-production-runbook.md).
 4. Verify collection health after migration with `docker compose logs solr-init`.
 
 ### Security UI
@@ -198,7 +198,7 @@ curl -sf "http://localhost/v1/search?q=test" | jq '.facets.folder'
 curl -sf -u admin:${SOLR_ADMIN_PASSWORD} "http://localhost/admin/solr/ui/"
 # Expected: 200 OK
 
-# 6. blockUnknown in effect (unauthenticated Solr call should be rejected)
+# 6. blockUnknown compatibility posture (health/metrics unauthenticated access remains allowed by policy)
 curl -s "http://localhost/admin/solr/api/v2/node/properties" | jq '.error.code'
 # Expected: 401
 ```
@@ -209,7 +209,7 @@ curl -s "http://localhost/admin/solr/api/v2/node/properties" | jq '.error.code'
 
 - **Solr 10 startup time:** Solr 10 SolrCloud takes 45–60 seconds to complete ZooKeeper registration and collection bootstrap; increase `--health-retries` if seeing startup timeouts in CI.
 - **Standalone mode limitations:** Standalone Solr does not support sharding or multi-node replication. Use the SolrCloud topology for production deployments or libraries with large document counts.
-- **Legacy Solr 9 data directories:** Direct migration from Solr 9 data directories to Solr 10 without schema migration will result in startup errors. Always follow the [migration runbook](migration/solr-10-production-runbook.md).
+- **Legacy Solr 9 data directories:** Direct migration from Solr 9 data directories to Solr 10 without schema migration will result in startup errors. Always follow the [migration runbook](../migration/solr-10-production-runbook.md).
 - **Solr 10 Security UI is read-linked:** The **Admin → Security** page in Aithena provides a scaffold link to Solr's Security UI. User and role management is performed natively in the Solr UI, not in the Aithena admin portal.
 
 ---
@@ -236,7 +236,7 @@ curl -s "http://localhost/admin/solr/api/v2/node/properties" | jq '.error.code'
 - **#1339** — `[v2.5] Verify wt=json response writer`
 - **#1340** — `[v2.5] Update E2E tests for Solr 10`
 - **#1341** — `[v2.5] Update CI/CD for Solr 10 image builds`
-- **#1342** — `[v2.5] Implement standalone Solr mode`
+- **#1342** — `[v2.5] Implement standalone Solr mode` (closed; shipped docs/code use single-node SolrCloud, not ZooKeeper-free standalone/core mode)
 - **#1350** — `[v2.5] Implement simplified Security UI`
 - **#1352** — `[v2.5] Verify PathHierarchyTokenizer behavior`
 - **#1353** — `[v2.5] Update documentation for Solr 10`
@@ -254,11 +254,11 @@ curl -s "http://localhost/admin/solr/api/v2/node/properties" | jq '.error.code'
 - **Newt** (Product Manager) — Release coordination and documentation
 - **Ripley** (Lead) — Architectural review and approval
 - **Ash** (Search Engineer) — Solr 10 schema migration and API compatibility
-- **Brett** (Infra Architect) — Container image builds, CI/CD updates, standalone mode
+- **Brett** (Infra Architect) — Container image builds, CI/CD updates, lightweight Solr topology
 - **Kane** (Security Engineer) — Security audit, blockUnknown hardening, security posture review
 - **Lambert** (Tester) — E2E test suite updates and validation
 - **Copilot** (Coding Agent) — Implementation and coordination
 
 ---
 
-For detailed technical information, see [CHANGELOG.md](https://github.com/jmservera/aithena/blob/main/CHANGELOG.md), the [v2.5.0 Test Report](../test-reports/v2.5.0.md), the [Solr 10 Migration Runbook](migration/solr-10-production-runbook.md), and the [Admin Manual](../admin-manual.md).
+For detailed technical information, see [CHANGELOG.md](https://github.com/jmservera/aithena/blob/main/CHANGELOG.md), the [v2.5.0 Test Report](../test-reports/v2.5.0.md), the [Solr 10 Migration Runbook](../migration/solr-10-production-runbook.md), and the [Admin Manual](../admin-manual.md).

--- a/docs/test-reports/v2.5.0.md
+++ b/docs/test-reports/v2.5.0.md
@@ -14,7 +14,7 @@
 
 - `VERSION` milestone: `v2.5.0`
 - Previous release tag: `v2.3.0` (Solr 9)
-- Scope: Solr 9 → Solr 10 upgrade, standalone mode, Security UI, schema migration
+- Scope: Solr 9 → Solr 10 upgrade, single-node SolrCloud lightweight topology, Security UI, schema migration
 - v2.5.0 milestone issues closed: 13 (#1335–#1359)
 - Pre-release validation issues closed: 3 (#1654, #1655, #1656)
 - OpenVINO pre-release hardening issue closed: 1 (#1662 — fix applied at commit `a8a5cb5`)
@@ -33,7 +33,7 @@ v2.5.0 is the Solr 10 upgrade release. The implemented evidence path covers:
 3. Rewrite `solr-init` bootstrap using Solr 10 CLI APIs (#1337).
 4. Explicitly handle the `blockUnknown` security default change in Solr 10 (#1338).
 5. Verify `wt=json` response writer and `PathHierarchyTokenizer` under Solr 10 (#1339, #1352).
-6. Add a ZooKeeper-free standalone Solr mode for lightweight deployments (#1342).
+6. Validate the single-node SolrCloud lightweight topology; true ZooKeeper-free standalone/core mode remains unshipped in v2.5 (#1342).
 7. Surface Solr 10's built-in Security UI via Admin → Security (#1350).
 8. Update the CI/CD pipeline and E2E test suite for Solr 10 images (#1340, #1341).
 9. Complete a security audit of Solr 10 defaults and publish the Solr 9→10 migration runbook (#1358, #1359).
@@ -67,13 +67,13 @@ No CI run JSON or PR merge data were provided in the release context (`ci-run.js
 | Area | Status | Evidence |
 |---|---:|---|
 | Solr 10 base image upgrade | ✅ Closed | Issue #1335 closed — Solr base image upgraded to Apache Solr 10.x. |
-| HNSW schema migration | ✅ Closed | Issue #1336 closed — `hnswMaxConnections`→`maxConnections`, `hnswBeamWidth`→`beamWidth` in `managed-schema.xml`. |
+| HNSW schema migration | ✅ Closed | Issue #1336 closed — `hnswMaxConnections`→`hnswM`, `hnswBeamWidth`→`hnswEfConstruction` in `managed-schema.xml`; Solr 9 compatibility rewrites remain in bootstrap. |
 | solr-init CLI rewrite | ✅ Closed | Issue #1337 closed — solr-init uses Solr 10 CLI (`solr create`, `solr config`, `solr auth`); Solr 9 invocations removed. |
-| blockUnknown security hardening | ✅ Closed | Issue #1338 closed — `security.json` bootstrap explicitly sets `blockUnknown=true` for deterministic Solr 10 behavior. |
+| blockUnknown compatibility posture | ✅ Closed | Issue #1338/#1663 closed — Aithena v2.5 explicitly keeps `blockUnknown=false` for health/metrics compatibility while authenticating container health checks. |
 | wt=json response writer | ✅ Closed | Issue #1339 closed — Response writer verified; `solr-search` handles Solr 10 JSON responses correctly. |
 | E2E test suite (Solr 10) | ✅ Closed | Issue #1340 closed — Playwright and integration test suites updated for Solr 10 API responses and UI. |
 | CI/CD image builds (Solr 10) | ✅ Closed | Issue #1341 closed — GitHub Actions builds and publishes Solr 10 container images. |
-| Standalone Solr mode | ✅ Closed | Issue #1342 closed — `docker/compose.solr-standalone.yml` added; installer topology prompt updated. |
+| Lightweight Solr topology | ✅ Closed | Issue #1342 closed — single-node SolrCloud remains the shipped lightweight topology; true ZooKeeper-free standalone/core mode is not shipped in v2.5. |
 | Security UI integration | ✅ Closed | Issue #1350 closed — Admin → Security page links to Solr 10 Security UI at `/admin/solr/ui/#/~security`. |
 | PathHierarchyTokenizer | ✅ Closed | Issue #1352 closed — Folder facet tokenizer verified; behavior unchanged between Solr 9 and Solr 10. |
 | Documentation (Solr 10) | ✅ Closed | Issue #1353 closed — Admin manual, user manual, deployment docs updated for Solr 10. |
@@ -89,8 +89,8 @@ No CI run JSON or PR merge data were provided in the release context (`ci-run.js
 ## Critical Validations
 
 - **Schema migration coverage:** Issue #1336 confirms HNSW parameter names were updated to Solr 10 nomenclature. The migration runbook (#1359) covers the upgrade path for existing Solr 9 collections.
-- **blockUnknown explicit:** Issue #1338 confirms `security.json` bootstrap now explicitly sets `blockUnknown=true`, aligning with Solr 10 default while making the intent clear in config.
-- **Standalone mode introduced:** Issue #1342 confirms ZooKeeper-free topology is available; standalone mode is not a replacement for SolrCloud in production multi-node deployments.
+- **blockUnknown explicit:** Issue #1338/#1663 confirms Aithena v2.5 explicitly keeps `blockUnknown=false`, preserving the current health/metrics access posture while authenticated health checks are used by the stack.
+- **Lightweight topology:** Issue #1342 validation is represented as single-node SolrCloud in shipped docs/code; ZooKeeper-free standalone/core mode remains unshipped in v2.5.
 - **Folder facets unaffected:** Issue #1352 confirms `PathHierarchyTokenizer` behavior is unchanged in Solr 10; folder path facets require no operator action.
 - **Security UI scaffold:** Issue #1350 confirms the Admin → Security page links correctly to Solr 10's native Security UI. Aithena does not proxy or replicate Solr's security management — it provides navigational access only.
 - **wt=json compatibility:** Issue #1339 confirms the `solr-search` service handles Solr 10 JSON response format without code changes.
@@ -110,4 +110,4 @@ No CI run JSON or PR merge data were provided in the release context (`ci-run.js
 
 ## Release-Gate Conclusion
 
-For the v2.5.0 milestone, all 13 issue-level deliverables are closed and the documented changes are coherent. The Solr 10 schema migration, standalone mode, Security UI, and CI/CD updates are covered by issue-closure evidence. Pre-release validation issues #1654, #1655, and #1656 are closed, and issue #1662 (OpenVINO dependency hardening) was resolved with a successful pre-release re-run at commit `a8a5cb5` ([run 27026253418](https://github.com/jmservera/aithena/actions/runs/27026253418)). The v2.5.0 release gate is clear based on pre-release evidence. If formal `ci-run.json` data becomes available, it should be appended to this report for completeness.
+For the v2.5.0 milestone, all 13 issue-level deliverables are closed and the documented changes are coherent after aligning planned topology language to shipped behavior. The Solr 10 schema migration, single-node SolrCloud lightweight topology, Security UI, and CI/CD updates are covered by issue-closure evidence. Pre-release validation issues #1654, #1655, and #1656 are closed, and issue #1662 (OpenVINO dependency hardening) was resolved with a successful pre-release re-run at commit `a8a5cb5` ([run 27026253418](https://github.com/jmservera/aithena/actions/runs/27026253418)). The v2.5.0 release gate is clear based on pre-release evidence. If formal `ci-run.json` data becomes available, it should be appended to this report for completeness.


### PR DESCRIPTION
## Summary
- Align README, v2.5 release notes, admin manual, and test report to shipped v2.5 behavior: single-node SolrCloud, blockUnknown=false compatibility posture, and Solr 10 HNSW names.
- Soften deployment topology quantization claims and point production use to #1344-style evidence gates.
- Archive the completed Admin React migration PRD and record Newt docs consistency learning/decision.

## Validation
- Changed-doc relative link check passed (admin-manual excluded from ad-hoc link check because it has a pre-existing unrelated missing guide link).
- .squad/scripts/verify.sh
- git diff --cached --check

Refs #1452
Refs #1344