### PR TITLE
Refactor shared-base service Dockerfiles

### DIFF
--- a/docker/python-service-healthcheck.py
+++ b/docker/python-service-healthcheck.py
@@ -5,6 +5,7 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 def fail(message: str) -> int:
@@ -13,9 +14,11 @@ def fail(message: str) -> int:
 
 
 def check_http(url: str, timeout: float) -> int:
+    if urlparse(url).scheme not in {"http", "https"}:
+        return fail(f"http healthcheck only supports http/https URLs: {url}")
     request = urllib.request.Request(url, headers={"User-Agent": "aithena-healthcheck/1.0"})  # noqa: S310
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310  # noqa: S310
             status = getattr(response, "status", response.getcode())
     except urllib.error.URLError as exc:
         return fail(f"http healthcheck failed for {url}: {exc}")

--- a/src/document-indexer/Dockerfile
+++ b/src/document-indexer/Dockerfile
@@ -2,41 +2,23 @@ ARG BASE_IMAGE=aithena:base
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
-
 FROM ${BASE_IMAGE}
-
 ARG VERSION
 ARG GIT_COMMIT
 ARG BUILD_DATE
-
 LABEL org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.source="https://github.com/jmservera/aithena" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${GIT_COMMIT}"
-
 ENV VERSION=${VERSION} \
-    GIT_COMMIT=${GIT_COMMIT} \
-    BUILD_DATE=${BUILD_DATE} \
-    RABBITMQ_HOST=localhost \
-    RABBITMQ_PORT=5672 \
-    REDIS_HOST=localhost \
-    REDIS_PORT=6379 \
-    QUEUE_NAME=new_documents \
-    EXCHANGE_NAME=documents \
-    BASE_PATH=/data/documents/ \
-    SOLR_HOST=solr \
-    SOLR_PORT=8983 \
-    SOLR_COLLECTION=books \
-    HEALTHCHECK_MODE=process \
-    HEALTHCHECK_PROCESS=document_indexer
-
+    GIT_COMMIT=${GIT_COMMIT} BUILD_DATE=${BUILD_DATE} \
+    RABBITMQ_HOST=localhost RABBITMQ_PORT=5672 REDIS_HOST=localhost REDIS_PORT=6379 \
+    QUEUE_NAME=new_documents EXCHANGE_NAME=documents BASE_PATH=/data/documents/ \
+    SOLR_HOST=solr SOLR_PORT=8983 SOLR_COLLECTION=books \
+    HEALTHCHECK_MODE=process HEALTHCHECK_PROCESS=document_indexer
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project --native-tls
-
 COPY document_indexer /app/document_indexer
-RUN mkdir -p /data/thumbnails \
-    && chown -R app:app /app /data/thumbnails
-
+RUN install -d -o app -g app /data/thumbnails && chown -R app:app /app
 USER app
-
 CMD ["python", "-m", "document_indexer"]

--- a/src/document-lister/Dockerfile
+++ b/src/document-lister/Dockerfile
@@ -2,39 +2,23 @@ ARG BASE_IMAGE=aithena:base
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
-
 FROM ${BASE_IMAGE}
-
 ARG VERSION
 ARG GIT_COMMIT
 ARG BUILD_DATE
-
 LABEL org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.source="https://github.com/jmservera/aithena" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${GIT_COMMIT}"
-
 ENV VERSION=${VERSION} \
-    GIT_COMMIT=${GIT_COMMIT} \
-    BUILD_DATE=${BUILD_DATE} \
-    RABBITMQ_HOST=localhost \
-    RABBITMQ_PORT=5672 \
-    REDIS_HOST=localhost \
-    REDIS_PORT=6379 \
-    DOCUMENT_WILDCARD=*.pdf \
-    QUEUE_NAME=new_documents \
-    EXCHANGE_NAME=documents \
-    HEALTHCHECK_MODE=process \
-    HEALTHCHECK_PROCESS=document_lister
-
+    GIT_COMMIT=${GIT_COMMIT} BUILD_DATE=${BUILD_DATE} \
+    RABBITMQ_HOST=localhost RABBITMQ_PORT=5672 REDIS_HOST=localhost REDIS_PORT=6379 \
+    DOCUMENT_WILDCARD=*.pdf QUEUE_NAME=new_documents EXCHANGE_NAME=documents \
+    HEALTHCHECK_MODE=process HEALTHCHECK_PROCESS=document_lister
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project --native-tls
-
 COPY document_lister /app/document_lister
 COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh \
-    && mkdir -p /data/documents \
-    && chown -R app:app /app /data/documents
-
+RUN chmod +x /app/entrypoint.sh && install -d -o app -g app /data/documents && chown -R app:app /app
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["python", "-m", "document_lister"]

--- a/src/solr-search/Dockerfile
+++ b/src/solr-search/Dockerfile
@@ -2,40 +2,28 @@ ARG BASE_IMAGE=aithena:base
 ARG VERSION=dev
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
-
 FROM ${BASE_IMAGE}
-
 ARG VERSION
 ARG GIT_COMMIT
 ARG BUILD_DATE
-
 LABEL org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.source="https://github.com/jmservera/aithena" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${GIT_COMMIT}"
-
 ENV VERSION=${VERSION} \
-    GIT_COMMIT=${GIT_COMMIT} \
-    BUILD_DATE=${BUILD_DATE} \
-    PORT=8080 \
-    SOLR_URL=http://solr:8983/solr \
-    SOLR_COLLECTION=books \
-    BASE_PATH=/data/documents \
-    CORS_ORIGINS=http://localhost:5173 \
-    HEALTHCHECK_MODE=http \
+    GIT_COMMIT=${GIT_COMMIT} BUILD_DATE=${BUILD_DATE} PORT=8080 \
+    SOLR_URL=http://solr:8983/solr SOLR_COLLECTION=books BASE_PATH=/data/documents \
+    CORS_ORIGINS=http://localhost:5173 HEALTHCHECK_MODE=http \
     HEALTHCHECK_URL=http://localhost:8080/health
-
 COPY src/aithena-common/ /aithena-common/
 COPY src/solr-search/pyproject.toml src/solr-search/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project --native-tls
-
 COPY src/solr-search/*.py /app/
 COPY src/solr-search/migrations /app/migrations
 COPY src/solr-search/scripts /app/scripts
 COPY src/solr-search/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh \
-    && mkdir -p /data/documents/uploads /data/auth /data/collections \
-    && chown -R app:app /app /data
-
+    && install -d -o app -g app /data/documents/uploads /data/auth /data/collections \
+    && chown -R app:app /app
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["sh","-c","python -m uvicorn --port=$PORT --host 0.0.0.0 main:app"]


### PR DESCRIPTION
Closes #1749

## Summary
- trim the shared-base Dockerfiles for document-indexer, document-lister, and solr-search to 30 lines or fewer
- collapse redundant ENV declarations and remove setup already covered by Dockerfile.base
- keep the existing COPY/RUN/ENTRYPOINT/CMD behavior intact

## Validation
- [x] .squad/scripts/verify.sh
- [x] docker build -f Dockerfile.base -t aithena:base .
- [x] docker compose build document-indexer document-lister solr-search
- [x] smoke-tested image health checks after build
