### PR TITLE
docs: tighten quantization evidence gate

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -14,6 +14,7 @@
 - 2026-06-06: Solr 10 scalar quantization must use `bits="7"` (or `4`) rather than `8`; Aithena's int8 path keeps `vectorDimension="768"` and `similarityFunction="cosine"`, with Solr 9 rollback rewriting to `DenseVectorField vectorEncoding="BYTE"`.
 - 2026-06-06: Quantization evaluation lives in `scripts/benchmark/`: run paired float32/int8 reports with `run_benchmark.py`, compare recall@10 with `compare_quantization.py`, and attach measured `docker stats` memory samples before claiming runtime savings.
 - **2026-06-06:** For #1344 scalar quantization closure, validate against `dev` when #1670 is only merged there; schema/preflight/unit checks can prove bits=7 wiring, but recall@10 and memory savings still require same-corpus float32 vs int8 runtime benchmark artifacts.
+- **2026-06-07:** For #1717 preflight, quantization acceptance is per semantic/hybrid query-mode recall@10 ≥0.95 from `compare_quantization.py`, or explicit exception review; measured same-host Docker stats are required and payload estimates are not release evidence.
 
 ## Research Loop Participation (2026-06-06)
 

--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -14,7 +14,7 @@
 - 2026-06-06: Solr 10 scalar quantization must use `bits="7"` (or `4`) rather than `8`; Aithena's int8 path keeps `vectorDimension="768"` and `similarityFunction="cosine"`, with Solr 9 rollback rewriting to `DenseVectorField vectorEncoding="BYTE"`.
 - 2026-06-06: Quantization evaluation lives in `scripts/benchmark/`: run paired float32/int8 reports with `run_benchmark.py`, compare recall@10 with `compare_quantization.py`, and attach measured `docker stats` memory samples before claiming runtime savings.
 - **2026-06-06:** For #1344 scalar quantization closure, validate against `dev` when #1670 is only merged there; schema/preflight/unit checks can prove bits=7 wiring, but recall@10 and memory savings still require same-corpus float32 vs int8 runtime benchmark artifacts.
-- **2026-06-07:** For #1717 preflight, quantization acceptance is per semantic/hybrid query-mode recall@10 ≥0.95 from `compare_quantization.py`, or explicit exception review; measured same-host Docker stats are required and payload estimates are not release evidence.
+- **2026-06-07:** For #1717 preflight, quantization acceptance is per semantic/hybrid query-mode recall@10 ≥0.95 from `compare_quantization.py`, or explicit exception review; measured same-host Docker stats JSON with byte-valued memory samples is required and payload estimates are not release evidence.
 
 ## Research Loop Participation (2026-06-06)
 

--- a/scripts/benchmark/quantization_validation_config.json
+++ b/scripts/benchmark/quantization_validation_config.json
@@ -3,8 +3,8 @@
     "version": "1.0",
     "created_by": "Bishop (Vector Search & Data Science Specialist)",
     "created_at": "2026-06-05",
-    "updated_at": "2026-06-06T09:36:46.687+00:00",
-    "purpose": "Configuration for scalar quantization (int8) benchmark validation #1344",
+    "updated_at": "2026-06-07T16:55:27.144+00:00",
+    "purpose": "Configuration for scalar quantization (int8) benchmark validation #1344/#1717",
     "schema_prerequisite": "Solr 10 ScalarQuantizedDenseVectorField uses supported bits (4 or 7) and Solr 9 staging rewrites bits 4/7 to vectorEncoding=BYTE"
   },
   "corpus": {
@@ -75,16 +75,16 @@
   "pass_fail_criteria": {
     "release_blockers": [
       {
-        "metric": "recall_at_k",
+        "metric": "recall_at_k_individual",
         "threshold": 0.95,
-        "scope": "all_queries_aggregate",
-        "description": "Mean recall@10 across semantic and hybrid modes must be ≥0.95 (95% agreement with float32)"
+        "scope": "per_query_mode",
+        "description": "Every semantic and hybrid query/mode comparison must have recall@10 ≥0.95 against float32, or be listed for explicit exception review before release claims"
       },
       {
-        "metric": "recall_at_k_individual",
-        "threshold": 0.85,
-        "scope": "per_query",
-        "description": "No individual query should fall below 0.85 recall (85% agreement) without manual review"
+        "metric": "query_pairing",
+        "threshold": "exact_match",
+        "scope": "float32_vs_int8",
+        "description": "Query IDs, query file identity, search modes, top_k, collection, corpus ID, document count, and corpus bytes must match between float32 and int8 reports"
       },
       {
         "metric": "indexing_errors",
@@ -93,10 +93,10 @@
         "description": "Zero indexing or search errors during Phase 1 (float32) and Phase 2 (int8)"
       },
       {
-        "metric": "memory_reduction_ratio",
-        "threshold": 0.5,
-        "scope": "int8_vs_float32",
-        "description": "int8 collection memory must be ≤50% of float32 (target: 25% for 4x reduction)"
+        "metric": "measured_solr_memory_samples",
+        "threshold": "present",
+        "scope": "both_phases",
+        "description": "Attach same-host docker stats memory samples for every Solr node in both float32 and int8 runs; payload estimates alone are not acceptable evidence"
       }
     ],
     "warnings": [

--- a/scripts/benchmark/quantization_validation_config.json
+++ b/scripts/benchmark/quantization_validation_config.json
@@ -75,7 +75,7 @@
   "pass_fail_criteria": {
     "release_blockers": [
       {
-        "metric": "recall_at_k_individual",
+        "metric": "recall_at_k",
         "threshold": 0.95,
         "scope": "per_query_mode",
         "description": "Every semantic and hybrid query/mode comparison must have recall@10 ≥0.95 against float32, or be listed for explicit exception review before release claims"
@@ -93,10 +93,10 @@
         "description": "Zero indexing or search errors during Phase 1 (float32) and Phase 2 (int8)"
       },
       {
-        "metric": "measured_solr_memory_samples",
+        "metric": "run_metadata.docker_stats.mem_usage_bytes",
         "threshold": "present",
         "scope": "both_phases",
-        "description": "Attach same-host docker stats memory samples for every Solr node in both float32 and int8 runs; payload estimates alone are not acceptable evidence"
+        "description": "Attach same-host Docker stats JSON passed to run_benchmark.py --docker-stats-json with numeric mem_usage_bytes samples for every Solr node in both float32 and int8 runs; payload estimates alone are not acceptable evidence"
       }
     ],
     "warnings": [


### PR DESCRIPTION
## Summary\n- Align quantization validation config with #1717: per semantic/hybrid query-mode recall@10 must be >= 0.95 or explicitly exception-reviewed.\n- Replace memory-reduction threshold with measured same-host Docker stats evidence requirement before any release claim.\n- Record Bishop learning for future #1717 quantization preflight work.\n\nSupports #1717.\n\n## Validation\n- python3 -m json.tool scripts/benchmark/quantization_validation_config.json >/dev/null\n- .squad/scripts/verify.sh