### PR TITLE
fix(security): resolve open dependency and CodeQL alerts

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0

--- a/.squad/agents/kane/history.md
+++ b/.squad/agents/kane/history.md
@@ -158,3 +158,10 @@
 **Decision Record:** `.squad/decisions.md` → "Security Analysis: Internal Service Authentication (Redis, ZooKeeper, Solr)"
 
 **Next:** Pending team consensus on compliance implications; network isolation discussion recommended.
+
+### 2026-06-07T18:32:36.169+00:00 — Security alert triage
+
+- Dependabot open alerts: solr-search `urllib3` high CVEs GHSA-qccp-gfcp-xxvc/GHSA-mf9v-mfxr-j63j, solr-search `starlette` medium GHSA-86qp-5c8j-p5mr, embeddings-server `transformers` medium CVE-2026-1839.
+- Fixed solr-search lockfile by updating `urllib3` 2.6.3→2.7.0 and `starlette` 0.52.1→1.2.1.
+- `transformers` remains blocked/accepted-risk for now: patched version is 5.0.0rc3, but `sentence-transformers` still resolves transformers 4.x; prior Dependabot PR #1393 was closed as release-candidate/transitive.
+- Fixed open low-severity zizmor `artipacked` CodeQL alert by setting `actions/checkout` `persist-credentials: false` in `.github/workflows/codeql-analysis.yml`.

--- a/src/solr-search/uv.lock
+++ b/src/solr-search/uv.lock
@@ -1150,15 +1150,15 @@ dev = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -1199,11 +1199,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update solr-search lockfile: urllib3 2.6.3 -> 2.7.0 for two high Dependabot alerts (GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j).
- Update solr-search lockfile: starlette 0.52.1 -> 1.2.1 for GHSA-86qp-5c8j-p5mr.
- Harden CodeQL checkout with persist-credentials: false for open zizmor/artipacked alert.

Working as Kane (Security Engineer).

## Validation
- [x] .squad/scripts/verify.sh
- [x] pre-commit solr-search tests: 1180 passed, 21 skipped

## Triage notes
- embeddings-server transformers alert remains a routed/accepted blocker: patched version is 5.0.0rc3, but sentence-transformers still resolves transformers 4.x; prior Dependabot PR #1393 was closed as release-candidate/transitive.