### PR TITLE
feat(embeddings-server): widen OpenVINO compat to <2027

### DIFF
--- a/src/embeddings-server/pyproject.toml
+++ b/src/embeddings-server/pyproject.toml
@@ -12,10 +12,10 @@ dependencies = [
 [project.optional-dependencies]
 openvino = [
     "sentence-transformers[openvino]>=3.4,<6",
-    "openvino>=2025.4,<2026",
+    "openvino>=2025.4,<2027",
     "optimum-intel>=1.27,<2",
     "intel-extension-for-pytorch",
-    "openvino-tokenizers>=2025.4,<2026",
+    "openvino-tokenizers>=2025.4,<2027",
 ]
 
 [tool.aithena.openvino]
@@ -24,9 +24,9 @@ openvino = [
 # stay on the same OpenVINO series.
 base-image-series = "2025.4"
 openvino-min = "2025.4"
-openvino-max-exclusive = "2026"
+openvino-max-exclusive = "2027"
 openvino-tokenizers-min = "2025.4"
-openvino-tokenizers-max-exclusive = "2026"
+openvino-tokenizers-max-exclusive = "2027"
 optimum-intel-min = "1.27"
 optimum-intel-max-exclusive = "2"
 

--- a/src/embeddings-server/tests/conftest.py
+++ b/src/embeddings-server/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Pytest configuration for embeddings-server tests.
+
+Auto-skips tests that depend on PyTorch/CUDA when the runtime libraries
+are not available (e.g., local dev machines without GPU drivers).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# Check once at collection time whether torch can actually load.
+# Tests that import the app module (main, config) transitively require torch.
+_TORCH_AVAILABLE = False
+try:
+    importlib.import_module("torch")
+    _TORCH_AVAILABLE = True
+except (ImportError, OSError):
+    # OSError covers missing .so files like libcudnn.so
+    pass
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip tests that require torch/CUDA when the runtime isn't available."""
+    if _TORCH_AVAILABLE:
+        return
+
+    skip_torch = pytest.mark.skip(reason="torch not functional (missing CUDA libs)")
+    # Test files that import from main/config/app code requiring torch
+    torch_dependent_files = {"test_gpu_config.py", "test_embeddings_server.py"}
+
+    for item in items:
+        if item.path and item.path.name in torch_dependent_files:
+            item.add_marker(skip_torch)

--- a/src/embeddings-server/tests/conftest.py
+++ b/src/embeddings-server/tests/conftest.py
@@ -7,29 +7,27 @@ are not available (e.g., local dev machines without GPU drivers).
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
 
 import pytest
 
 # Check once at collection time whether torch can actually load.
-# Tests that import the app module (main, config) transitively require torch.
 _TORCH_AVAILABLE = False
 try:
     importlib.import_module("torch")
     _TORCH_AVAILABLE = True
 except (ImportError, OSError):
-    # OSError covers missing .so files like libcudnn.so
+    # OSError covers missing shared libraries like libcudnn.so
     pass
 
+# Files where EVERY test uses _fresh_import() → `import main` → torch.
+# No torch-free tests exist in these modules, so file-level exclusion
+# is correct (not overly broad).
+_TORCH_DEPENDENT_FILES = {"test_gpu_config.py", "test_embeddings_server.py"}
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Skip tests that require torch/CUDA when the runtime isn't available."""
-    if _TORCH_AVAILABLE:
-        return
 
-    skip_torch = pytest.mark.skip(reason="torch not functional (missing CUDA libs)")
-    # Test files that import from main/config/app code requiring torch
-    torch_dependent_files = {"test_gpu_config.py", "test_embeddings_server.py"}
-
-    for item in items:
-        if item.path and item.path.name in torch_dependent_files:
-            item.add_marker(skip_torch)
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
+    """Skip collection of torch-dependent test files when CUDA is unavailable."""
+    if not _TORCH_AVAILABLE and collection_path.name in _TORCH_DEPENDENT_FILES:
+        return True
+    return None

--- a/src/embeddings-server/tests/test_openvino_runtime_verifier.py
+++ b/src/embeddings-server/tests/test_openvino_runtime_verifier.py
@@ -35,7 +35,8 @@ def test_openvino_runtime_verifier_rejects_lockfile_drift(monkeypatch: pytest.Mo
 
     failures = verify_openvino_runtime.verify_openvino_runtime(PYPROJECT_PATH)
 
-    assert any("openvino 2026.0.0 does not satisfy" in failure for failure in failures)
+    # openvino 2026.0.0 satisfies >=2025.4,<2027 but the runtime verifier
+    # still rejects when openvino and openvino-tokenizers minor versions differ
     assert any("minor versions differ" in failure for failure in failures)
 
 

--- a/src/embeddings-server/uv.lock
+++ b/src/embeddings-server/uv.lock
@@ -326,8 +326,8 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.135.3,<1" },
     { name = "intel-extension-for-pytorch", marker = "extra == 'openvino'" },
-    { name = "openvino", marker = "extra == 'openvino'", specifier = ">=2025.4,<2026" },
-    { name = "openvino-tokenizers", marker = "extra == 'openvino'", specifier = ">=2025.4,<2026" },
+    { name = "openvino", marker = "extra == 'openvino'", specifier = ">=2025.4,<2027" },
+    { name = "openvino-tokenizers", marker = "extra == 'openvino'", specifier = ">=2025.4,<2027" },
     { name = "optimum-intel", marker = "extra == 'openvino'", specifier = ">=1.27,<2" },
     { name = "sentence-transformers", specifier = ">=3.4,<6" },
     { name = "sentence-transformers", extras = ["openvino"], marker = "extra == 'openvino'", specifier = ">=3.4,<6" },


### PR DESCRIPTION
Updates the OpenVINO compatibility matrix to allow versions up to 2027 (from 2026).

## Changes
- Widen `openvino` and `openvino-tokenizers` upper bound: `<2026` → `<2027`
- Update `[tool.aithena.openvino]` matrix to match
- Fix runtime verifier test (2026.0.0 now satisfies the widened spec)
- Add `tests/conftest.py` to skip CUDA-dependent tests when torch runtime isn't available

## Safety
- Lockfile still resolves to **2025.4.1** (matching base-image-series)
- Docker builds unaffected — `uv sync --inexact` keeps base-image packages
- All 11 openvino-specific tests pass locally

Closes #1722
Closes #1720