### PR TITLE
fix(ci): stabilize OpenVINO smoke diagnostics

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -339,7 +339,7 @@ jobs:
           {
             echo ""
             echo "--- Freeing runner disk space for large OpenVINO image pull ---"
-            sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
+            sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
             docker system prune -af || true
             echo ""
             echo "--- Disk usage after cleanup ---"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -321,10 +321,41 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare OpenVINO smoke diagnostics
+        run: |
+          {
+            echo "=== OpenVINO smoke diagnostics ==="
+            echo "Timestamp: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo ""
+            echo "--- Disk usage before cleanup ---"
+            df -h
+            echo ""
+            echo "--- Docker disk usage before cleanup ---"
+            docker system df || true
+          } | tee openvino-smoke-output.txt
+
+      - name: Free runner disk space for OpenVINO image
+        run: |
+          {
+            echo ""
+            echo "--- Freeing runner disk space for large OpenVINO image pull ---"
+            sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
+            docker system prune -af || true
+            echo ""
+            echo "--- Disk usage after cleanup ---"
+            df -h
+            echo ""
+            echo "--- Docker disk usage after cleanup ---"
+            docker system df || true
+          } | tee -a openvino-smoke-output.txt
+
       - name: Pull OpenVINO image
         env:
           RC_TAG: ${{ needs.prepare.outputs.full_tag }}-openvino
-        run: docker pull "ghcr.io/jmservera/aithena-embeddings-server:${RC_TAG}"
+        run: |
+          set -o pipefail
+          docker pull "ghcr.io/jmservera/aithena-embeddings-server:${RC_TAG}" \
+            2>&1 | tee -a openvino-smoke-output.txt
 
       - name: Run OpenVINO permissions smoke test
         id: smoke
@@ -335,7 +366,7 @@ jobs:
           chmod +x e2e/smoke-openvino-permissions.sh
           ./e2e/smoke-openvino-permissions.sh \
             "ghcr.io/jmservera/aithena-embeddings-server:${RC_TAG}" \
-            2>&1 | tee openvino-smoke-output.txt
+            2>&1 | tee -a openvino-smoke-output.txt
 
       - name: Dump container logs on failure
         if: failure()


### PR DESCRIPTION
Closes #1766

Working as Lambert (Tester)

## Summary
- free runner disk space before the dedicated OpenVINO smoke job pulls the large embeddings image
- always create and append to openvino-smoke-output.txt so pull failures include actionable diagnostics
- preserve pull failures with set -o pipefail while still teeing logs into the issue artifact and summary path

## Validation
- python3 YAML parse for .github/workflows/pre-release.yml
- .squad/scripts/verify.sh
- local repro: ./e2e/smoke-openvino-permissions.sh ghcr.io/jmservera/aithena-embeddings-server:2.5.1-rc.1-openvino

## Root cause
The failing workflow job never reached e2e/smoke-openvino-permissions.sh: docker pull failed on the GitHub runner with failed to register layer ... no space left on device, and the workflow only created openvino-smoke-output.txt inside the later smoke step, so the auto-filed issue showed (no output captured).
